### PR TITLE
Add residential address step

### DIFF
--- a/app/controllers/mailing_address_controller.rb
+++ b/app/controllers/mailing_address_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddressController < StandardStepsController
+class MailingAddressController < StandardStepsController
   private
 
   def step_params

--- a/app/controllers/residential_address_controller.rb
+++ b/app/controllers/residential_address_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class ResidentialAddressController < StandardStepsController
-  def edit
-    @step = step_class.new(snap_application_attributes.slice(*step_attrs))
-  end
-
   def update
     @step = step_class.new(step_params)
 

--- a/app/controllers/residential_address_controller.rb
+++ b/app/controllers/residential_address_controller.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class ResidentialAddressController < StandardStepsController
+  def edit
+    @step = step_class.new(snap_application_attributes.slice(*step_attrs))
+  end
+
+  def update
+    @step = step_class.new(step_params)
+
+    if @step.valid?
+      current_snap_application.update!(unstable_housing: unstable_housing?)
+      residential_address.update!(step_params.except(:unstable_housing))
+      redirect_to(next_path)
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def snap_application_attributes
+    HashWithIndifferentAccess.new(residential_address_attributes)
+  end
+
+  def residential_address_attributes
+    residential_address.attributes.merge(unstable_housing: current_snap_application.unstable_housing)
+  end
+
+  def residential_address
+    current_snap_application.addresses.where.not(mailing: true).first || current_snap_application.addresses.create(mailing: false)
+  end
+
+  def step_params
+    super.merge(state: "MI", county: "Genesee")
+  end
+
+  def unstable_housing?
+    step_params[:unstable_housing] == "1"
+  end
+
+  def skip?
+    current_snap_application.mailing_address_same_as_residential_address?
+  end
+end

--- a/app/controllers/residential_address_controller.rb
+++ b/app/controllers/residential_address_controller.rb
@@ -24,7 +24,7 @@ class ResidentialAddressController < StandardStepsController
   end
 
   def residential_address
-    current_snap_application.addresses.where.not(mailing: true).first || current_snap_application.addresses.create(mailing: false)
+    current_snap_application.addresses.where.not(mailing: true).first || current_snap_application.addresses.new(mailing: false)
   end
 
   def step_params

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -3,6 +3,8 @@
 class StepsController < ApplicationController
   layout "step"
 
+  before_action :maybe_skip, only: :edit
+
   def self.to_param
     controller_path.dasherize
   end
@@ -43,5 +45,15 @@ class StepsController < ApplicationController
 
   def step_navigation
     @step_navigation ||= StepNavigation.new(self)
+  end
+
+  def maybe_skip
+    if skip?
+      redirect_to next_path
+    end
+  end
+
+  def skip?
+    false
   end
 end

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -33,6 +33,31 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     HTML
   end
 
+  def mb_checkbox_set(collection, label_text: nil, notes: [])
+    checkbox_html = <<-HTML.html_safe
+      <fieldset class="input-group">
+    HTML
+
+    checkbox_html << collection.map do |item|
+      method = item[:method]
+      label = item[:label]
+      mb_checkbox(method, label)
+    end.join.html_safe
+
+    checkbox_html << <<-HTML.html_safe
+      </fieldset>
+    HTML
+
+    if label_text || notes
+      label_html = <<-HTML.html_safe
+        #{label_contents(label_text, notes)}
+      HTML
+      checkbox_html = label_html + checkbox_html
+    end
+
+    checkbox_html
+  end
+
   private
 
   def label_contents(label_text, notes)
@@ -100,5 +125,20 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
       </radiogroup>
     HTML
     radio_html
+  end
+
+  def mb_checkbox(method, label_text)
+    <<-HTML.html_safe
+      <label class="checkbox">
+    #{check_box_with_label(label_text, method)}
+      </label>
+    #{errors_for(object, method)}
+    HTML
+  end
+
+  def check_box_with_label(label_text, method)
+    <<-HTML.html_safe
+    #{check_box(method)} #{label_text}
+    HTML
   end
 end

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,2 @@
+class Address < ApplicationRecord
+end

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -1,2 +1,3 @@
 class SnapApplication < ApplicationRecord
