### PR TITLE
Add bundler-audit to default rake task(s)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ end
 
 group :development, :test do
   gem "awesome_print", require: false
+  gem "bundler-audit"
   gem "capybara"
   gem "climate_control"
   gem "codeclimate-test-reporter"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,9 @@ GEM
       sass (~> 3.4)
       thor (~> 0.19)
     builder (3.2.3)
+    bundler-audit (0.5.0)
+      bundler (~> 1.2)
+      thor (~> 0.18)
     capybara (2.14.4)
       addressable
       mime-types (>= 1.16)
@@ -322,6 +325,7 @@ DEPENDENCIES
   awesome_print
   aws-sdk
   bourbon (~> 4.2.0)
+  bundler-audit
   capybara
   climate_control
   codeclimate-test-reporter

--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,6 @@ task(:rubocop) do
   RuboCop::RakeTask.new
 end
 
-task default: %w(spec rubocop)
+task default: %w(spec rubocop bundler:audit)
 
 Rails.application.load_tasks

--- a/lib/tasks/bundler_audit.rake
+++ b/lib/tasks/bundler_audit.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+if Rails.env.development? || Rails.env.test?
+  require "bundler/audit/cli"
+
+  namespace :bundler do
+    desc "Updates the ruby-advisory-db and runs audit"
+    task :audit do
+      %w[update check].each do |command|
+        Bundler::Audit::CLI.start [command]
+      end
+    end
+  end
+end


### PR DESCRIPTION
The bundler-audit gem allows us to check that all currently installed
gems in the bundle are not versions that have had a security issue
reported as a CVE.

This commit adds the rake task `bundler:audit` to the task pipeline in
addition to rspec and rubocop. The test suite will *not* pass if a gem
has an open CVE in the bundle.