### PR TITLE
Add and configure mailcatcher

### DIFF
--- a/.foreman
+++ b/.foreman
@@ -1,0 +1,1 @@
+procfile: Procfile.dev

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "haml-lint", require: false
   gem "listen"
+  gem "mailcatcher", "~> 0.2"
   gem "poltergeist"
   gem "pry-rails"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       simplecov (<= 0.13)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
+    daemons (1.2.4)
     database_cleaner (1.6.1)
     delayed_job (4.1.3)
       activesupport (>= 3.0, < 5.2)
@@ -88,6 +89,7 @@ GEM
     diff-lcs (1.3)
     docile (1.1.5)
     erubi (1.6.1)
+    eventmachine (1.0.9.1)
     execjs (2.7.0)
     factory_girl (4.8.0)
       activesupport (>= 3.0.0)
@@ -127,6 +129,16 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.6)
       mime-types (>= 1.16, < 4)
+    mailcatcher (0.2.4)
+      eventmachine
+      haml
+      i18n
+      json
+      mail
+      sinatra
+      skinny (>= 0.1.2)
+      sqlite3-ruby
+      thin
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -135,6 +147,7 @@ GEM
     mini_portile2 (2.2.0)
     minitest (5.10.2)
     multi_json (1.12.1)
+    mustermann (1.0.0)
     neat (1.9.0)
       sass (>= 3.3)
       thor (~> 0.19)
@@ -177,6 +190,8 @@ GEM
     public_suffix (2.0.5)
     puma (3.9.1)
     rack (2.0.3)
+    rack-protection (2.0.0)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.1.2)
@@ -258,6 +273,14 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.1)
+    sinatra (2.0.0)
+      mustermann (~> 1.0)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0)
+      tilt (~> 2.0)
+    skinny (0.2.4)
+      eventmachine (~> 1.0.0)
+      thin (>= 1.5, < 1.7)
     slop (3.6.0)
     sprockets (3.7.1)
       concurrent-ruby (~> 1.0)
@@ -266,8 +289,15 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    sqlite3 (1.3.13)
+    sqlite3-ruby (1.3.3)
+      sqlite3 (>= 1.3.3)
     sysexits (1.2.0)
     temple (0.8.0)
+    thin (1.6.2)
+      daemons (>= 1.0.9)
+      eventmachine (>= 1.0.0)
+      rack (>= 1.0.0)
     thor (0.19.4)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -305,6 +335,7 @@ DEPENDENCIES
   haml-lint
   jquery-rails
   listen
+  mailcatcher (~> 0.2)
   neat (~> 1.8)
   overcommit
   paperclip (~> 5.0.0)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+web: bundle exec rails server -p $PORT
+worker: rake jobs:work
+mail: mailcatcher

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,17 +20,21 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.perform_caching = false
   config.active_support.deprecation = :log
   config.active_record.migration_error = :page_load
   config.assets.debug = true
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
   # Customize default host
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_caching = false
+  config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.smtp_settings = {
+    address: "127.0.0.1",
+    port: 1025,
+  }
   config.action_mailer.default_url_options = {
     host: ENV["HOSTNAME_FOR_URLS"],
     protocol: "http",
   }
-  config.action_mailer.smtp_settings = SMTP_SETTINGS
-  config.action_mailer.delivery_method = :smtp
 end


### PR DESCRIPTION
In order for mailcatcher to work, we have to boot it up alongside both the
rails and worker processes. A small wrinkle attached to this is that we don't
want this process to start via the main, canonical, Procfile.  We'll need a
separate, dev-specific, Profile that we can run locally - `Profile.dev`. In
order for this procfile to run in the dev environment we can add a .foreman
file that will point to the other file - `Profile.dev`.

* Move mailcatcher to development gem group
* Configure mailcatcher in config/environments/development.rb