### PR TITLE
Ignore pdf files created by specs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 !/log/.keep
 /tmp
 /coverage
+
+test_pdf.pdf


### PR DESCRIPTION
Reason for Change
=================
* Running the test suite leaves a new `test_pdf.pdf` file in the repository.

Changes
=======
* `.gitignore` the test file.

Questions
=========
* I wonder if we shouldn't just save the file in `/tmp` or alternatively clean up the file after the spec?