### PR TITLE
Automatically migrate database when releasing

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 web: bundle exec rails server -p $PORT
 worker: rake jobs:work
+release: ./bin/release_tasks

--- a/bin/release_tasks
+++ b/bin/release_tasks
@@ -1,0 +1,1 @@
+bundle exec rake db:migrate


### PR DESCRIPTION
Reason for Change
=================
* We auto-deploy to `staging` when we merge to the `master` branch.
* Sometimes, we can forget to run the database migrations.
* We can automate this!

Changes
=======
* Use the [release-phase] option on Heroku to automatically run a script upon release.
* Set it to run a task that runs the migrations

[release-phase]: https://devcenter.heroku.com/articles/release-phase