### PR TITLE
Add a Pull Request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+Reason for Change
+===================
+* Describe the big picture of your changes here.
+* This should describe why this pull request should be merged.
+* If it fixes a bug or resolves a feature request, link to that issue.
+
+Changes
+=======
+* Describe your changes as a concise list of items.
+
+Minor
+=====
+* List any minor changes or style fixes here.
+
+Risks
+=====
+* Describe any risks you see to existing systems this fix or feature might have
+if those systems where to incorporate this change.
+
+Checklist
+=========
+_Put an `x` in the boxes that apply.
+You can also fill these out after creating the PR._
+
+- [ ] I have linked to all relevant reference issues or work requests
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have added or updated necessary documentation (if appropriate)
+- [ ] Any dependent changes have been merged and published in downstream
+
+Recommended Reviewers
+=====================
+@jesseay, @adarsh, @jayroh

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,17 +16,3 @@ Risks
 =====
 * Describe any risks you see to existing systems this fix or feature might have
 if those systems where to incorporate this change.
-
-Checklist
-=========
-_Put an `x` in the boxes that apply.
-You can also fill these out after creating the PR._
-
-- [ ] I have linked to all relevant reference issues or work requests
-- [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] I have added or updated necessary documentation (if appropriate)
-- [ ] Any dependent changes have been merged and published in downstream
-
-Recommended Reviewers
-=====================
-@jesseay, @adarsh, @jayroh


### PR DESCRIPTION
Reason for Change
=================
* Consistent Pull Requests are good because they allow us to communicate in a unified way.
* [GitHub offers a convention for this kind of template via their `.github/` folder.][1]

Changes
=======
* Add a PR template in the "RFC" or "Request for Change" format.

[1]: https://github.com/blog/2111-issue-and-pull-request-templates