### PR TITLE
Fix typo for disabling a field

### DIFF
--- a/app/views/address/edit.html.erb
+++ b/app/views/address/edit.html.erb
@@ -10,7 +10,7 @@
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_input_field :street_address, "Address", options:  { placeholder: "123 Main St." } %>
       <%= f.mb_input_field :city, "City", options:  { placeholder: "Flint" } %>
-      <%= f.mb_input_field :county, "County (currently serving Genesee County)", options:  { value: "Genesee", disabled: true } %>
+      <%= f.mb_input_field :county, "County (currently serving Genesee County)", options:  { value: "Genesee", readonly: "readonly" } %>
       <%= f.mb_input_field :state, "State", options:  { placeholder: "MI" } %>
       <%= f.mb_input_field :zip, "ZIP code", options:  { placeholder: "12345" } %>
       <%= render 'shared/next_step' %>

--- a/app/views/address/edit.html.erb
+++ b/app/views/address/edit.html.erb
@@ -10,7 +10,7 @@
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_input_field :street_address, "Address", options:  { placeholder: "123 Main St." } %>
       <%= f.mb_input_field :city, "City", options:  { placeholder: "Flint" } %>
-      <%= f.mb_input_field :county, "County", options:  { value: "Genesee", disable: true } %>
+      <%= f.mb_input_field :county, "County (currently serving Genesee County)", options:  { value: "Genesee", disabled: true } %>
       <%= f.mb_input_field :state, "State", options:  { placeholder: "MI" } %>
       <%= f.mb_input_field :zip, "ZIP code", options:  { placeholder: "12345" } %>
       <%= render 'shared/next_step' %>

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -14,7 +14,6 @@ feature "SNAP application" do
 
     fill_in "Address", with: "123 Main St"
     fill_in "City", with: "Flint"
-    fill_in "County", with: "Genesee"
     fill_in "State", with: "MI"
     fill_in "ZIP code", with: "12345"
     click_on "Continue"
@@ -47,7 +46,6 @@ feature "SNAP application" do
 
     fill_in "Address", with: "123 Main St"
     fill_in "City", with: "Flint"
-    fill_in "County", with: "Genesee"
     fill_in "State", with: "MI"
     fill_in "ZIP code", with: "12345"
     click_on "Continue"


### PR DESCRIPTION
Reason for Change
=================
* The HTML directive is `disabled: true` with a "d" at the end. I had it as `disable: true` accidentally.
* See [reference].

[reference]: https://www.w3schools.com/jsref/prop_text_disabled.asp

Changes
=======
* Fix typo.

Minor
-----
* Add note specifying we are currently only serving Genesee County, so people aren't upset about the disabled text box.