### PR TITLE
Ask clients how they would like to be interviewed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /coverage
 .rspec
 mkmf.log
+Guardfile

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ Ask the team for access to the following services to begin contributing:
 
 ## What's Included
 
+### Step Skipping
+
+This application is a long questionaire.
+You will probably want to work on parts of it
+without completing the whole application.
+
+After booting the server and filling out the first step,
+go to `http://localhost:3000/steps`
+to jump around.
+
 ### Document / Photo Uploading Details
 
 * The file uploading service is called [Shubox]. The [dashboard] can be

--- a/app/controllers/preferences_interview_controller.rb
+++ b/app/controllers/preferences_interview_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class PreferencesInterviewController < StandardStepsController
+end

--- a/app/steps/preferences_interview.rb
+++ b/app/steps/preferences_interview.rb
@@ -1,0 +1,10 @@
+class PreferencesInterview < Step
+  step_attributes(
+    :interview_preference,
+  )
+
+  validates :interview_preference, inclusion: {
+    in: %w(in_person telephone),
+    message: "Make sure to answer this question",
+  }
+end

--- a/app/steps/step_navigation.rb
+++ b/app/steps/step_navigation.rb
@@ -33,6 +33,9 @@ class StepNavigation
       ExpensesAdditionalSourcesController,
       ExpensesAdditionalController,
     ],
+    "Preferences" => [
+      PreferencesInterviewController,
+    ],
     "Legal" => [
       LegalAgreementController,
       SignAndSubmitController,

--- a/app/views/preferences_interview/edit.html.erb
+++ b/app/views/preferences_interview/edit.html.erb
@@ -1,0 +1,24 @@
+<% content_for :header_title, "Interview Preferences" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="step-section-header">
+      <div class="step-section-header__subhead">
+        The next step after you apply is a brief interview with your county.
+      </div>
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+      <%= f.mb_radio_set :interview_preference,
+        "What do you prefer?",
+        [
+          { value: :telephone, label: "Telephone Interview" },
+          { value: :in_person, label: "In-Person Interview" },
+        ]
+       %>
+
+    <%= render 'shared/next_step' %>
+  <% end %>
+</div>

--- a/db/migrate/20170823185812_add_interview_preference_to_snap_application.rb
+++ b/db/migrate/20170823185812_add_interview_preference_to_snap_application.rb
@@ -1,0 +1,5 @@
+class AddInterviewPreferenceToSnapApplication < ActiveRecord::Migration[5.1]
+  def change
+    add_column :snap_applications, :interview_preference, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170821212353) do
+ActiveRecord::Schema.define(version: 20170823185812) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -92,15 +92,6 @@ ActiveRecord::Schema.define(version: 20170821212353) do
     t.boolean "anyone_living_elsewhere"
     t.boolean "income_change"
     t.text "income_change_explanation"
-    t.text "additional_income", default: [], array: true
-    t.float "income_child_support"
-    t.float "income_foster_care"
-    t.float "income_other"
-    t.float "income_pension"
-    t.float "income_social_security"
-    t.float "income_ssi_or_disability"
-    t.float "income_unemployment_insurance"
-    t.float "income_workers_compensation"
     t.integer "rent_expense"
     t.integer "property_tax_expense"
     t.integer "insurance_expense"
@@ -120,11 +111,21 @@ ActiveRecord::Schema.define(version: 20170821212353) do
     t.string "care_expenses", default: [], array: true
     t.string "medical_expenses", default: [], array: true
     t.string "court_ordered_expenses", default: [], array: true
+    t.text "additional_income", default: [], array: true
+    t.float "income_child_support"
+    t.float "income_foster_care"
+    t.float "income_other"
+    t.float "income_pension"
+    t.float "income_social_security"
+    t.float "income_ssi_or_disability"
+    t.float "income_unemployment_insurance"
+    t.float "income_workers_compensation"
     t.boolean "money_or_accounts_income"
     t.boolean "real_estate_income"
     t.boolean "vehicle_income"
     t.string "financial_accounts", default: [], array: true
     t.float "total_money"
+    t.string "interview_preference"
   end
 
 end

--- a/spec/controllers/preferences_interview_controller_spec.rb
+++ b/spec/controllers/preferences_interview_controller_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PreferencesInterviewController do
+  let(:step) { assigns(:step) }
+  let(:invalid_params) { { step: { interview_preference: "telepathy" } } }
+  let(:step_class) { PreferencesInterview }
+
+  before { session[:snap_application_id] = current_app.id }
+
+  include_examples "step controller"
+
+  describe "#edit" do
+    it "assigns the attributes to the step" do
+      get :edit
+
+      expect(attributes.keys.map { |attr| [attr, step.send(attr)] }.to_h).to eq(
+        attributes,
+      )
+    end
+  end
+
+  describe "#update" do
+    context "the preference is for a telephone interview" do
+      it "is valid" do
+        params = { interview_preference: "telephone" }
+
+        put :update, params: { step: params }
+
+        expect(response).to redirect_to("/steps/legal-agreement")
+        expect(current_app.interview_preference).to eq("telephone")
+      end
+    end
+  end
+
+  def current_app
+    @_current_app ||= create(:snap_application, attributes)
+  end
+
+  def attributes
+    { interview_preference: "telephone" }
+  end
+end

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -145,6 +145,11 @@ accounts?",
     submit_expense_sources(answer: "yes")
     submit_expenses
 
+    on_page "Interview Preferences" do
+      choose "Telephone Interview"
+      click_on "Continue"
+    end
+
     consent_to_terms
 
     fill_in "Your signature", with: "Jessie Tester"
@@ -240,6 +245,11 @@ accounts?",
     end
 
     submit_expense_sources(answer: "no")
+
+    on_page "Interview Preferences" do
+      choose "Telephone Interview"
+      click_on "Continue"
+    end
 
     consent_to_terms
 


### PR DESCRIPTION
Reason for Change
=================
* We should ask clients how they would like to be interviewed by the county.

Change
======
* Create a "Preferences" subsection
* Add a step for interview preferences.

Minor
=====
* Add a note in the `README.md` on skipping around the steps.
* Remove migration command related to paperclip. After removing paperclip, the migration using `add_attachment` no longer works. The suggestion [here][1] was to just rename the columns in the migration.

[1]: https://github.com/thoughtbot/paperclip/issues/1351#issuecomment-29522904