### PR TITLE
Allow clients to add additional information

### DIFF
--- a/app/controllers/general_anything_else_controller.rb
+++ b/app/controllers/general_anything_else_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class GeneralAnythingElseController < StandardStepsController
+end

--- a/app/controllers/general_interview_preference_controller.rb
+++ b/app/controllers/general_interview_preference_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class GeneralInterviewPreferenceController < StandardStepsController
+end

--- a/app/controllers/preferences_interview_controller.rb
+++ b/app/controllers/preferences_interview_controller.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class PreferencesInterviewController < StandardStepsController
-end

--- a/app/steps/general_anything_else.rb
+++ b/app/steps/general_anything_else.rb
@@ -1,0 +1,3 @@
+class GeneralAnythingElse < Step
+  step_attributes(:additional_information)
+end

--- a/app/steps/general_interview_preference.rb
+++ b/app/steps/general_interview_preference.rb
@@ -1,4 +1,4 @@
-class PreferencesInterview < Step
+class GeneralInterviewPreference < Step
   step_attributes(
     :interview_preference,
   )

--- a/app/steps/step_navigation.rb
+++ b/app/steps/step_navigation.rb
@@ -33,8 +33,9 @@ class StepNavigation
       ExpensesAdditionalSourcesController,
       ExpensesAdditionalController,
     ],
