### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :development, :test do
   gem 'haml-lint', require: false
   gem 'poltergeist'
   gem 'pry-rails'
+  gem 'rspec_junit_formatter'
   gem 'rspec-rails'
   gem 'rubocop-rspec', require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,9 @@ source 'https://rubygems.org'
 
 ruby '2.4.1'
 
-gem 'awesome_print'
 gem 'aws-sdk'
 gem 'bourbon', '~> 4.2.0' # to keep in sync with getcalfresh
-gem 'coffee-rails'
 gem 'haml', '~> 5.0'
-gem 'jbuilder', '~> 2.0'
 gem 'jquery-rails'
 gem 'neat', '~> 1.8' # to keep in sync with getcalfresh
 gem 'paperclip', '~> 5.0.0'
@@ -17,7 +14,6 @@ gem 'pdf-forms'
 gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'
 gem 'rails', '~> 5.1'
-gem 'rake'
 gem 'responders'
 gem 'sass-rails', '~> 5.0'
 gem 'sorcery'
@@ -28,48 +24,23 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'uglifier', '>= 1.3.0'
 
-# from gcf
-# gem 'prawn'
-# gem 'StreetAddress', :require => "street_address"
-
 group :test do
   gem 'database_cleaner'
   gem 'faker'
   gem 'rails-controller-testing'
-  gem 'selenium-webdriver'
 end
 
 group :development, :test do
-  gem 'byebug', platform: :mri
   gem 'capybara'
   gem 'capybara-accessible'
-  gem 'capybara-screenshot'
   gem 'climate_control'
   gem 'haml-lint', require: false
-  gem 'launchy'
   gem 'poltergeist'
   gem 'pry-rails'
   gem 'rspec-rails'
-  gem 'rspec_junit_formatter'
-  gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false
-
-  # from gcf
-  # gem 'pdf-inspector'
 end
 
 group :development do
   gem 'citizen-scripts', git: 'https://github.com/citizencode/citizen-scripts'
-  gem 'guard', require: false
-  gem 'guard-rspec', require: false
-  gem 'listen', '~> 3.0.5'
-  gem 'meta_request'
-  gem 'pivotal_git_scripts'
-  gem 'pry-rescue'
-  gem 'pry-stack_explorer'
-  gem 'spring'
-  gem 'spring-commands-rspec'
-  gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'web-console'
-  gem 'xray-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,6 +210,8 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
+    rspec_junit_formatter (0.3.0)
+      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -286,6 +288,7 @@ DEPENDENCIES
   rails-controller-testing
   responders
   rspec-rails
+  rspec_junit_formatter
   rubocop-rspec
   sass-rails (~> 5.0)
   sorcery

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,7 +48,6 @@ GEM
       public_suffix (~> 2.0, >= 2.0.2)
     arel (8.0.0)
     ast (2.3.0)
-    awesome_print (1.8.0)
     aws-sdk (2.10.9)
       aws-sdk-resources (= 2.10.9)
     aws-sdk-core (2.10.9)
@@ -58,15 +57,10 @@ GEM
       aws-sdk-core (= 2.10.9)
     aws-sigv4 (1.0.0)
     bcrypt (3.1.11)
-    bindex (0.5.0)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     bourbon (4.2.7)
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.3)
-    byebug (9.0.6)
-    callsite (0.0.11)
     capybara (2.14.4)
       addressable
       mime-types (>= 1.16)
@@ -76,26 +70,13 @@ GEM
       xpath (~> 2.0)
     capybara-accessible (0.2.1)
       capybara (~> 2.0)
-    capybara-screenshot (1.0.16)
-      capybara (>= 1.0, < 3)
-      launchy
-    childprocess (0.7.1)
-      ffi (~> 1.0, >= 1.0.11)
     climate_control (0.2.0)
     cliver (0.3.2)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
     coderay (1.1.1)
-    coffee-rails (4.2.2)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0)
-    coffee-script (2.4.1)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
     database_cleaner (1.6.1)
-    debug_inspector (0.0.3)
     diff-lcs (1.3)
     erubi (1.6.1)
     execjs (2.7.0)
@@ -103,24 +84,8 @@ GEM
       i18n (~> 0.5)
     faraday (0.12.1)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.18)
-    formatador (0.2.5)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
-    guard (2.14.1)
-      formatador (>= 0.2.4)
-      listen (>= 2.7, < 4.0)
-      lumberjack (~> 1.0)
-      nenv (~> 0.1)
-      notiffany (~> 0.0)
-      pry (>= 0.9.12)
-      shellany (~> 0.0)
-      thor (>= 0.18.1)
-    guard-compat (1.2.1)
-    guard-rspec (4.7.3)
-      guard (~> 2.1)
-      guard-compat (~> 1.1)
-      rspec (>= 2.99.0, < 4.0)
     haml (5.0.1)
       temple (>= 0.8.0)
       tilt
@@ -133,30 +98,16 @@ GEM
       rubocop (>= 0.49.0)
       sysexits (~> 1.1)
     i18n (0.8.6)
