### PR TITLE
Three small but distinct changes

### DIFF
--- a/app/controllers/address_controller.rb
+++ b/app/controllers/address_controller.rb
@@ -14,11 +14,12 @@ class AddressController < StandardStepsController
   private
 
   def existing_attributes
-    HashWithIndifferentAccess.new(address_attributes)
+    attributes = address.attributes.merge(current_snap_application.attributes)
+    HashWithIndifferentAccess.new(attributes)
   end
 
   def address_attributes
-    address.attributes.merge(snap_application_update_params)
+    address.attributes.merge(current_snap_application.attributes)
   end
 
   def step_params

--- a/app/controllers/mailing_address_controller.rb
+++ b/app/controllers/mailing_address_controller.rb
@@ -9,14 +9,14 @@ class MailingAddressController < AddressController
   end
 
   def snap_application_update_params
-    { snap_application_param => mailing_address_same_as_residential_address? }
+    { snap_application_param => mailing_address_same_as_residential_address }
+  end
+
+  def mailing_address_same_as_residential_address
+    step_params[snap_application_param]
   end
 
   def snap_application_param
     :mailing_address_same_as_residential_address
-  end
-
-  def mailing_address_same_as_residential_address?
-    step_params[snap_application_param] == "true"
   end
 end

--- a/app/controllers/residential_address_controller.rb
+++ b/app/controllers/residential_address_controller.rb
@@ -9,15 +9,15 @@ class ResidentialAddressController < AddressController
   end
 
   def snap_application_update_params
-    { snap_application_param => unstable_housing? }
+    { snap_application_param => unstable_housing }
+  end
+
+  def unstable_housing
+    step_params[snap_application_param]
   end
 
   def snap_application_param
     :unstable_housing
-  end
-
-  def unstable_housing?
-    step_params[snap_application_param] == "1"
   end
 
   def skip?

--- a/app/views/sign_and_submit/edit.html.erb
+++ b/app/views/sign_and_submit/edit.html.erb
@@ -11,7 +11,7 @@
   <div class="form-card__content">
     <p>
       By entering your name you agree that you want to apply for
-      FAB, that you have been honest on this application.
+      FAP, that you have been honest on this application.
     </p>
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_input_field :signature, "Your signature", options: { placeholder: "Your full legal name" } %>

--- a/app/views/success/edit.html.erb
+++ b/app/views/success/edit.html.erb
@@ -9,61 +9,60 @@
         </div>
       </div>
     </header>
-    <div class="form-card__content">
-      <h2>
-        Want a copy of your application?
-      </h2>
-      <p>
-        Enter your email address below to receive an email with a copy of your
-        application.
-      </p>
-      <%= f.mb_input_field :email, "Your email address", type: "email", options: { placeholder: "test@example.com" } %>
-    </div>
-    <footer class="form-card__footer">
-      <button class="button button--next button--cta button--full-width" type="submit">
-        Submit
-        <i class="button__icon icon-arrow_forward"></i>
-      </button>
-      <%= link_to skip_send_application_path, method: :post, class: "button" do %>
-        Skip this step
-      <% end %>
-    </footer>
-  <% end %>
 
-  <div class="form-card__content form-card__expect_next">
-    <h3 class="with-padding-med">What to expect next:</h3>
-    <div class="media-box with-padding-small">
-      <div class="media-box__media">
-        <div class="emoji emoji--med emoji--clipboard"></div>
+    <div class="form-card__content form-card__expect_next">
+      <h3 class="with-padding-med">What to expect next:</h3>
+      <div class="media-box with-padding-small">
+        <div class="media-box__media">
+          <div class="emoji emoji--med emoji--clipboard"></div>
+        </div>
+        <div class="media-box__content">
+          <p>
+          <b>The interview will take about 30 minutes.</b> A worker will ask you
+          about your household, income, expenses, and other eligibility
+          requirements.
+          </p>
+        </div>
       </div>
-      <div class="media-box__content">
-        <p>
-        <b>The interview will take about 30 minutes.</b> A worker will ask you
-        about your household, income, expenses, and other eligibility
-        requirements.
-        </p>
-      </div>
-    </div>
 
