### PR TITLE
Redirect home if no application is in session

### DIFF
--- a/app/controllers/introduce_yourself_controller.rb
+++ b/app/controllers/introduce_yourself_controller.rb
@@ -17,6 +17,10 @@ class IntroduceYourselfController < StandardStepsController
 
   private
 
+  def ensure_application_present
+    _application_not_created = true
+  end
+
   def existing_attributes
     HashWithIndifferentAccess.new(member.attributes)
   end

--- a/app/controllers/residential_address_controller.rb
+++ b/app/controllers/residential_address_controller.rb
@@ -21,6 +21,6 @@ class ResidentialAddressController < AddressController
   end
 
   def skip?
-    current_snap_application.mailing_address_same_as_residential_address?
+    current_snap_application&.mailing_address_same_as_residential_address?
   end
 end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -4,6 +4,7 @@ class StepsController < ApplicationController
   layout "step"
 
   before_action :maybe_skip, only: :edit
+  before_action :ensure_application_present, only: :edit
 
   def self.to_param
     controller_path.dasherize
@@ -18,6 +19,12 @@ class StepsController < ApplicationController
   private
 
   delegate :step_class, to: :class
+
+  def ensure_application_present
+    if current_snap_application.blank?
+      redirect_to root_path
+    end
+  end
 
   def step_params
     params.fetch(:step, {}).permit(*step_attrs)

--- a/spec/controllers/introduce_yourself_controller_spec.rb
+++ b/spec/controllers/introduce_yourself_controller_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe IntroduceYourselfController do
       expect(step.last_name).to eq("booboo")
       expect(step.birthday).to eq(birthday)
     end
+
+    context "application has not yet been created" do
+      it "does not redirect to the homepage" do
+        session[:snap_application_id] = nil
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
   end
 
   describe "#update" do

--- a/spec/support/shared_examples/step_controller.rb
+++ b/spec/support/shared_examples/step_controller.rb
@@ -9,6 +9,18 @@ RSpec.shared_examples "step controller" do
 
       expect(step).to be_an_instance_of step_class
     end
+
+    context "no application is currently under way" do
+      it "redirects to the homepage" do
+        if subject.class != IntroduceYourselfController
+          session[:snap_application_id] = nil
+
+          get :edit
+
+          expect(response).to redirect_to(root_path)
+        end
+      end
+    end
   end
 
   describe "#update" do


### PR DESCRIPTION
If someone tries to go to one of the steps (steps that are NOT the very
first step) then they should be redirected to the homepage. Once they
start the application process and create a new application, they will be
able to go back and forth along all of the steps.