### PR TITLE
Add sfax, corresponding fax adapter and test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,3 +48,8 @@ build on Circle CI.
   without an explicit PR / code review process.
 * During the team's weekly retro meetings, feedback about the workflow is noted
   and related changes are incorporated into this document.
+
+## Conventions
+
+* **Secrets** - api keys and secrets should be placed in `config/secrets.yml` and
+  referenced via Rails' secrets api. Eg: `Rails.application.secrets.an_api_key`.

--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ ruby "2.4.1"
 gem "aws-sdk"
 gem "bourbon", "~> 4.2.0" # to keep in sync with getcalfresh
 gem "delayed_job_active_record"
+gem "faraday"
 gem "haml", "~> 5.0"
 gem "jquery-rails"
 gem "neat", "~> 1.8" # to keep in sync with getcalfresh
@@ -17,6 +18,9 @@ gem "puma", "~> 3.0"
 gem "rails", "~> 5.1"
 gem "responders"
 gem "sass-rails", "~> 5.0"
+gem "sfax",
+  git: "https://github.com/codeforamerica/sfax",
+  ref: "da88847faaf5ab51255e4d7e47d76493d05113b1"
 gem "twilio-ruby"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,10 @@
+GIT
+  remote: https://github.com/codeforamerica/sfax
+  revision: da88847faaf5ab51255e4d7e47d76493d05113b1
+  ref: da88847faaf5ab51255e4d7e47d76493d05113b1
+  specs:
+    sfax (0.1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -92,6 +99,8 @@ GEM
       railties (>= 3.0.0)
     faker (1.8.0)
       i18n (~> 0.5)
+    faraday (0.12.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -142,6 +151,7 @@ GEM
     minitest (5.10.2)
     multi_json (1.12.1)
     mustermann (1.0.0)
+    multipart-post (2.0.0)
     neat (1.9.0)
       sass (>= 3.3)
       thor (~> 0.19)
@@ -324,6 +334,7 @@ DEPENDENCIES
   delayed_job_active_record
   factory_girl_rails
   faker
+  faraday
   haml (~> 5.0)
   haml-lint
   jquery-rails
@@ -345,6 +356,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop-rspec
   sass-rails (~> 5.0)
+  sfax!
   simplecov
   twilio-ruby
   tzinfo-data

--- a/app/models/fax.rb
+++ b/app/models/fax.rb
@@ -21,11 +21,9 @@ class Fax
     sfax.send_fax(number, file)
   end
 
-  protected
+  private
 
   attr_reader :file, :number
-
-  private
 
   def sfax
     SFax::Faxer.new(

--- a/app/models/fax.rb
+++ b/app/models/fax.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class Fax
+  delegate \
+    :sfax_api_key,
+    :sfax_encryption_key,
+    :sfax_init_vector,
+    :sfax_username,
+    to: :"Rails.application.secrets"
+
+  def self.send_fax(number:, file:)
+    new(number, file).send_fax
+  end
+
+  def initialize(number, file)
+    @number = number
+    @file = file
+  end
+
+  def send_fax
+    sfax.send_fax(number, file)
+  end
+
+  protected
+
+  attr_reader :file, :number
+
+  private
+
+  def sfax
+    SFax::Faxer.new(
+      sfax_username,
+      sfax_api_key,
+      sfax_init_vector,
+      sfax_encryption_key,
+    )
+  end
+end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,8 +15,19 @@ development:
 
 test:
   secret_key_base: a4601e0fb037b7d1ed534a5d5dd114f47b753c9945757ebe0f9fedff98d41b12741f7dd631e0d9a69cd518623384d871b0387ec5645ccccbbb5d9336ff1cf800
+  sfax_username: sfax_username
+  sfax_api_key: sfax_api_key
+  sfax_encryption_key: sfax_encryption_key
+  sfax_init_vector: sfax_init_vector
+
+from_environment: &deployable_settings
+  sfax_username: <%= ENV['SFAX_USERNAME'] %>
+  sfax_api_key: <%= ENV['SFAX_API_KEY'] %>
+  sfax_encryption_key: <%= ENV['SFAX_ENCRYPTION_KEY'] %>
+  sfax_init_vector: <%= ENV['SFAX_INIT_VECTOR'] %>
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.
 production:
+  <<: *deployable_settings
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>

--- a/spec/models/fax_spec.rb
+++ b/spec/models/fax_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Fax do
+  describe ".send_fax" do
+    it "initializes SFax with rails secrets" do
+      fake_faxer = double(send_fax: true)
+      allow(SFax::Faxer).to receive(:new).and_return(fake_faxer)
+
+      Fax.send_fax(number: "+18005550000", file: "file.pdf")
+
+      expect(SFax::Faxer).to have_received(:new).with(
+        Rails.application.secrets.sfax_username,
+        Rails.application.secrets.sfax_api_key,
+        Rails.application.secrets.sfax_init_vector,
+        Rails.application.secrets.sfax_encryption_key,
+      )
+    end
+
+    it "sends a file to desired number with sfax" do
+      fake_faxer = double(send_fax: true)
+      allow(SFax::Faxer).to receive(:new).and_return(fake_faxer)
+
+      Fax.send_fax(number: "+18005550000", file: "file.pdf")
+
+      expect(fake_faxer).to have_received(:send_fax).
+        with("+18005550000", "file.pdf")
+    end
+  end
+end


### PR DESCRIPTION
The sfax gem has been taken over by another project so pointing to the
CFA fork that the GCF team has set up is the best bet.

This commit adds an adapter class to interface with the SFax gem and
tests that it is being called correctly, using the credentials places in
the Rails secret yaml file.

NOTE: Adding faraday is necessary, for some reason to get things to
function reliably.