+  has_many :addresses
 end

--- a/app/steps/mailing_address.rb
+++ b/app/steps/mailing_address.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-class Address < Step
+class MailingAddress < Step
   step_attributes(
     :city,
     :county,
+    :mailing_address_same_as_residential_address,
     :state,
     :street_address,
     :zip,
@@ -23,4 +24,7 @@ class Address < Step
 
   validates :state,
     inclusion: { in: %w(MI), message: "Make sure the county is MI" }
+
+  validates :mailing_address_same_as_residential_address,
+    inclusion: { in: %w(true false), message: "Make sure to answer this question" }
 end

--- a/app/steps/residential_address.rb
+++ b/app/steps/residential_address.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class ResidentialAddress < Step
+  step_attributes(
+    :city,
+    :county,
+    :state,
+    :street_address,
+    :unstable_housing,
+    :zip,
+  )
+
+  validates :street_address,
+    presence: { message: "Make sure to provide a street address" }
+
+  validates :city,
+    presence: { message: "Make sure to provide a city" }
+
+  validates :zip,
+    length: { is: 5, message: "Make sure your ZIP code is 5 digits long" }
+
+  validates :county,
+    inclusion: { in: %w(Genesee), message: "Make sure the county is Genesee" }
+
+  validates :state,
+    inclusion: { in: %w(MI), message: "Make sure the county is MI" }
+end

--- a/app/steps/step_navigation.rb
+++ b/app/steps/step_navigation.rb
@@ -5,7 +5,8 @@ class StepNavigation
     "Minimal Snap Application" => [
       PersonalDetailController,
       ContactInformationController,
-      AddressController,
+      MailingAddressController,
+      ResidentialAddressController,
       DocumentsController,
       LegalAgreementController,
       SignAndSubmitController,

--- a/app/views/mailing_address/edit.html.erb
+++ b/app/views/mailing_address/edit.html.erb
@@ -11,6 +11,10 @@
       <%= f.mb_input_field :street_address, "Address", options:  { placeholder: "123 Main St." } %>
       <%= f.mb_input_field :city, "City", options:  { placeholder: "Flint" } %>
       <%= f.mb_input_field :zip, "ZIP code", options:  { placeholder: "12345" } %>
+      <%= f.mb_radio_set :mailing_address_same_as_residential_address,
+          'Is this address the same as your home address?',
+          [{ value: true, label: "Yes" }, { value: false, label: "No" }],
+          layout: "inline" %>
       <%= render 'shared/next_step' %>
     <% end %>
   </div>

--- a/app/views/residential_address/edit.html.erb
+++ b/app/views/residential_address/edit.html.erb
@@ -1,0 +1,19 @@
+<% content_for :header_title, "Your Location" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="step-section-header">
+      <div class="step-section-header__subhead">Tell us where you currently live.</div>
+    </div>
+  </header>
+  <div class="form-card__content">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+      <%= f.mb_input_field :street_address, "Address" %>
+      <%= f.mb_input_field :city, "City" %>
+      <%= f.mb_input_field :zip, "ZIP code" %>
+      <%= f.mb_checkbox_set [{ label: 'Check this box if you do not have a stable address', method: :unstable_housing }],
+        label_text: '' %>
+      <%= render 'shared/next_step' %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,14 +13,4 @@
 # end
 
 ActiveSupport::Inflector.inflections(:en) do |inflect|
-  inflect.uncountable %w[
-    expenses_additional_sources
-    household_health_situations
-    household_personal_details
-    household_situations
-    income_additional_sources
-    income_other_assets
-    maybe_submit_documents
-    preferences_reminders
-  ]
 end

--- a/db/migrate/20170808220230_add_mailing_address_same_as_residential_address_to_snap_applications.rb
+++ b/db/migrate/20170808220230_add_mailing_address_same_as_residential_address_to_snap_applications.rb
@@ -1,0 +1,5 @@
+class AddMailingAddressSameAsResidentialAddressToSnapApplications < ActiveRecord::Migration[5.1]
+  def change
+    add_column :snap_applications, :mailing_address_same_as_residential_address, :boolean
+  end
+end

--- a/db/migrate/20170808225329_create_addresses.rb
+++ b/db/migrate/20170808225329_create_addresses.rb
@@ -2,12 +2,12 @@ class CreateAddresses < ActiveRecord::Migration[5.1]
   def change
     create_table :addresses do |t|
       t.timestamps null: false
-      t.string :street_address
-      t.string :city
-      t.string :county
-      t.string :state
-      t.string :zip
-      t.boolean :mailing
+      t.string :street_address, null: false
+      t.string :city, null: false
+      t.string :county, null: false
+      t.string :state, null: false
+      t.string :zip, null: false
+      t.boolean :mailing, default: true, null: false
       t.belongs_to :snap_application, index: true
     end
   end

--- a/db/migrate/20170808225329_create_addresses.rb
+++ b/db/migrate/20170808225329_create_addresses.rb
@@ -1,0 +1,14 @@
+class CreateAddresses < ActiveRecord::Migration[5.1]
+  def change
+    create_table :addresses do |t|
+      t.timestamps null: false
+      t.string :street_address
+      t.string :city
+      t.string :county
+      t.string :state
+      t.string :zip
+      t.boolean :mailing
+      t.belongs_to :snap_application, index: true
+    end
+  end
+end

--- a/db/migrate/20170809000628_add_unstable_housing_to_snap_applications.rb
+++ b/db/migrate/20170809000628_add_unstable_housing_to_snap_applications.rb
@@ -1,0 +1,5 @@
+class AddUnstableHousingToSnapApplications < ActiveRecord::Migration[5.1]
+  def change
+    add_column :snap_applications, :unstable_housing, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,12 +18,12 @@ ActiveRecord::Schema.define(version: 20170809000628) do
   create_table "addresses", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "street_address"
-    t.string "city"
-    t.string "county"
-    t.string "state"
-    t.string "zip"
-    t.boolean "mailing"
+    t.string "street_address", null: false
+    t.string "city", null: false
+    t.string "county", null: false
+    t.string "state", null: false
+    t.string "zip", null: false
+    t.boolean "mailing", default: true, null: false
     t.bigint "snap_application_id"
     t.index ["snap_application_id"], name: "index_addresses_on_snap_application_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170807235447) do
+ActiveRecord::Schema.define(version: 20170809000628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "addresses", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "street_address"
+    t.string "city"
+    t.string "county"
+    t.string "state"
+    t.string "zip"
+    t.boolean "mailing"
+    t.bigint "snap_application_id"
+    t.index ["snap_application_id"], name: "index_addresses_on_snap_application_id"
+  end
 
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
@@ -47,5 +60,8 @@ ActiveRecord::Schema.define(version: 20170807235447) do
     t.string "phone_number"
     t.boolean "sms_subscribed"
     t.boolean "consent_to_terms"
+    t.boolean "mailing_address_same_as_residential_address"
+    t.boolean "unstable_housing", default: false
   end
+
 end

--- a/spec/controllers/contact_information_controller_spec.rb
+++ b/spec/controllers/contact_information_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ContactInformationController, type: :controller do
 
         put :update, params: { step: valid_params }
 
-        expect(response).to redirect_to("/steps/address")
+        expect(response).to redirect_to("/steps/mailing-address")
       end
     end
 

--- a/spec/controllers/mailing_address_controller_spec.rb
+++ b/spec/controllers/mailing_address_controller_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe MailingAddressController, type: :controller do
+  let(:step) { assigns(:step) }
+  before { session[:snap_application_id] = current_app.id }
+
+  describe "#edit" do
+    it "assigns the correct step" do
+      get :edit
+
+      expect(step).to be_an_instance_of MailingAddress
+    end
+
+    it "assigns the fields to the step" do
+      get :edit
+
+      expect(step.street_address).to eq("123 Fake St")
+      expect(step.city).to eq("Springfield")
+      expect(step.zip).to eq("12345")
+    end
+  end
+
+  describe "#update" do
+    context "when valid" do
+      it "updates the app" do
+        valid_params = {
+          street_address: "321 Real St",
+          city: "Shelbyville",
+          zip: "54321",
+          mailing_address_same_as_residential_address: true,
+        }
+
+        put :update, params: { step: valid_params }
+
+        current_app.reload
+
+        valid_params.each do |key, value|
+          expect(current_app[key]).to eq(value)
+        end
+      end
+
+      it "always sets the county to 'Genesee' and state to 'MI'" do
+        valid_params = {
+          street_address: "321 Main St",
+          city: "Plymouth",
+          zip: "48170",
+        }
+
+        put :update, params: { step: valid_params }
+
+        current_app.reload
+
+        expect(current_app["county"]).to eq("Genesee")
+        expect(current_app["state"]).to eq("MI")
+      end
+
+      it "redirects to the next step" do
+        valid_params = {
+          street_address: "321 Real St",
+          city: "Shelbyville",
+          zip: "54321",
+          mailing_address_same_as_residential_address: true,
+        }
+
+        put :update, params: { step: valid_params }
+
+        expect(response).to redirect_to("/steps/residential-address")
+      end
+    end
+
+    it "renders edit if the step is invalid" do
+      put :update, params: { step: { zip: "1111111111" } }
+
+      expect(assigns(:step)).to be_an_instance_of(MailingAddress)
+      expect(response).to render_template(:edit)
+    end
+  end
+
+  def current_app
+    @_current_app ||= FactoryGirl.create(
+      :snap_application,
+      street_address: "123 Fake St",
+      city: "Springfield",
+      zip: "12345",
+    )
+  end
+end

--- a/spec/controllers/residential_address_controller_spec.rb
+++ b/spec/controllers/residential_address_controller_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe AddressController, type: :controller do
+RSpec.describe ResidentialAddressController, type: :controller do
   let(:step) { assigns(:step) }
   before { session[:snap_application_id] = current_app.id }
 
@@ -10,15 +10,15 @@ RSpec.describe AddressController, type: :controller do
     it "assigns the correct step" do
       get :edit
 
-      expect(step).to be_an_instance_of Address
+      expect(step).to be_an_instance_of ResidentialAddress
     end
 
     it "assigns the fields to the step" do
       get :edit
 
-      expect(step.street_address).to eq("123 Fake St")
-      expect(step.city).to eq("Springfield")
-      expect(step.zip).to eq("12345")
+      expect(step.street_address).to eq("I live here")
+      expect(step.city).to eq("Hometown")
+      expect(step.zip).to eq("54321")
     end
   end
 
@@ -31,13 +31,17 @@ RSpec.describe AddressController, type: :controller do
           zip: "54321",
         }
 
-        put :update, params: { step: valid_params }
+        unstable_housing = { unstable_housing: "1" }
 
-        current_app.reload
+        put :update, params: { step: valid_params.merge(unstable_housing) }
+
+        current_app_residential_address.reload
 
         valid_params.each do |key, value|
-          expect(current_app[key]).to eq(value)
+          expect(current_app_residential_address[key]).to eq(value)
         end
+
+        expect(current_app.reload.unstable_housing).to be true
       end
 
       it "always sets the county to 'Genesee' and state to 'MI'" do
@@ -60,6 +64,7 @@ RSpec.describe AddressController, type: :controller do
           street_address: "321 Real St",
           city: "Shelbyville",
           zip: "54321",
+          unstable_housing: "1",
         }
 
         put :update, params: { step: valid_params }
@@ -71,17 +76,26 @@ RSpec.describe AddressController, type: :controller do
     it "renders edit if the step is invalid" do
       put :update, params: { step: { zip: "1111111111" } }
 
-      expect(assigns(:step)).to be_an_instance_of(Address)
+      expect(assigns(:step)).to be_an_instance_of(ResidentialAddress)
       expect(response).to render_template(:edit)
     end
   end
 
   def current_app
-    @_current_app ||= FactoryGirl.create(
-      :snap_application,
-      street_address: "123 Fake St",
-      city: "Springfield",
-      zip: "12345",
+    @_current_app ||= FactoryGirl.create(:snap_application, addresses: [address])
+  end
+
+  def current_app_residential_address
+    current_app.addresses.where.not(mailing: true).first
+  end
+
+  def address
+    FactoryGirl.create(
+      :address,
+      street_address: "I live here",
+      city: "Hometown",
+      zip: "54321",
+      mailing: false,
     )
   end
 end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -2,6 +2,8 @@ FactoryGirl.define do
   factory :address do
     street_address "123 Main St."
     city "Flint"
+    zip "12345"
     county "Genesee"
+    state "MI"
   end
 end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :address do
+    street_address "123 Main St."
+    city "Flint"
+    county "Genesee"
+  end
+end

--- a/spec/factories/snap_applications.rb
+++ b/spec/factories/snap_applications.rb
@@ -10,5 +10,6 @@ FactoryGirl.define do
     zip "48501"
     signature "Mr. RJD2"
     signed_at Date.current
+    mailing_address_same_as_residential_address false
   end
 end

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -19,6 +19,7 @@ feature "SNAP application" do
     fill_in "Address", with: "123 Main St"
     fill_in "City", with: "Flint"
     fill_in "ZIP code", with: "12345"
+    select_address_same_as_home_address
     click_on "Continue"
 
     add_document_photo "https://example.com/images/drivers_license.jpg"
@@ -56,6 +57,7 @@ feature "SNAP application" do
     fill_in "Address", with: "123 Main St"
     fill_in "City", with: "Flint"
     fill_in "ZIP code", with: "12345"
+    select_address_same_as_home_address
     click_on "Continue"
 
     add_document_photo "https://example.com/images/drivers_license.jpg"
@@ -72,6 +74,37 @@ feature "SNAP application" do
     expect(page).to have_text(
       "Your application has been submitted.",
     )
+  end
+
+  scenario "home address not same as mailing address" do
+    visit root_path
+    click_on "Apply now"
+
+    fill_in "What is your full name?", with: "Jessie Tester"
+    select "January", from: "step_birthday_2i"
+    select "1", from: "step_birthday_3i"
+    select "1969", from: "step_birthday_1i"
+    click_on "Continue"
+
+    fill_in "What is the best phone number to reach you?", with: "12345678990"
+    subscribe_to_sms_updates
+    fill_in "What is your email address?", with: "test@example.com"
+    click_on "Continue"
+
+    fill_in "Address", with: "123 Main St"
+    fill_in "City", with: "Flint"
+    fill_in "ZIP code", with: "12345"
+    select_address_not_same_as_home_address
+    click_on "Continue"
+
+    expect(current_path).to eq "/steps/residential-address"
+    fill_in "Address", with: "456 Hello St"
+    fill_in "City", with: "Flint"
+    fill_in "ZIP code", with: "12345"
+    select_unstable_address
+    click_on "Continue"
+
+    expect(current_path).to eq "/steps/documents"
   end
 
   scenario "does not fill in all required fields" do
@@ -104,6 +137,18 @@ feature "SNAP application" do
 
   def subscribe_to_sms_updates
     choose "Yes"
+  end
+
+  def select_address_same_as_home_address
+    choose "Yes"
+  end
+
+  def select_address_not_same_as_home_address
+    choose "No"
+  end
+
+  def select_unstable_address
+    check "Check this box if you do not have a stable address"
   end
 
   def consent_to_terms


### PR DESCRIPTION
* This is skipped if the client indicates mailing and residential are
the same
* To do in follow up PRs:
   - save mailing address in the "addresses" table instead of on the snap
   app
  - make sure "back" works with "skip" functionality

![screen shot 2017-08-09 at 9 42 48 am](https://user-images.githubusercontent.com/601515/29133064-25403c2a-7ce7-11e7-8fcf-560dcd47c150.png)

