### PR TITLE
Serve only Genesee County

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ group :test do
 end
 
 group :development, :test do
+  gem "awesome_print", require: false
   gem "capybara"
   gem "climate_control"
   gem "codeclimate-test-reporter"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
     afm (0.2.2)
     arel (8.0.0)
     ast (2.3.0)
+    awesome_print (1.8.0)
     aws-sdk (2.10.9)
       aws-sdk-resources (= 2.10.9)
     aws-sdk-core (2.10.9)
@@ -327,6 +328,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  awesome_print
   aws-sdk
   bourbon (~> 4.2.0)
   capybara

--- a/app/views/address/edit.html.erb
+++ b/app/views/address/edit.html.erb
@@ -10,7 +10,7 @@
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_input_field :street_address, "Address", options:  { placeholder: "123 Main St." } %>
       <%= f.mb_input_field :city, "City", options:  { placeholder: "Flint" } %>
-      <%= f.mb_input_field :county, "County", options:  { placeholder: "Genesee" } %>
+      <%= f.mb_input_field :county, "County", options:  { value: "Genesee", disable: true } %>
       <%= f.mb_input_field :state, "State", options:  { placeholder: "MI" } %>
       <%= f.mb_input_field :zip, "ZIP code", options:  { placeholder: "12345" } %>
       <%= render 'shared/next_step' %>

--- a/spec/controllers/address_controller_spec.rb
+++ b/spec/controllers/address_controller_spec.rb
@@ -28,17 +28,15 @@ RSpec.describe AddressController, type: :controller do
 
   describe "#update" do
     context "when valid" do
-      let(:valid_params) do
-        {
+      it "updates the app" do
+        valid_params = {
           street_address: "321 Real St",
           city: "Shelbyville",
           zip: "54321",
           county: "Genesee",
           state: "MI",
         }
-      end
 
-      it "updates the app" do
         put :update, params: { step: valid_params }
 
         current_app.reload
@@ -48,7 +46,31 @@ RSpec.describe AddressController, type: :controller do
         end
       end
 
+      it "always sets the county to 'Genesee'" do
+        valid_params = {
+          street_address: "321 Main St",
+          city: "Plymouth",
+          zip: "48170",
+          county: nil,
+          state: "MI",
+        }
+
+        put :update, params: { step: valid_params }
+
+        current_app.reload
+
+        expect(current_app["county"]).to eq("Genesee")
+      end
+
       it "redirects to the next step" do
+        valid_params = {
+          street_address: "321 Real St",
+          city: "Shelbyville",
+          zip: "54321",
+          county: "Genesee",
+          state: "MI",
+        }
+
         put :update, params: { step: valid_params }
 
         expect(response).to redirect_to("/steps/documents")


### PR DESCRIPTION
Reason for Change
=================
* Users often are not aware of their county name.
* As such, asking them to fill in a form with the county name may not be productive.

Changes
=======
* Lock the usage to users of Genesee county only.

Minor
-----
* Add the `awesome_print` gem for colorful debugging (use `ap` instead of `puts`)
