### PR TITLE
Only show work detail forms for employed and self employed

### DIFF
--- a/app/steps/income_details_per_member.rb
+++ b/app/steps/income_details_per_member.rb
@@ -2,4 +2,8 @@
 
 class IncomeDetailsPerMember < Step
   step_attributes :members
+
+  def working_members
+    members.where(employment_status: ["employed", "self_employed"])
+  end
 end

--- a/app/views/income_details_per_member/edit.html.erb
+++ b/app/views/income_details_per_member/edit.html.erb
@@ -11,7 +11,7 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <% @step.members.each do |member| %>
+      <% @step.working_members.each do |member| %>
         <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <div class="household-member-group" data-member-name="<%= member.full_name %>">
             <h2 class="step-section-header__headline"><%= member.full_name %></h2>

--- a/spec/steps/income_details_per_member_spec.rb
+++ b/spec/steps/income_details_per_member_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe IncomeDetailsPerMember do
+  describe "#working_members" do
+    it "returns members who are employed or self employed" do
+      working = create(:member, employment_status: "employed")
+      not_working = create(:member, employment_status: "not_employed")
+      self_employed = create(:member, employment_status: "self_employed")
+      members = [working, not_working, self_employed]
+      snap_application = create(:snap_application, members: members)
+
+      step = IncomeDetailsPerMember.new(members: snap_application.members)
+
+      expect(step.working_members).to match_array([working, self_employed])
+    end
+  end
+end


### PR DESCRIPTION
**WHY**: this was a product requirement that was accidentally overlooked
  the first time around