-    interception (0.5)
-    jbuilder (2.7.0)
-      activesupport (>= 4.2.0)
-      multi_json (>= 1.2)
     jmespath (1.3.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     jwt (1.5.6)
-    launchy (2.4.3)
-      addressable (~> 2.3)
-    listen (3.0.8)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
-    lumberjack (1.0.12)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
-    meta_request (0.4.3)
-      callsite (~> 0.0, >= 0.0.11)
-      rack-contrib (>= 1.1, < 3)
-      railties (>= 3.0.0, < 5.2.0)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -170,13 +121,9 @@ GEM
     neat (1.9.0)
       sass (>= 3.3)
       thor (~> 0.19)
-    nenv (0.3.0)
     nio4r (2.1.0)
     nokogiri (1.8.0)
       mini_portile2 (~> 2.2.0)
-    notiffany (0.1.1)
-      nenv (~> 0.1)
-      shellany (~> 0.0)
     oauth (0.5.3)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)
@@ -197,7 +144,6 @@ GEM
       cliver (~> 0.3.2)
       safe_shell (>= 1.0.3, < 2.0)
     pg (0.21.0)
-    pivotal_git_scripts (1.4.0)
     poltergeist (1.15.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -209,17 +155,9 @@ GEM
       slop (~> 3.4)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
-    pry-rescue (1.4.5)
-      interception (>= 0.5)
-      pry
-    pry-stack_explorer (0.4.9.2)
-      binding_of_caller (>= 0.7)
-      pry (>= 0.9.11)
     public_suffix (2.0.5)
     puma (3.9.1)
     rack (2.0.3)
-    rack-contrib (1.2.0)
-      rack (>= 0.9.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.1.2)
@@ -252,16 +190,9 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.0.0)
-    rb-fsevent (0.10.2)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    rspec (3.6.0)
-      rspec-core (~> 3.6.0)
-      rspec-expectations (~> 3.6.0)
-      rspec-mocks (~> 3.6.0)
     rspec-core (3.6.0)
       rspec-support (~> 3.6.0)
     rspec-expectations (3.6.0)
@@ -279,8 +210,6 @@ GEM
       rspec-mocks (~> 3.6.0)
       rspec-support (~> 3.6.0)
     rspec-support (3.6.0)
-    rspec_junit_formatter (0.3.0)
-      rspec-core (>= 2, < 4, != 2.12.0)
     rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -291,7 +220,6 @@ GEM
     rubocop-rspec (1.15.1)
       rubocop (>= 0.42.0)
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.1)
     safe_shell (1.1.0)
     sass (3.4.25)
     sass-rails (5.0.6)
@@ -300,22 +228,11 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selenium-webdriver (3.4.3)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.0)
-    shellany (0.0.1)
     slop (3.6.0)
     sorcery (0.11.0)
       bcrypt (~> 3.1)
       oauth (~> 0.4, >= 0.4.4)
       oauth2 (~> 1.0, >= 0.8.0)
-    spring (2.0.2)
-      activesupport (>= 4.2)
-    spring-commands-rspec (1.0.4)
-      spring (>= 0.9.1)
-    spring-watcher-listen (2.0.1)
-      listen (>= 2.7, < 4.0)
-      spring (>= 1.2, < 3.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -337,76 +254,47 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
-    web-console (3.5.1)
-      actionview (>= 5.0)
-      activemodel (>= 5.0)
-      bindex (>= 0.4.0)
-      railties (>= 5.0)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    xray-rails (0.3.1)
-      rails (>= 3.1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  awesome_print
   aws-sdk
   bourbon (~> 4.2.0)
-  byebug
   capybara
   capybara-accessible
-  capybara-screenshot
   citizen-scripts!
   climate_control
-  coffee-rails
   database_cleaner
   faker
-  guard
-  guard-rspec
   haml (~> 5.0)
   haml-lint
-  jbuilder (~> 2.0)
   jquery-rails
-  launchy
-  listen (~> 3.0.5)
-  meta_request
   neat (~> 1.8)
   paperclip (~> 5.0.0)
   pdf-forms
   pg (~> 0.18)
-  pivotal_git_scripts
   poltergeist
   pry-rails
-  pry-rescue
-  pry-stack_explorer
   puma (~> 3.0)
   rails (~> 5.1)
   rails-controller-testing
-  rake
   responders
   rspec-rails
-  rspec_junit_formatter
-  rubocop
   rubocop-rspec
   sass-rails (~> 5.0)
-  selenium-webdriver
   sorcery
-  spring
-  spring-commands-rspec
-  spring-watcher-listen (~> 2.0.0)
   twilio-ruby
   tzinfo-data
   uglifier (>= 1.3.0)
-  web-console
-  xray-rails
 
 RUBY VERSION
    ruby 2.4.1p111
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -17,7 +17,6 @@ headless_capybara = true
 require 'capybara/rails'
 require 'capybara/rspec'
 require 'capybara/accessible'
-require 'capybara-screenshot/rspec'
 
 if headless_capybara
   require 'capybara/poltergeist'


### PR DESCRIPTION
**WHY**: This is mostly dev-only stuff that Cylinder folks won't use.
Plus, better not to have dev-specific stuff in the Gemfile when
possible.