### PR TITLE
Ignore brakeman warning (via code climate)

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "c7c9b4de9c22b2c60bc74a8246bae70fe99146bae901fc6559dd983fe02ce6b1",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/models/dhs1171_pdf.rb",
+      "line": 44,
+      "link": "http://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "system(\"pdftk #{\"#{\"lib/pdfs\".freeze}/michigan_snap_fax_cover_letter.pdf\".freeze} #{completed_filename} cat output #{output_filename}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Dhs1171Pdf",
+        "method": "add_cover_sheet_to_completed_form"
+      },
+      "user_input": "\"lib/pdfs\".freeze",
+      "confidence": "Medium",
+      "note": ""
+    }
+  ],
+  "updated": "2017-07-28 13:56:10 -0700",
+  "brakeman_version": "3.7.0"
+}


### PR DESCRIPTION
**WHY**: we are not worried about this because we determine input

* Output file is programmatically ignored via:
```
gem install brakeman
brakeman --interactive-ignore
```