-    <div class="media-box with-padding-med">
-      <div class="media-box__media">
-        <div class="emoji emoji--med emoji--page-facing-up"></div>
-      </div>
-      <div class="media-box__content">
-        <p>
-        <b>Your county will provide you with a list of documents</b> that you
-        will need to submit within 30 days from today to verify your
-        eligibility. You can submit documents any time at <%= link_to 'the
+      <div class="media-box with-padding-med">
+        <div class="media-box__media">
+          <div class="emoji emoji--med emoji--page-facing-up"></div>
+        </div>
+        <div class="media-box__content">
+          <p>
+          <b>Your county will provide you with a list of documents</b> that you
+          will need to submit within 30 days from today to verify your
+          eligibility. You can submit documents any time at <%= link_to 'the
         documents step', documents_steps_path %>.
-        </p>
+          </p>
+        </div>
       </div>
-    </div>
 
-    <p class="text--small">
-    If you need more help with food,
-    <a class="link--subtle" href="http://www.foodpantries.org/st/michigan">
-      find your local food bank or food pantry
-    </a>.
-    </p>
-  </div>
+      <p class="text--small">
+      If you need more help with food,
+      <a class="link--subtle" href="http://www.foodpantries.org/st/michigan">
+        find your local food bank or food pantry
+      </a>.
+      </p>
+
+      <section class="slab">
+        <h3>Want a copy of your application?</h3>
+        <p>
+          Enter your email address below to receive an email with a copy of your
+          application.
+        </p>
+        <%= f.mb_input_field :email, "Your email address", type: "email", options: { placeholder: "test@example.com" } %>
+
+        <button class="button button--next button--cta button--full-width" type="submit">
+          Submit
+          <i class="button__icon icon-arrow_forward"></i>
+        </button>
+        <%= link_to skip_send_application_path, method: :post, class: "button" do %>
+          Skip this step
+        <% end %>
+      <% end %>
+
+      </section>
+    </div>
 </div>

--- a/db/migrate/20170821164112_add_default_true_to_mailing_address_same_as_residential_address.rb
+++ b/db/migrate/20170821164112_add_default_true_to_mailing_address_same_as_residential_address.rb
@@ -1,0 +1,5 @@
+class AddDefaultTrueToMailingAddressSameAsResidentialAddress < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default :snap_applications, :mailing_address_same_as_residential_address, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170818220929) do
+ActiveRecord::Schema.define(version: 20170821164112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -83,7 +83,7 @@ ActiveRecord::Schema.define(version: 20170818220929) do
     t.string "phone_number"
     t.boolean "sms_subscribed"
     t.boolean "consent_to_terms"
-    t.boolean "mailing_address_same_as_residential_address"
+    t.boolean "mailing_address_same_as_residential_address", default: true
     t.boolean "unstable_housing", default: false
     t.boolean "everyone_a_citizen"
     t.boolean "anyone_disabled"

--- a/spec/controllers/mailing_address_controller_spec.rb
+++ b/spec/controllers/mailing_address_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe MailingAddressController, type: :controller do
       expect(step.street_address).to eq("123 Fake St")
       expect(step.city).to eq("Springfield")
       expect(step.zip).to eq("12345")
+      expect(step.mailing_address_same_as_residential_address).to eq(true)
     end
   end
 
@@ -31,7 +32,7 @@ RSpec.describe MailingAddressController, type: :controller do
         }
 
         mailing_same_as_residential = {
-          mailing_address_same_as_residential_address: "true",
+          mailing_address_same_as_residential_address: "false",
         }
 
         put :update,
@@ -44,7 +45,7 @@ RSpec.describe MailingAddressController, type: :controller do
         end
 
         expect(current_app.mailing_address_same_as_residential_address).to be(
-          true,
+          false,
         )
       end
 
@@ -85,7 +86,11 @@ RSpec.describe MailingAddressController, type: :controller do
   end
 
   def current_app
-    @_current_app ||= create(:snap_application, addresses: [address])
+    @_current_app ||= create(
+      :snap_application,
+      mailing_address_same_as_residential_address: true,
+      addresses: [address],
+    )
   end
 
   def address


### PR DESCRIPTION
1. Set default to be "mailing address same as residential" (true)
2. Change FAB to FAP (typo)
3. Reverse order of contents on success page so "what to expect next"
  is more prominent (email section below)

success page:

![screen shot 2017-08-21 at 10 41 29 am](https://user-images.githubusercontent.com/601515/29531461-7eb9eefc-865d-11e7-9163-193b10a1c53a.png)
