### PR TITLE
Client can go "Back" if home and residential addresses are same

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -30,12 +30,10 @@ class StepsController < ApplicationController
   end
 
   def maybe_skip
-    if skip?
-      if going_backwards?
-        redirect_to previous_path(rel: "back")
-      else
-        redirect_to next_path
-      end
+    if skip? && going_backwards?
+      redirect_to previous_path(rel: "back")
+    elsif skip?
+      redirect_to next_path
     end
   end
 

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -17,10 +17,6 @@ class StepsController < ApplicationController
 
   delegate :step_class, to: :class
 
-  def going_backwards?
-    params["rel"] == "back"
-  end
-
   def step_params
     params.fetch(:step, {}).permit(*step_attrs)
   end
@@ -29,13 +25,31 @@ class StepsController < ApplicationController
     step_class.attribute_names
   end
 
+  def current_path(params = nil)
+    step_path(self.class, params)
+  end
+
+  def maybe_skip
+    if skip?
+      if going_backwards?
+        redirect_to previous_path(rel: "back")
+      else
+        redirect_to next_path
+      end
+    end
+  end
+
+  def skip?
+    false
+  end
+
   def previous_path(params = nil)
     previous_step = step_navigation.previous
     previous_step ? step_path(previous_step, params) : root_path
   end
 
-  def current_path(params = nil)
-    step_path(self.class, params)
+  def going_backwards?
+    params["rel"] == "back"
   end
 
   def next_path(params = nil)
@@ -45,15 +59,5 @@ class StepsController < ApplicationController
 
   def step_navigation
     @step_navigation ||= StepNavigation.new(self)
-  end
-
-  def maybe_skip
-    if skip?
-      redirect_to next_path
-    end
-  end
-
-  def skip?
-    false
   end
 end

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -102,9 +102,36 @@ feature "SNAP application" do
     fill_in "City", with: "Flint"
     fill_in "ZIP code", with: "12345"
     select_unstable_address
+
     click_on "Continue"
 
     expect(current_path).to eq "/steps/legal-agreement"
+  end
+
+  scenario "goes back after skipping residential address step" do
+    visit root_path
+    click_on "Apply now"
+
+    fill_in "What is your full name?", with: "Jessie Tester"
+    select "January", from: "step_birthday_2i"
+    select "1", from: "step_birthday_3i"
+    select "1969", from: "step_birthday_1i"
+    click_on "Continue"
+
+    fill_in "What is the best phone number to reach you?", with: "12345678990"
+    subscribe_to_sms_updates
+    fill_in "What is your email address?", with: "test@example.com"
+    click_on "Continue"
+
+    fill_in "Address", with: "123 Main St"
+    fill_in "City", with: "Flint"
+    fill_in "ZIP code", with: "12345"
+    select_address_same_as_home_address
+    click_on "Continue"
+
+    find(".step-header__back-link").click
+
+    expect(current_path).to eq "/steps/mailing-address"
   end
 
   scenario "does not fill in all required fields" do


### PR DESCRIPTION
* Before, `skip` logic would always send the user forward
