### PR TITLE
Fix deprecation re: encrypted attribute

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,4 +1,5 @@
 class Member < ApplicationRecord
+  attribute :ssn
   attr_encrypted(
     :ssn,
     key: Rails.application.secrets.secret_key_for_ssn_encryption,


### PR DESCRIPTION
```
DEPRECATION WARNING: ssn is not an attribute known to Active Record.
This behavior is deprecated and will be removed in the next version of
Rails. If you'd like ssn to be managed by Active Record, add `attribute :ssn to your class.
```

Adding the attribute to the model fixes and removes this deprecation
warning.