### PR TITLE
Refactor flash-partial code

### DIFF
--- a/app/assets/stylesheets/molecules/_flashes.scss
+++ b/app/assets/stylesheets/molecules/_flashes.scss
@@ -1,33 +1,14 @@
-@include keyframes(slide-in) {
-  0% {
-    top: -3em;
-  }
-  30% {
-    top: -3em;
-  }
-  100% {
-    top: 0;
-  }
-}
-
 .flash-container {
-  @include transition(opacity $animation-med);
-  @include animation(slide-in ease-out .5s);
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 10;
-  text-align: center;
-  pointer-events: none;
+  padding-top: 1em;
+
   &:target {
-    opacity: 0;
+    display: none;
   }
 }
 
 .flash {
   pointer-events: auto;
-  display: inline-block;
+  display: block;
   text-align: left;
   position: relative;
   margin-bottom: 1em;
@@ -35,7 +16,6 @@
   font-size: $font-size-small;
   background-color: #FFFFFF;
   border: 2px solid $color-teal;
-  border-top: 0;
   border-radius: $border-radius;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
@@ -45,11 +25,14 @@
 .flash--error {
   color: $color-red;
   border-color: tint($color-red, 75%);
+
   .flash__message:before {
     content: "\e002";
   }
+
   .flash__dismiss {
     border-color: $color-red;
+
     &:hover {
       color: $color-red;
       background-color: tint($color-red, 90%);
@@ -81,6 +64,16 @@
   text-align: center;
   text-decoration: none;
   border-left: 0px solid $color-teal;
+
+  span {
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    top: 50%;
+    right: 10px;
+    margin-top: -10px;
+  }
+
   &:hover {
     background-color: tint($color-teal, 90%);
   }

--- a/app/views/layouts/step.html.erb
+++ b/app/views/layouts/step.html.erb
@@ -12,6 +12,7 @@
     </h4>
   </div>
   <%= render 'shared/debug' %>
+  <%= render 'shared/flashes' %>
   <%= yield %>
   <%= render 'shared/footer' %>
 <% end %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -16,7 +16,6 @@
 
 <div class="slab slab--white" id="apply-for-programs">
   <div class="card--narrow">
-    <%= render 'shared/flashes' %>
     <label class="program-selector">
       <div class="program-selector__checkbox">
         <% icon_class = "illustration--icn_food" %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -16,6 +16,7 @@
 
 <div class="slab slab--white" id="apply-for-programs">
   <div class="card--narrow">
+    <%= render 'shared/flashes' %>
     <label class="program-selector">
       <div class="program-selector__checkbox">
         <% icon_class = "illustration--icn_food" %>

--- a/app/views/shared/_flashes.html.erb
+++ b/app/views/shared/_flashes.html.erb
@@ -1,17 +1,10 @@
-<% if notice %>
-<div class="flash-container" id="dismiss-notice">
-  <div class="flash">
-    <p class="flash__message"><%= notice %></p>
-    <a href="#dismiss-notice" class="flash__dismiss"><span class="icon icon-close"></span></a>
+<% if flash.any? -%>
+  <div class="flash-container max-container" id="dismiss-notice">
+    <% flash.each do |key, value| %>
+      <div class="flash flash--<%= key %>">
+        <p class="flash__message"><%= value %></p>
+        <a href="#dismiss-notice" class="flash__dismiss"><span class="icon icon-close icon-<%= key %>"></span></a>
+      </div>
+    <% end %>
   </div>
-</div>
-<% end %>
-
-<% if alert %>
-<div class="flash-container" id="dismiss-notice">
-  <div class="flash flash--error">
-    <p class="flash__message"><%= alert %></p>
-    <a href="#dismiss-notice" class="flash__dismiss"><span class="icon icon-close"></span></a>
-  </div>
-</div>
-<% end %>
+<% end -%>


### PR DESCRIPTION
The existing display/dismiss flash partial code is tricky within the context of
the new michigan benefits app so I've made some changes to allow things to fit
in, for the time being, until there's a more robust visual treatment.

This commit changes things to loop through all flash keys and values and
display the corresponding html. It keeps the ability to dismiss the flash
notices albeit on a slightly superficial level (read: using the `:target`
pseudo-class in css).

![flashes](https://www.evernote.com/l/AUpXEy8RGFFMYZHt0KvEyN5hVvdSyL1vj8sB/image.png)

Trello: https://trello.com/c/FPMNPuGm/53-refactor-flashes-code