### PR TITLE
Split shared examples

### DIFF
--- a/spec/controllers/contact_information_controller_spec.rb
+++ b/spec/controllers/contact_information_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe ContactInformationController, type: :controller do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   describe "#edit" do
     it "assigns the fields to the step" do

--- a/spec/controllers/household_add_member_controller_spec.rb
+++ b/spec/controllers/household_add_member_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe HouseholdAddMemberController do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   describe "#edit" do
     context "existing member" do

--- a/spec/controllers/household_more_info_controller_spec.rb
+++ b/spec/controllers/household_more_info_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe HouseholdMoreInfoController do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   def current_app
     @_current_app ||= create(:snap_application)

--- a/spec/controllers/income_employment_status_controller_spec.rb
+++ b/spec/controllers/income_employment_status_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe IncomeEmploymentStatusController do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   describe "#update" do
     context "when valid" do

--- a/spec/controllers/income_other_assets_controller_spec.rb
+++ b/spec/controllers/income_other_assets_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe IncomeOtherAssetsController do
   let(:invalid_params) { { step: { vehicle_income: "" } } }
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   def current_app
     @_current_app ||= create(:snap_application)

--- a/spec/controllers/introduce_yourself_controller_spec.rb
+++ b/spec/controllers/introduce_yourself_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe IntroduceYourselfController do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   describe "#edit" do
     it "assigns the name and birthday to the step" do

--- a/spec/controllers/legal_agreement_controller_spec.rb
+++ b/spec/controllers/legal_agreement_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe LegalAgreementController do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   describe "#edit" do
     it "assigns the attributes to the step" do

--- a/spec/controllers/mailing_address_controller_spec.rb
+++ b/spec/controllers/mailing_address_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe MailingAddressController, type: :controller do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   describe "#edit" do
     it "assigns the fields to the step" do

--- a/spec/controllers/personal_detail_controller_spec.rb
+++ b/spec/controllers/personal_detail_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PersonalDetailController do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   describe "#edit" do
     it "assigns the fields to the step" do

--- a/spec/controllers/preferences_interview_controller_spec.rb
+++ b/spec/controllers/preferences_interview_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe PreferencesInterviewController do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   describe "#edit" do
     it "assigns the attributes to the step" do

--- a/spec/controllers/residential_address_controller_spec.rb
+++ b/spec/controllers/residential_address_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe ResidentialAddressController, type: :controller do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   describe "#edit" do
     it "assigns the fields to the step" do

--- a/spec/controllers/sign_and_submit_controller_spec.rb
+++ b/spec/controllers/sign_and_submit_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SignAndSubmitController do
 
   before { session[:snap_application_id] = current_app.id }
 
-  include_examples "step controller"
+  include_examples "step controller", "param validation"
 
   describe "#edit" do
     it "assigns the attributes to the step" do

--- a/spec/support/shared_examples/param_validation.rb
+++ b/spec/support/shared_examples/param_validation.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.shared_examples "param validation" do
+  before { session[:snap_application_id] = current_app.id }
+
+  describe "#update" do
+    context "invalid params" do
+      it "renders edit" do
+        put :update, params: invalid_params
+
+        expect(step).to be_an_instance_of(step_class)
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/step_controller.rb
+++ b/spec/support/shared_examples/step_controller.rb
@@ -22,15 +22,4 @@ RSpec.shared_examples "step controller" do
       end
     end
   end
-
-  describe "#update" do
-    context "invalid params" do
-      it "renders edit" do
-        put :update, params: invalid_params
-
-        expect(step).to be_an_instance_of(step_class)
-        expect(response).to render_template(:edit)
-      end
-    end
-  end
 end


### PR DESCRIPTION
Reason for Change
=================
* Some steps don't have validation associated.
* Combining the validation shared example with the other ones then becomes brittle.

Changes
=======
* Split the shared examples into one for general steps and one for param validation.
