### PR TITLE
Fix overlapping element issue in test

### DIFF
--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -256,9 +256,9 @@ feature "SNAP application" do
       question: "Does anyone have a disability?",
       answer: "No",
     )
-    select_radio(
+    js_select_radio(
       question: "Is anyone pregnant or has been pregnant recently?",
-      answer: "No",
+      answer_id: "step_anyone_new_mom_false",
     )
     select_radio(
       question: "Is anyone enrolled in college or vocational school?",

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -17,6 +17,12 @@ module FeatureHelper
     end
   end
 
+  def js_select_radio(question:, answer_id:)
+    within(find(:fieldset, text: question)) do
+      find("##{answer_id}").trigger("click")
+    end
+  end
+
   def on_page(page_title)
     expect(page.title).to eq page_title
     yield


### PR DESCRIPTION
* was getting this error on `master` after styles were updated:

```
Capybara::Poltergeist::MouseEventFailed:
  Firing a click at co-ordinates [342.5, 11.5] failed. Poltergeist detected another element with CSS selector 'html body.template--step div.page-wrapper div.step-header' at this position. It may be overlapping the element you are trying to interact with. If you don't care about overlapping elements, try using node.trigger('click').
./spec/support/feature_helper.rb:16:in `block in select_radio'
./spec/support/feature_helper.rb:15:in `select_radio'
./spec/features/snap_app_spec.rb:259:in `answer_household_more_info_questions'
./spec/features/snap_app_spec.rb:110:in `block (3 levels) in <top (required)>'
./spec/support/feature_helper.rb:22:in `on_page'
./spec/features/snap_app_spec.rb:109:in `block (2 levels) in <top (required)>'
```

better not to call `trigger('click')` for all radio buttons, but for
this radio where there is help text it is needed for some reason.
