### PR TITLE
Use headless chrome instead of poltergeist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 /tmp/*
 /coverage
 .rspec
+mkmf.log

--- a/Gemfile
+++ b/Gemfile
@@ -44,11 +44,11 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "listen"
   gem "mailcatcher", "~> 0.2"
-  gem "poltergeist"
   gem "pry-rails"
   gem "rspec-rails"
   gem "rspec_junit_formatter"
   gem "rubocop-rspec", require: false
+  gem "selenium-webdriver"
   gem "simplecov"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,10 +200,6 @@ GEM
       ruby-rc4
       ttfunk
     pg (0.21.0)
-    poltergeist (1.16.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -284,6 +280,7 @@ GEM
       rubocop (>= 0.42.0)
     ruby-progressbar (1.8.1)
     ruby-rc4 (0.1.5)
+    rubyzip (1.2.1)
     safe_shell (1.1.0)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
@@ -297,6 +294,9 @@ GEM
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
     selectize-rails (0.12.4)
+    selenium-webdriver (3.4.3)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.0)
     simplecov (0.13.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -371,7 +371,6 @@ DEPENDENCIES
   pdf-forms
   pdf-reader
   pg (~> 0.18)
-  poltergeist
   pry-rails
   puma
   rails (~> 5.1)
@@ -381,6 +380,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop-rspec
   sass-rails (~> 5.0)
+  selenium-webdriver
   sfax!
   simplecov
   twilio-ruby

--- a/bin/setup
+++ b/bin/setup
@@ -20,6 +20,14 @@ chdir APP_ROOT do
     end
   end
 
+  step "Installing ChromeDriver - a separate executable that WebDriver uses to control Chrome" do
+    if cli_installed?("chromedriver")
+      puts "chromedriver already installed."
+    else
+      system!("brew install chromedriver")
+    end
+  end
+
   step "Copying sample files" do
     [".env"].each do |file|
       unless File.exist?(file)

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,13 @@
 dependencies:
   pre:
     - sudo apt-get update; sudo apt-get install pdftk
+    - wget https://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip
+    - unzip chromedriver_linux64.zip
+    - sudo cp chromedriver /usr/local/bin/chromedriver
+    - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    - sudo dpkg -i google-chrome.deb
+    - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+    - rm google-chrome.deb
 
 test:
   override:

--- a/lib/find_chrome.rb
+++ b/lib/find_chrome.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "mkmf"
+
+class FindChrome
+  CHROME_PATHS = [
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/opt/google/chrome/chrome",
+    ENV["CHROME_PATH"],
+    find_executable("chrome"),
+  ].compact.freeze
+
+  CHROMEDRIVER_PATHS = [
+    "/usr/local/bin/chromedriver",
+    ENV["CHROMEDRIVER_PATH"],
+    find_executable("chromedriver"),
+  ].compact.freeze
+
+  def self.binary
+    found = CHROME_PATHS.select { |path| File.executable? path }
+    return found.first if found.any?
+    raise "Chrome not found on system"
+  end
+
+  def self.driver
+    found = CHROMEDRIVER_PATHS.select { |path| File.executable? path }
+    return found.first if found.any?
+    raise "Chromedriver not found on system"
+  end
+end

--- a/lib/find_chrome.rb
+++ b/lib/find_chrome.rb
@@ -17,14 +17,16 @@ class FindChrome
   ].compact.freeze
 
   def self.binary
-    found = CHROME_PATHS.select { |path| File.executable? path }
-    return found.first if found.any?
-    raise "Chrome not found on system"
+    search(CHROME_PATHS, for_binary_named: "Chrome")
   end
 
   def self.driver
-    found = CHROMEDRIVER_PATHS.select { |path| File.executable? path }
+    search(CHROMEDRIVER_PATHS, for_binary_named: "Chromedriver")
+  end
+
+  def self.search(paths, for_binary_named:)
+    found = paths.select { |path| File.executable? path }
     return found.first if found.any?
-    raise "Chromedriver not found on system"
+    raise "#{for_binary_named} not found on system"
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,31 +4,23 @@ ENV["RAILS_ENV"] ||= "test"
 require "spec_helper"
 require File.expand_path("../../config/environment", __FILE__)
 require "rspec/rails"
-
-Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
-
-headless_capybara = true
 require "capybara/rails"
 require "capybara/rspec"
+require "selenium/webdriver"
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
-if headless_capybara
-  require "capybara/poltergeist"
-  Capybara.javascript_driver = :poltergeist
-else
-  Capybara.register_driver :chrome do |app|
-    Capybara::Selenium::Driver.new(app, browser: :chrome)
-  end
-  Capybara.javascript_driver = :chrome
-end
+Capybara.javascript_driver = :headless_chrome # or `:chrome` for full browser
 
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = false
+
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
   end
+
   config.before(:each) do |example|
     DatabaseCleaner.strategy = if example.metadata[:js]
                                  :truncation
@@ -37,13 +29,13 @@ RSpec.configure do |config|
                                end
     DatabaseCleaner.start
   end
+
   config.after(:each) do
     DatabaseCleaner.clean
     FakeTwilioClient.clear!
   end
 
   config.infer_spec_type_from_file_location!
-
   config.include FeatureHelper, type: :feature
   config.include GenericHelper
 end

--- a/spec/support/chrome_browser.rb
+++ b/spec/support/chrome_browser.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "find_chrome"
+
+Capybara.register_driver :chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: {
+      binary: FindChrome.binary,
+    },
+  )
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    desired_capabilities: capabilities,
+    driver_path: FindChrome.driver,
+  )
+end

--- a/spec/support/chrome_headless.rb
+++ b/spec/support/chrome_headless.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "find_chrome"
+
+Capybara.register_driver :headless_chrome do |app|
+  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: {
+      args: %w[headless disable-gpu],
+      binary: FindChrome.binary,
+    },
+  )
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    desired_capabilities: capabilities,
+    driver_path: FindChrome.driver,
+  )
+end

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -53,7 +53,7 @@ module FeatureHelper
 
   def js_select_radio(question:, answer_id:)
     within(find(:fieldset, text: question)) do
-      find("##{answer_id}").trigger("click")
+      page.execute_script("$('##{answer_id}').trigger('click')")
     end
   end
 


### PR DESCRIPTION
When our JS-enabled tests run we should use (headless) chrome and
chromedriver as the driver. This removes the dependency of poltergeist
but adds the need for chromedriver. As a result:

1. Add the installation of chromedriver to our setup script
2. Add the installation of chromedriver to circle.yml

Because the platforms we test on install chrome(driver) in different
locations this commit adds a `FindChrome` class that will locate chrome
and chromedriver in either the most common locations, or a location we
can specify with the ENV variables `CHROME_PATH` or `CHROMEDRIVER_PATH`.
If they're not found - raise an exception.

Default JS driver is `:headless_chrome` but can be changed to `:chrome`
in `rails_helper.rb` if we want to watch those tests in a real chrome
browser.

Also:

* Update feature_helper to work with this driver. For some reason
capybara was complaining about the previous api usage - something about
how that wasn't implemented. ¯\_(ツ)_/¯