### PR TITLE
Add overcommit gem

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,34 @@
+gemfile: Gemfile
+
+PreCommit:
+  BundleCheck:
+    enabled: true
+
+  ExecutePermissions:
+    enabled: true
+    exclude:
+      - 'bin/**/*'
+      - 'libexec/**/*'
+      - 'template-dir/hooks/**/*'
+
+  HardTabs:
+    enabled: true
+
+  MasterHooksMatch:
+    enabled: true
+    quiet: true
+
+  RuboCop:
+    enabled: true
+    command: ['bundle', 'exec', 'rubocop']
+    include:
+      - '**/*.gemspec'
+      - '**/*.rb'
+      - '**/Gemfile'
+      - template-dir/hooks/overcommit-hook
+
+  TrailingWhitespace:
+    enabled: true
+
+  YamlSyntax:
+    enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -46,4 +46,5 @@ end
 
 group :development do
   gem "citizen-scripts", git: "https://github.com/citizencode/citizen-scripts"
+  gem "overcommit"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    childprocess (0.7.1)
+      ffi (~> 1.0, >= 1.0.11)
     climate_control (0.2.0)
     cliver (0.3.2)
     cocaine (0.5.8)
@@ -100,6 +102,7 @@ GEM
       rubocop (>= 0.49.0)
       sysexits (~> 1.1)
     i18n (0.8.6)
+    iniparse (1.4.4)
     jmespath (1.3.1)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -137,6 +140,9 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    overcommit (0.40.0)
+      childprocess (~> 0.6, >= 0.6.3)
+      iniparse (~> 1.4)
     paperclip (5.0.0)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
@@ -293,6 +299,7 @@ DEPENDENCIES
   jquery-rails
   listen
   neat (~> 1.8)
+  overcommit
   paperclip (~> 5.0.0)
   pdf-forms
   pg (~> 0.18)

--- a/bin/setup
+++ b/bin/setup
@@ -40,4 +40,13 @@ chdir APP_ROOT do
   step "Restarting application server" do
     system! "bin/rails restart"
   end
+
+  step "Installing git commit hooks (uninstall via `overcommit --uninstall)" do
+    if cli_installed?("overcommit")
+      puts "Already installed"
+    else
+      puts "Installing overcommit..."
+      system!("overcommit --install")
+    end
+  end
 end


### PR DESCRIPTION
Reason for Change
=================
* The [overcommit] gem allows for installation of git commit hooks.
* This can provide a way to run checks like Rubocop when committing, as opposed running tests or on CI, which are further down the code lifecycle.

[overcommit]: https://github.com/brigade/overcommit

Changes
=======
* Add the overcommit gem to the Gemfile
* Add overcommit installation to setup script
* Add the default configuration file.

Minor
=====
* Add a helper to detect if a cli is installed or now.