### PR TITLE
Split documents page in two

### DIFF
--- a/app/assets/javascripts/upload_setup.js
+++ b/app/assets/javascripts/upload_setup.js
@@ -11,6 +11,12 @@ var uploadSetup = function (previewTemplate) {
       window.alert(msg)
     },
     success: function (f) {
+      $('.button--next').removeAttr('disabled')
+
+      var button = $('#click-to-upload')
+      var buttonHtml = button.html()
+      button.html(buttonHtml.replace('Upload documents', 'Upload more documents'))
+
       var source = $('#form-card__documents__handlebars_template').html()
       var template = window.Handlebars.compile(source)
       var context = {

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,13 @@ class ApplicationController < ActionController::Base
 
   respond_to :html
 
-  helper_method :previous_path, :current_path, :next_path, :current_snap_application, :current_or_new_snap_application
+  helper_method \
+    :current_or_new_snap_application,
+    :current_path,
+    :current_snap_application,
+    :next_path,
+    :previous_path,
+    :skip_path
 
   delegate :variable_size_secure_compare, to: ActiveSupport::SecurityUtils
 

--- a/app/controllers/document_guide_controller.rb
+++ b/app/controllers/document_guide_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class DocumentGuideController < StandardStepsController
+end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -57,6 +57,11 @@ class StepsController < ApplicationController
     step_path(next_step, params) if next_step
   end
 
+  def skip_path(params = nil)
+    skip_step = step_navigation.skip
+    step_path(skip_step, params) if skip_step
+  end
+
   def step_navigation
     @step_navigation ||= StepNavigation.new(self)
   end

--- a/app/steps/step_navigation.rb
+++ b/app/steps/step_navigation.rb
@@ -9,6 +9,7 @@ class StepNavigation
       ResidentialAddressController,
       LegalAgreementController,
       SignAndSubmitController,
+      DocumentGuideController,
       DocumentsController,
       SuccessController,
     ],
@@ -45,6 +46,10 @@ class StepNavigation
 
   def next
     step_at(1)
+  end
+
+  def skip
+    step_at(2)
   end
 
   def previous

--- a/app/views/document_guide/edit.html.erb
+++ b/app/views/document_guide/edit.html.erb
@@ -1,0 +1,42 @@
+<% content_for :header_title, "Document Guide" %>
+
+<div class="form-card" id="document-drop">
+  <header class="form-card__header">
+    <div class="step-section-header">
+      <div class="step-section-header__subhead">
+        Lastly, we suggest including some documents if you can right now.
+      </div>
+    </div>
+  </header>
+  <div class="form-card__content">
+    <p>
+      You can do this later but this will help speed up the process.
+    </p>
+    <p>
+      The following page will allow you to both upload photos of your documents
+      with your phone, as well as submit files you already have on your
+      computer or mobile phone/tablet.
+    </p>
+
+    <%= form_for @step,
+      as: :step,
+      builder: MbFormBuilder,
+      url: current_path,
+      method: :put do |f| %>
+
+      <div class="form-card__documents__ctas">
+        <%= link_to next_path, class: "button button--next button--cta" do %>
+          Submit documents here
+        <% end %>
+
+        <%= link_to skip_path, class: "button" do %>
+          I'll do this later
+        <% end %>
+      </div>
+    <% end %>
+
+    <div class="form-card__documents__faqs">
+      <%= render 'shared/commonly_requested_documents' %>
+    </div>
+  </div>
+</div>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -7,18 +7,22 @@
   <header class="form-card__header">
     <div class="step-section-header">
       <div class="step-section-header__subhead">
-        Lastly, we suggest including some documents if you can right now.
+        Submit Documents
       </div>
     </div>
   </header>
   <div class="form-card__content">
     <p>
-      You can do this later but this will help speed up the process.
+      If you can, we suggest submitting documents like a copy of your ID, proof
+      of income, or proof of residency. You can also do this later if now is
+      not a good time.
     </p>
     <p>
-      Clicking the "Add documents button" that follows will allow you to upload
-      photos of your documents taken with your phone. You may also drag and drop
-      photos or documents onto this area of the page to upload them.
+      Clicking the "Upload documents button" below, or dragging and dropping
+      photos or documents onto this area of the page, will upload them.
+    </p>
+    <p>
+      Clicking "Continue" will attach these documents to your application.
     </p>
 
     <%= form_for @step,
@@ -41,7 +45,7 @@
       <div class="form-card__documents__ctas">
         <button type="button" class="button button--next button--cta button--full-width" id="click-to-upload">
           <i class="icon-file_upload"></i>
-          Add documents
+          Upload documents
         </button>
 
         <%= link_to next_path, class: "button" do %>
@@ -49,12 +53,8 @@
         <% end %>
       </div>
 
-      <%= render 'shared/next_step' %>
+      <%= render 'shared/next_step', disabled: true %>
     <% end %>
-
-    <div class="form-card__documents__faqs">
-      <%= render 'shared/commonly_requested_documents' %>
-    </div>
   </div>
 </div>
 

--- a/app/views/shared/_next_step.html.erb
+++ b/app/views/shared/_next_step.html.erb
@@ -1,5 +1,7 @@
+<% disabled = disabled ? 'disabled="disabled"' : '' %>
+
 <footer class="form-card__footer">
-  <button class="button button--next button--cta button--full-width" type="submit">
+  <button class="button button--next button--cta button--full-width" type="submit" <%= disabled %>>
     <%= local_assigns[:button_label].presence || "Continue" %>
     <i class="button__icon icon-arrow_forward"></i>
   </button>

--- a/spec/controllers/sign_and_submit_controller_spec.rb
+++ b/spec/controllers/sign_and_submit_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe SignAndSubmitController do
 
       put :update, params: params
 
-      expect(response).to redirect_to("/steps/documents")
+      expect(response).to redirect_to("/steps/document-guide")
     end
   end
 

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -27,8 +27,7 @@ feature "SNAP application" do
     fill_in "Your signature", with: "Jessie Tester"
     click_on "Sign and submit"
 
-    add_document_photo "https://example.com/images/drivers_license.jpg"
-    add_document_photo "https://example.com/images/proof_of_income.jpg"
+    upload_documents
     click_on "Continue"
 
     fill_in "Your email address", with: "test@example.com"
@@ -65,8 +64,7 @@ feature "SNAP application" do
     fill_in "Your signature", with: "Jessie Tester"
     click_on "Sign and submit"
 
-    add_document_photo "https://example.com/images/drivers_license.jpg"
-    add_document_photo "https://example.com/images/proof_of_income.jpg"
+    upload_documents
     click_on "Continue"
 
     click_on "Skip this step"
@@ -181,5 +179,12 @@ feature "SNAP application" do
   def consent_to_terms
     choose "I agree"
     click_on "Continue"
+  end
+
+  def upload_documents
+    click_on "Submit documents here"
+    add_document_photo "https://example.com/images/drivers_license.jpg"
+    add_document_photo "https://example.com/images/proof_of_income.jpg"
+    enable_continue
   end
 end

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 module FeatureHelper
+  def enable_continue
+    page.execute_script %(document.querySelector('button[disabled]').removeAttribute('disabled'))
+  end
+
   def add_document_photo(url)
     input = %(<input type="hidden" name="step[documents][]" value="#{url}">)
     page.execute_script %(document.querySelector('[data-documents-form]').insertAdjacentHTML('beforeend', '#{input}'))


### PR DESCRIPTION
..., update copy, and enhance the usability of the actual document
upload page.

1. Do not allow submission of the form unless there have been files
   uploaded and saved to the form.
2. Do not allow submission of the form until files are done being
   uploaded.
3. Change button to say "Upload *more* documents" so that the client
   knows they CAN upload more files

![documents guide page](https://www.evernote.com/l/AUoTcK6a85NKQLpyJD3Jso1shBewH1U59BgB/image.png)

* * *

![document upload](https://www.evernote.com/l/AUrqQmfH9odHdL8P728VZUOz6oKq1q2zp_oB/image.png)

* * *

![documents uploaded](https://www.evernote.com/l/AUpmRaDmmdFDQryx2dTb-wPR8i_ZTdvvFsAB/image.png)