### PR TITLE
Validate length of SSN

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby "2.4.1"
 
 gem "administrate"
 gem "attr_encrypted"
+gem "auto_strip_attributes"
 gem "aws-sdk"
 gem "bourbon", "~> 4.2.0" # to keep in sync with getcalfresh
 gem "delayed_job_active_record"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,8 @@ GEM
     ast (2.3.0)
     attr_encrypted (3.0.3)
       encryptor (~> 3.0.0)
+    auto_strip_attributes (2.1.0)
+      activerecord (>= 3.0)
     autoprefixer-rails (7.1.2.6)
       execjs
     awesome_print (1.8.0)
@@ -351,6 +353,7 @@ PLATFORMS
 DEPENDENCIES
   administrate
   attr_encrypted
+  auto_strip_attributes
   awesome_print
   aws-sdk
   bourbon (~> 4.2.0)

--- a/app/steps/concerns/social_security_number.rb
+++ b/app/steps/concerns/social_security_number.rb
@@ -1,0 +1,28 @@
+module SocialSecurityNumber
+  extend ActiveSupport::Concern
+
+  SSN_REGEX = /\A\d{9}\z/
+
+  included do
+    auto_strip_attributes :ssn
+
+    validates :ssn,
+      allow_blank: true,
+      format: {
+        with: SSN_REGEX,
+        message: "Make sure your SSN has 9 digits",
+      }
+
+    # Overriding @record[key]=val, that's only found in ActiveRecord, so we can
+    # use auto_strip_attributes with ActiveModel
+    def []=(key, val)
+      # send("#{key}=", val)  # We dont want to call setter again
+      instance_variable_set(:"@#{key}", val)
+    end
+
+    def [](key)
+      k = :"@#{key}"
+      instance_variable_defined?(k) ? instance_variable_get(k) : nil
+    end
+  end
+end

--- a/app/steps/household_add_member.rb
+++ b/app/steps/household_add_member.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "./concerns/social_security_number.rb"
+
 class HouseholdAddMember < Step
   include MultiparameterAttributeAssignment
+  extend AutoStripAttributes
+  include SocialSecurityNumber
 
   step_attributes(
     :birthday,

--- a/app/steps/personal_detail.rb
+++ b/app/steps/personal_detail.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
 
+require_relative "./concerns/social_security_number.rb"
+
 class PersonalDetail < Step
+  extend AutoStripAttributes
+  include SocialSecurityNumber
+
   step_attributes(
     :sex,
     :marital_status,

--- a/spec/controllers/personal_detail_controller_spec.rb
+++ b/spec/controllers/personal_detail_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe PersonalDetailController do
 
       expect(step.sex).to eq("male")
       expect(step.marital_status).to eq("Married")
-      expect(step.ssn).to eq("12345")
+      expect(step.ssn).to eq("123456789")
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe PersonalDetailController do
         valid_params = {
           sex: "female",
           marital_status: "Divorced",
-          ssn: "54321",
+          ssn: "987654321",
         }
 
         put :update, params: { step: valid_params }
@@ -52,6 +52,6 @@ RSpec.describe PersonalDetailController do
   end
 
   def member
-    create(:member, sex: "male", marital_status: "Married", ssn: "12345")
+    create(:member, sex: "male", marital_status: "Married", ssn: "123456789")
   end
 end

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -29,7 +29,7 @@ feature "SNAP application" do
 
     select_radio(question: "What is your sex?", answer: "Female")
     select "Divorced", from: "What is your marital status?"
-    fill_in "What is your social security number?", with: "123 12 1234"
+    fill_in "What is your social security number?", with: "123121234"
     click_on "Continue"
 
     on_page "Your Household" do

--- a/spec/steps/household_add_member_spec.rb
+++ b/spec/steps/household_add_member_spec.rb
@@ -1,0 +1,13 @@
+require "rails_helper"
+
+RSpec.describe HouseholdAddMember do
+  let(:subject) do
+    HouseholdAddMember.new(
+      first_name: "Light",
+      last_name: "Bulb",
+      requesting_food_assistance: "true",
+    )
+  end
+
+  include_examples "social security number"
+end

--- a/spec/steps/personal_detail_spec.rb
+++ b/spec/steps/personal_detail_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe PersonalDetail do
+  let(:subject) do
+    PersonalDetail.new(marital_status: "Widowed", sex: "male")
+  end
+
+  include_examples "social security number"
+end

--- a/spec/support/shared_examples/social_security_number.rb
+++ b/spec/support/shared_examples/social_security_number.rb
@@ -5,6 +5,11 @@ RSpec.shared_examples "social security number" do
       expect(subject).to be_valid
     end
 
+    it "allows ssn to start with zero" do
+      subject.ssn = "012345678"
+      expect(subject).to be_valid
+    end
+
     it "allows ssns with no delimiters" do
       subject.ssn = "123121234"
       expect(subject).to be_valid

--- a/spec/support/shared_examples/social_security_number.rb
+++ b/spec/support/shared_examples/social_security_number.rb
@@ -1,0 +1,39 @@
+RSpec.shared_examples "social security number" do
+  describe "social security number" do
+    it "allows nils" do
+      subject.ssn = nil
+      expect(subject).to be_valid
+    end
+
+    it "allows ssns with no delimiters" do
+      subject.ssn = "123121234"
+      expect(subject).to be_valid
+    end
+
+    it "disallows bogus ssns" do
+      subject.ssn = "BOGUS"
+      expect(subject).not_to be_valid
+    end
+
+    it "invalidates bad SSNs with a friendly message" do
+      subject.ssn = "111 22 333"
+      expect(subject).not_to be_valid
+      expect(subject.errors[:ssn]).to include(
+        "Make sure your SSN has 9 digits",
+      )
+    end
+
+    it "disallows bogus ssns with newlines" do
+      subject.ssn = "BOGUS\n'--DROP TABLE CALFRESH_APPLICATIONS"
+      expect(subject).not_to be_valid
+    end
+
+    it "does not allow dashes" do
+      subject.ssn = "  123-12-1234  "
+      expect(subject).to be_invalid
+      expect(subject.errors[:ssn]).to include(
+        "Make sure your SSN has 9 digits",
+      )
+    end
+  end
+end


### PR DESCRIPTION
**WHY**: So we can know that it is 9 digits when entering it,
digit-by-digit, into the 1171 PDF.

Also adds auto-strip-attributes so that if someone has an extra
whitespace when entering their SSN it is auto-stripped

This approach was inspired by the SSN formatting in GCF, which I had a
hand in.

