### PR TITLE
Cleaner calls to action on the documents step

### DIFF
--- a/app/steps/document.rb
+++ b/app/steps/document.rb
@@ -2,10 +2,6 @@
 
 class Document < Step
   step_attributes(
-    :document,
     documents: [],
   )
-
-  validates :documents,
-    presence: { message: "Make sure to upload some documents" }
 end

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -18,11 +18,8 @@
       not a good time.
     </p>
     <p>
-      Clicking the "Upload documents button" below, or dragging and dropping
+      Clicking the "Upload documents" button below, or dragging and dropping
       photos or documents onto this area of the page, will upload them.
-    </p>
-    <p>
-      Clicking "Continue" will attach these documents to your application.
     </p>
 
     <%= form_for @step,
@@ -48,12 +45,10 @@
           Upload documents
         </button>
 
-        <%= link_to next_path, class: "button" do %>
-          I'll do this later
-        <% end %>
+        <button class="button button--next button--cta button--full-width" type="submit">
+          Done uploading documents
+        </button>
       </div>
-
-      <%= render 'shared/next_step', disabled: true %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_next_step.html.erb
+++ b/app/views/shared/_next_step.html.erb
@@ -1,7 +1,5 @@
-<% disabled = disabled ? 'disabled="disabled"' : '' %>
-
 <footer class="form-card__footer">
-  <button class="button button--next button--cta button--full-width" type="submit" <%= disabled %>>
+  <button class="button button--next button--cta button--full-width" type="submit">
     <%= local_assigns[:button_label].presence || "Continue" %>
     <i class="button__icon icon-arrow_forward"></i>
   </button>

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -33,7 +33,7 @@ feature "SNAP application" do
     click_on "Sign and submit"
 
     upload_documents
-    click_on "Continue"
+    click_on "Done uploading documents"
 
     fill_in "Your email address", with: "test@example.com"
     click_on "Submit"
@@ -74,7 +74,7 @@ feature "SNAP application" do
     click_on "Sign and submit"
 
     upload_documents
-    click_on "Continue"
+    click_on "Done uploading documents"
 
     click_on "Skip this step"
 
@@ -193,6 +193,5 @@ feature "SNAP application" do
     click_on "Submit documents here"
     add_document_photo "https://example.com/images/drivers_license.jpg"
     add_document_photo "https://example.com/images/proof_of_income.jpg"
-    enable_continue
   end
 end

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 module FeatureHelper
-  def enable_continue
-    page.execute_script %(document.querySelector('button[disabled]').removeAttribute('disabled'))
-  end
-
   def add_document_photo(url)
     input = %(<input type="hidden" name="step[documents][]" value="#{url}">)
     page.execute_script %(document.querySelector('[data-documents-form]').insertAdjacentHTML('beforeend', '#{input}'))


### PR DESCRIPTION
Reason for Change
===================
* A more clear collection of calls to action on the documents step
* Clear up copy

![michigan_benefits](https://user-images.githubusercontent.com/28194/29230070-5437655c-7eaf-11e7-8a7c-be648951192d.jpg)