-    "Preferences" => [
-      PreferencesInterviewController,
+    "General" => [
+      GeneralInterviewPreferenceController,
+      GeneralAnythingElseController,
     ],
     "Legal" => [
       LegalAgreementController,

--- a/app/views/general_anything_else/edit.html.erb
+++ b/app/views/general_anything_else/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :header_title, "General" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="step-section-header">
+      Is there anything else you'd like us to know about your situation?
+
+      <div class="step-section-header__subhead">
+        Feel free to give other details you think might be helpful for us to
+        know. Otherwise, you can skip this question.
+      </div>
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+      <%= f.mb_textarea :additional_information, "Anything else?" %>
+
+    <%= render 'shared/next_step' %>
+  <% end %>
+</div>

--- a/app/views/general_interview_preference/edit.html.erb
+++ b/app/views/general_interview_preference/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :header_title, "Interview Preferences" %>
+<% content_for :header_title, "General" %>
 
 <div class="form-card">
   <header class="form-card__header">

--- a/db/migrate/20170406224506_add_anything_else_to_app.rb
+++ b/db/migrate/20170406224506_add_anything_else_to_app.rb
@@ -2,6 +2,6 @@
 
 class AddAnythingElseToApp < ActiveRecord::Migration[5.0]
   def change
-    add_column :apps, :anything_else, :text
+    add_column :apps, :additional_information, :text
   end
 end

--- a/db/migrate/20170824170659_add_anything_else_to_snap_application.rb
+++ b/db/migrate/20170824170659_add_anything_else_to_snap_application.rb
@@ -1,0 +1,5 @@
+class AddAnythingElseToSnapApplication < ActiveRecord::Migration[5.1]
+  def change
+    add_column :snap_applications, :additional_information, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -92,15 +92,6 @@ ActiveRecord::Schema.define(version: 20170825182343) do
     t.boolean "anyone_living_elsewhere"
     t.boolean "income_change"
     t.text "income_change_explanation"
-    t.text "additional_income", default: [], array: true
-    t.float "income_child_support"
-    t.float "income_foster_care"
-    t.float "income_other"
-    t.float "income_pension"
-    t.float "income_social_security"
-    t.float "income_ssi_or_disability"
-    t.float "income_unemployment_insurance"
-    t.float "income_workers_compensation"
     t.integer "rent_expense"
     t.integer "property_tax_expense"
     t.integer "insurance_expense"
@@ -120,12 +111,22 @@ ActiveRecord::Schema.define(version: 20170825182343) do
     t.string "care_expenses", default: [], array: true
     t.string "medical_expenses", default: [], array: true
     t.string "court_ordered_expenses", default: [], array: true
+    t.text "additional_income", default: [], array: true
+    t.float "income_child_support"
+    t.float "income_foster_care"
+    t.float "income_other"
+    t.float "income_pension"
+    t.float "income_social_security"
+    t.float "income_ssi_or_disability"
+    t.float "income_unemployment_insurance"
+    t.float "income_workers_compensation"
     t.boolean "money_or_accounts_income"
     t.boolean "real_estate_income"
     t.boolean "vehicle_income"
     t.string "financial_accounts", default: [], array: true
     t.float "total_money"
     t.string "interview_preference"
+    t.text "additional_information"
   end
 
 end

--- a/spec/controllers/general_anything_else_controller_spec.rb
+++ b/spec/controllers/general_anything_else_controller_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe GeneralAnythingElseController do
+  let(:step) { assigns(:step) }
+  let(:step_class) { GeneralAnythingElse }
+
+  include_examples "step controller"
+
+  describe "#edit" do
+    it "assigns the attributes to the step" do
+      session[:snap_application_id] = current_app.id
+
+      get :edit
+      step_attributes = attributes.keys.map do |attr|
+        [attr, step.send(attr)]
+      end.to_h
+
+      expect(step_attributes).to eq(attributes)
+    end
+  end
+
+  describe "#update" do
+    context "When additional information is provided" do
+      it "is valid" do
+        put :update
+
+        expect(response).to redirect_to("/steps/legal-agreement")
+        expect(current_app.additional_information).to eq(
+          attributes.fetch(:additional_information),
+        )
+      end
+    end
+
+    context "When additional information is NOT provided" do
+      it "is valid" do
+        current_app = create(:snap_application)
+
+        put :update, params: { step: { additional_information: nil } }
+
+        expect(response).to redirect_to("/steps/legal-agreement")
+        expect(current_app.additional_information).to be_nil
+      end
+    end
+  end
+
+  def current_app
+    @_current_app ||= create(:snap_application, attributes)
+  end
+
+  def attributes
+    { additional_information: "Thank you!" }
+  end
+end

--- a/spec/controllers/general_interview_preference_controller_spec.rb
+++ b/spec/controllers/general_interview_preference_controller_spec.rb
@@ -2,10 +2,10 @@
 
 require "rails_helper"
 
-RSpec.describe PreferencesInterviewController do
+RSpec.describe GeneralInterviewPreferenceController do
   let(:step) { assigns(:step) }
   let(:invalid_params) { { step: { interview_preference: "telepathy" } } }
-  let(:step_class) { PreferencesInterview }
+  let(:step_class) { GeneralInterviewPreference }
 
   before { session[:snap_application_id] = current_app.id }
 
@@ -28,7 +28,7 @@ RSpec.describe PreferencesInterviewController do
 
         put :update, params: { step: params }
 
-        expect(response).to redirect_to("/steps/legal-agreement")
+        expect(response).to redirect_to("/steps/general-anything-else")
         expect(current_app.interview_preference).to eq("telephone")
       end
     end

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -145,8 +145,13 @@ accounts?",
     submit_expense_sources(answer: "yes")
     submit_expenses
 
-    on_page "Interview Preferences" do
+    on_page "General" do
       choose "Telephone Interview"
+      click_on "Continue"
+    end
+
+    on_page "General" do
+      fill_in "Anything else?", with: "This is helpful, thank you!"
       click_on "Continue"
     end
 
@@ -246,8 +251,12 @@ accounts?",
 
     submit_expense_sources(answer: "no")
 
-    on_page "Interview Preferences" do
+    on_page "General" do
       choose "Telephone Interview"
+      click_on "Continue"
+    end
+
+    on_page "General" do
       click_on "Continue"
     end
 


### PR DESCRIPTION
Reason for Change
=================
* Allowing clients to add additional information about their current situation, _in their own words_ has proven valuable for food assistance applications.

Changes
=======
* Add a step in the Preferences section at the end, just before signatures.

Minor
-----
* Remove warning for hash key defined twice.