### PR TITLE
Send a fax upon application submission

### DIFF
--- a/app/jobs/send_application_job.rb
+++ b/app/jobs/send_application_job.rb
@@ -4,6 +4,7 @@ class SendApplicationJob < ApplicationJob
 
     create_pdf
     send_pdf
+    fax_pdf
   ensure
     complete_form_with_cover.try(:close)
     complete_form_with_cover.try(:unlink)
@@ -24,5 +25,27 @@ class SendApplicationJob < ApplicationJob
       file_name: complete_form_with_cover.path,
       recipient_email: snap_application.email,
     ).deliver
+  end
+
+  def fax_pdf
+    if fax_phone_number_exists?
+      Fax.send_fax(
+        number: fax_number,
+        file: complete_form_with_cover.path,
+        recipient: fax_recipient_name,
+      )
+    end
+  end
+
+  def fax_number
+    ENV.fetch("FAX_NUMBER", "")
+  end
+
+  def fax_recipient_name
+    ENV.fetch("FAX_RECIPIENT", "Michigan Bridges")
+  end
+
+  def fax_phone_number_exists?
+    !fax_number.empty?
   end
 end

--- a/spec/jobs/send_application_job_spec.rb
+++ b/spec/jobs/send_application_job_spec.rb
@@ -27,5 +27,45 @@ RSpec.describe SendApplicationJob do
         SendApplicationJob.new.perform(snap_application: snap_application)
       end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
+
+    context "when a fax phone number is set" do
+      it "sends a fax" do
+        snap_application = create(:snap_application, :with_member)
+        tempfile = Tempfile.new("send_application_job_spec")
+        file_path = tempfile.path
+        pdf_double = double(completed_file: tempfile)
+        allow(Dhs1171Pdf).to receive(:new).
+          with(snap_application: snap_application).
+          and_return(pdf_double)
+
+        job = SendApplicationJob.new
+        allow(job).to receive(:fax_number).and_return("+15550001111")
+        allow(job).to receive(:fax_recipient_name).and_return("John Doe")
+
+        allow(Fax).to receive(:send_fax).
+          with(number: "+15550001111", file: file_path, recipient: "John Doe")
+
+        job.perform(snap_application: snap_application)
+
+        expect(Fax).to have_received(:send_fax).
+          with(number: "+15550001111", file: file_path, recipient: "John Doe")
+      end
+    end
+
+    context "when no fax number is set" do
+      it "does not send a fax" do
+        snap_application = create(:snap_application, :with_member)
+        tempfile = Tempfile.new("send_application_job_spec")
+        pdf_double = double(completed_file: tempfile)
+        allow(Dhs1171Pdf).to receive(:new).
+          with(snap_application: snap_application).
+          and_return(pdf_double)
+        allow(Fax).to receive(:send_fax)
+
+        SendApplicationJob.new.perform(snap_application: snap_application)
+
+        expect(Fax).not_to have_received(:send_fax)
+      end
+    end
   end
 end


### PR DESCRIPTION
IF a phone number is set in the FAX_NUMBER environment variable, the job
will trigger the faxing of the pdf document. If there's no fax number,
it will not be sent.