### PR TITLE
Use Ruby's tempfiles for temporary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 !/log/.keep
 /tmp/*
 /coverage
+.rspec

--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,0 @@
---color
---require spec_helper
---order random
---profile

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -5,7 +5,7 @@ class ApplicationMailer < ActionMailer::Base
   layout "mailer"
 
   def snap_application_notification(file_name:, recipient_email:)
-    attachments["snap_application.pdf"] = File.read("#{Rails.root}/#{file_name}")
+    attachments["snap_application.pdf"] = File.read(file_name)
     mail to: recipient_email, subject: "Your SNAP application"
   end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,26 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Command Injection",
+      "warning_code": 14,
+      "fingerprint": "40a7ec46252e4832ff4cfa253e332fc2859820a7a4e9c48a7124fb2cbf48df3c",
+      "check_name": "Execute",
+      "message": "Possible command injection",
+      "file": "app/models/dhs1171_pdf.rb",
+      "line": 49,
+      "link": "http://brakemanscanner.org/docs/warning_types/command_injection/",
+      "code": "system(\"pdftk #{\"#{\"lib/pdfs\".freeze}/michigan_snap_fax_cover_letter.pdf\".freeze} #{filled_in_form.path} cat output #{complete_form_with_cover.path}\")",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "Dhs1171Pdf",
+        "method": "prepend_cover_sheet_to_completed_form"
+      },
+      "user_input": "\"lib/pdfs\".freeze",
+      "confidence": "Medium",
+      "note": ""
+    }
+  ],
+  "updated": "2017-07-28 15:35:34 -0700",
+  "brakeman_version": "3.7.0"
+}

--- a/spec/jobs/send_application_job_spec.rb
+++ b/spec/jobs/send_application_job_spec.rb
@@ -3,22 +3,29 @@ require "rails_helper"
 RSpec.describe SendApplicationJob do
   describe "#perform" do
     it "creates a PDF with the snap application data" do
-      pdf_double = double(save: true)
-      allow(Dhs1171Pdf).to receive(:new).with(snap_application: snap_application, output_filename: "test_pdf.pdf").and_return(pdf_double)
+      snap_application = FactoryGirl.create(:snap_application)
+      tempfile = Tempfile.new("send_application_job_spec")
+      pdf_double = double(completed_file: tempfile)
+      allow(Dhs1171Pdf).to receive(:new).
+        with(snap_application: snap_application).
+        and_return(pdf_double)
 
       SendApplicationJob.new.perform(snap_application: snap_application)
 
-      expect(pdf_double).to have_received(:save)
+      expect(pdf_double).to have_received(:completed_file)
+      expect(Dhs1171Pdf).to have_received(:new).
+        with(snap_application: snap_application)
+
+      tempfile.close
+      tempfile.unlink
     end
 
     it "sends an email" do
+      snap_application = FactoryGirl.create(:snap_application)
+
       expect do
         SendApplicationJob.new.perform(snap_application: snap_application)
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
-  end
-
-  def snap_application
-    @_snap_application ||= FactoryGirl.create(:snap_application)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
   end
 
   config.example_status_persistence_file_path = "tmp/examples.txt"
+  config.order = :random
 
   config.filter_gems_from_backtrace \
     "actionpack",


### PR DESCRIPTION
Reason for Change
=================
* Much of what we were doing manually with files (creating them, randomizing names, cleaning them up after use) is managed by Ruby's [tempfile] library.

[tempfile]: https://docs.ruby-lang.org/en/2.4.0/Tempfile.html

Changes
=======
* In the generation of the completed `Dhs1171Pdf` file, use `tempfile`s in the pdf generation and return the resulting `tempfile`.
* Be sure to close the `tempfile` explicitly in this class.
* In the job class, generate and close the tempfile after sending is complete.

Minor
-----
* No need to profile all specs on every run.
* gitignore .rspec because those are personal preferences, not team ones