### PR TITLE
Conditional validation of residential address

### DIFF
--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -11,9 +11,20 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     append_html: ""
   )
     classes = classes.append(%w[text-input])
+    text_field_options = {
+      autofocus: autofocus,
+      type: type,
+      class: classes.join(" "),
+      autocomplete: "off",
+      autocorrect: "off",
+      autocapitalize: "off",
+      spellcheck: "false",
+    }.merge(options)
+    text_field_html = text_field(method, text_field_options)
+
     <<-HTML.html_safe
       <fieldset class="form-group#{error_state(object, method)}">
-        #{label_and_field(method, label_text, text_field(method, { autofocus: autofocus, type: type, class: classes.join(' '), autocomplete: 'off', autocorrect: 'off', autocapitalize: 'off', spellcheck: 'false' }.merge(options)), notes: notes, prefix: prefix)}
+        #{label_and_field(method, label_text, text_field_html, notes: notes, prefix: prefix)}
         #{errors_for(object, method)}
         #{append_html}
       </fieldset>

--- a/app/steps/residential_address.rb
+++ b/app/steps/residential_address.rb
@@ -10,18 +10,35 @@ class ResidentialAddress < Step
     :zip,
   )
 
-  validates :street_address,
-    presence: { message: "Make sure to provide a street address" }
+  with_options if: :stable_housing? do |address|
+    address.validates :street_address,
+      presence: {
+        message: "Make sure to provide a street address",
+        allow_blank: false,
+      }
 
-  validates :city,
-    presence: { message: "Make sure to provide a city" }
+    address.validates :city,
+      presence: {
+        message: "Make sure to provide a city",
+        allow_blank: false,
+      }
 
-  validates :zip,
-    length: { is: 5, message: "Make sure your ZIP code is 5 digits long" }
+    address.validates :zip,
+      length: {
+        is: 5,
+        message: "Make sure your ZIP code is 5 digits long",
+      }
+  end
 
   validates :county,
     inclusion: { in: %w(Genesee), message: "Make sure the county is Genesee" }
 
   validates :state,
-    inclusion: { in: %w(MI), message: "Make sure the county is MI" }
+    inclusion: { in: %w(MI), message: "Make sure the state is MI" }
+
+  private
+
+  def stable_housing?
+    unstable_housing == "0"
+  end
 end

--- a/app/views/residential_address/edit.html.erb
+++ b/app/views/residential_address/edit.html.erb
@@ -10,7 +10,7 @@
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_input_field :street_address, "Address" %>
       <%= f.mb_input_field :city, "City" %>
-      <%= f.mb_input_field :zip, "ZIP code" %>
+      <%= f.mb_input_field :zip, "ZIP code", options: { maxlength: 5 } %>
       <%= f.mb_checkbox_set [{ label: 'Check this box if you do not have a stable address', method: :unstable_housing }],
         label_text: '' %>
       <%= render 'shared/next_step' %>

--- a/spec/controllers/residential_address_controller_spec.rb
+++ b/spec/controllers/residential_address_controller_spec.rb
@@ -4,8 +4,15 @@ require "rails_helper"
 
 RSpec.describe ResidentialAddressController, type: :controller do
   let(:step) { assigns(:step) }
-  let(:invalid_params) { { step: { zip: "11111111111" } } }
   let(:step_class) { ResidentialAddress }
+  let(:invalid_params) do
+    {
+      step: {
+        zip: "11111111111",
+        unstable_housing: "0",
+      },
+    }
+  end
 
   before { session[:snap_application_id] = current_app.id }
 

--- a/spec/steps/residential_address_spec.rb
+++ b/spec/steps/residential_address_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ResidentialAddress do
+  context "client does not have a stable address" do
+    it "validates address, city, and zip" do
+      valid_residential_address = ResidentialAddress.new(
+        street_address: nil,
+        city: nil,
+        zip: nil,
+        county: "Genesee",
+        state: "MI",
+        unstable_housing: "1",
+      )
+
+      expect(valid_residential_address).to be_valid
+    end
+  end
+
+  context "client has a stable address" do
+    it "validates address, city, and zip" do
+      valid_residential_address = ResidentialAddress.new(
+        street_address: "123 Main St.",
+        city: "Flint",
+        zip: "12345",
+        county: "Genesee",
+        state: "MI",
+        unstable_housing: "0",
+      )
+
+      invalid_nil_address = ResidentialAddress.new(
+        street_address: nil,
+        city: nil,
+        zip: nil,
+        county: "Genesee",
+        state: "MI",
+        unstable_housing: "0",
+      )
+
+      invalid_blank_address = ResidentialAddress.new(
+        street_address: "",
+        city: "",
+        zip: "",
+        county: "Genesee",
+        state: "MI",
+        unstable_housing: "0",
+      )
+
+      expect(valid_residential_address).to be_valid
+      expect(invalid_nil_address).not_to be_valid
+      expect(invalid_blank_address).not_to be_valid
+    end
+  end
+end


### PR DESCRIPTION
If the client has an unstable or volatile home address the application
should *not* validate the presence of their home address. If they don't
have a stable address, allow them to continue without having to fill in
those fields.

ALSO:

* Small formatting refactor in the mb_form_builder to make the text
  input a little easier to read.
* Limit the number of chars in zip code form field as we validate it's
  length in the form object. We can match that restriction on the view
  layer.
* When validating presence of fields in the address form object, do not
  allow empty strings

![](http://g.recordit.co/oBSdPsRspw.gif)