### PR TITLE
Remove state and county fields from address page

### DIFF
--- a/app/controllers/address_controller.rb
+++ b/app/controllers/address_controller.rb
@@ -1,4 +1,9 @@
 # frozen_string_literal: true
 
 class AddressController < StandardStepsController
+  private
+
+  def step_params
+    super.merge(state: "MI", county: "Genesee")
+  end
 end

--- a/app/steps/address.rb
+++ b/app/steps/address.rb
@@ -15,12 +15,12 @@ class Address < Step
   validates :city,
     presence: { message: "Make sure to provide a city" }
 
-  validates :county,
-    presence: { message: "Make sure to provide a county" }
-
-  validates :state,
-    presence: { message: "Make sure to provide a state" }
-
   validates :zip,
     length: { is: 5, message: "Make sure your ZIP code is 5 digits long" }
+
+  validates :county,
+    inclusion: { in: %w(Genesee), message: "Make sure the county is Genesee" }
+
+  validates :state,
+    inclusion: { in: %w(MI), message: "Make sure the county is MI" }
 end

--- a/app/views/address/edit.html.erb
+++ b/app/views/address/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :header_title, "Address" %>
+<% content_for :header_title, "Contact Information" %>
 
 <div class="form-card">
   <header class="form-card__header">
@@ -10,8 +10,6 @@
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_input_field :street_address, "Address", options:  { placeholder: "123 Main St." } %>
       <%= f.mb_input_field :city, "City", options:  { placeholder: "Flint" } %>
-      <%= f.mb_input_field :county, "County (currently serving Genesee County)", options:  { value: "Genesee", readonly: "readonly" } %>
-      <%= f.mb_input_field :state, "State", options:  { placeholder: "MI" } %>
       <%= f.mb_input_field :zip, "ZIP code", options:  { placeholder: "12345" } %>
       <%= render 'shared/next_step' %>
     <% end %>

--- a/spec/controllers/address_controller_spec.rb
+++ b/spec/controllers/address_controller_spec.rb
@@ -20,9 +20,7 @@ RSpec.describe AddressController, type: :controller do
 
       expect(step.street_address).to eq("123 Fake St")
       expect(step.city).to eq("Springfield")
-      expect(step.county).to eq("Genesee")
       expect(step.zip).to eq("12345")
-      expect(step.state).to eq("MI")
     end
   end
 
@@ -33,8 +31,6 @@ RSpec.describe AddressController, type: :controller do
           street_address: "321 Real St",
           city: "Shelbyville",
           zip: "54321",
-          county: "Genesee",
-          state: "MI",
         }
 
         put :update, params: { step: valid_params }
@@ -46,13 +42,11 @@ RSpec.describe AddressController, type: :controller do
         end
       end
 
-      it "always sets the county to 'Genesee'" do
+      it "always sets the county to 'Genesee' and state to 'MI'" do
         valid_params = {
           street_address: "321 Main St",
           city: "Plymouth",
           zip: "48170",
-          county: nil,
-          state: "MI",
         }
 
         put :update, params: { step: valid_params }
@@ -60,6 +54,7 @@ RSpec.describe AddressController, type: :controller do
         current_app.reload
 
         expect(current_app["county"]).to eq("Genesee")
+        expect(current_app["state"]).to eq("MI")
       end
 
       it "redirects to the next step" do
@@ -67,8 +62,6 @@ RSpec.describe AddressController, type: :controller do
           street_address: "321 Real St",
           city: "Shelbyville",
           zip: "54321",
-          county: "Genesee",
-          state: "MI",
         }
 
         put :update, params: { step: valid_params }
@@ -89,9 +82,7 @@ RSpec.describe AddressController, type: :controller do
     @_current_app ||= SnapApplication.create!(
       street_address: "123 Fake St",
       city: "Springfield",
-      county: "Genesee",
       zip: "12345",
-      state: "MI",
     )
   end
 end

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -14,7 +14,6 @@ feature "SNAP application" do
 
     fill_in "Address", with: "123 Main St"
     fill_in "City", with: "Flint"
-    fill_in "State", with: "MI"
     fill_in "ZIP code", with: "12345"
     click_on "Continue"
 
@@ -46,7 +45,6 @@ feature "SNAP application" do
 
     fill_in "Address", with: "123 Main St"
     fill_in "City", with: "Flint"
-    fill_in "State", with: "MI"
     fill_in "ZIP code", with: "12345"
     click_on "Continue"
 


### PR DESCRIPTION
**WHY**: We are setting defaults for these for now.

Part of https://trello.com/c/Wcz2Uf6z/81-as-an-mdhhs-worker-i-want-to-know-the-clients-phone-number-and-email-so-i-can-follow-up-with-them

I am opening this as a separate PR because I am unsure if this is the best place to implement this. Alternative would be DB-level default. 