### PR TITLE
Validate 10 digit phone number

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,6 @@ gem "jquery-rails"
 gem "neat", "~> 1.8" # to keep in sync with getcalfresh
 gem "pdf-forms"
 gem "pg", "~> 0.18"
-gem "phony_rails"
 gem "puma"
 gem "rails", "~> 5.1"
 gem "responders"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,10 +202,6 @@ GEM
       ruby-rc4
       ttfunk
     pg (0.21.0)
-    phony (2.15.47)
-    phony_rails (0.14.6)
-      activesupport (>= 3.0)
-      phony (> 2.15)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -378,7 +374,6 @@ DEPENDENCIES
   pdf-forms
   pdf-reader
   pg (~> 0.18)
-  phony_rails
   pry-rails
   puma
   rails (~> 5.1)

--- a/app/models/snap_application_attributes.rb
+++ b/app/models/snap_application_attributes.rb
@@ -163,7 +163,7 @@ class SnapApplicationAttributes
   end
 
   def ten_digit_phone
-    snap_application.phone_number.split("").last(10)
+    snap_application.phone_number.split("")
   end
 
   def monthly_rent_taxes_and_insurance

--- a/app/steps/contact_information.rb
+++ b/app/steps/contact_information.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
 
 class ContactInformation < Step
-  attr_accessor :phone_number, :phone_number_as_normalized
-  phony_normalize :phone_number, default_country_code: "US"
-
   step_attributes(
     :email,
     :phone_number,
     :sms_subscribed,
   )
 
-  validates_plausible_phone :phone_number, with: /\A\+\d+/
   validates(
     :phone_number,
+    ten_digit_phone_number: true,
     presence: {
       message: "Make sure to provide a phone number at which we can reach you",
     },

--- a/app/validators/ten_digit_phone_number_validator.rb
+++ b/app/validators/ten_digit_phone_number_validator.rb
@@ -1,0 +1,8 @@
+class TenDigitPhoneNumberValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    unless value && value.match?(/\A\d{10}\z/)
+      record.errors[attribute] <<
+        "Make sure your phone number is 10 digits long"
+    end
+  end
+end

--- a/spec/controllers/contact_information_controller_spec.rb
+++ b/spec/controllers/contact_information_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ContactInformationController, type: :controller do
     context "when valid" do
       it "redirects to the next step" do
         valid_params = {
-          phone_number: "222-222-2222",
+          phone_number: "2222222222",
           sms_subscribed: "false",
         }
 

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -8,7 +8,7 @@ feature "SNAP application" do
     fill_in_name_and_birthday
     click_on "Continue"
 
-    fill_in "What is the best phone number to reach you?", with: "12345678990"
+    fill_in "What is the best phone number to reach you?", with: "2223334444"
     subscribe_to_sms_updates
     fill_in "What is your email address?", with: "test@example.com"
     click_on "Continue"
@@ -174,7 +174,7 @@ accounts?",
     fill_in_name_and_birthday
     click_on "Continue"
 
-    fill_in "What is the best phone number to reach you?", with: "222-222-2222"
+    fill_in "What is the best phone number to reach you?", with: "2222222222"
     subscribe_to_sms_updates
     fill_in "What is your email address?", with: "test@example.com"
     click_on "Continue"
@@ -273,7 +273,7 @@ accounts?",
     fill_in_name_and_birthday
     click_on "Continue"
 
-    fill_in "What is the best phone number to reach you?", with: "12345678990"
+    fill_in "What is the best phone number to reach you?", with: "2223334444"
     subscribe_to_sms_updates
     fill_in "What is your email address?", with: "test@example.com"
     click_on "Continue"
@@ -301,7 +301,7 @@ accounts?",
     fill_in_name_and_birthday
     click_on "Continue"
 
-    fill_in "What is the best phone number to reach you?", with: "12345678990"
+    fill_in "What is the best phone number to reach you?", with: "2223334444"
     subscribe_to_sms_updates
     fill_in "What is your email address?", with: "test@example.com"
     click_on "Continue"
@@ -324,12 +324,12 @@ accounts?",
     fill_in_name_and_birthday
     click_on "Continue"
 
-    fill_in "What is the best phone number to reach you?", with: "1234567890"
+    fill_in "What is the best phone number to reach you?", with: "2223334444"
     click_on "Continue"
 
     expect(
       find_field("What is the best phone number to reach you?").value,
-    ).to eq "+1234567890"
+    ).to eq "2223334444"
   end
 
   scenario "saves user data across steps", :js do

--- a/spec/models/snap_application_attributes_spec.rb
+++ b/spec/models/snap_application_attributes_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe SnapApplicationAttributes do
         :with_member,
         addresses: [mailing_address, residential_address],
         financial_accounts: [:four_oh_one_k],
-        phone_number: "+12222222222",
+        phone_number: "2222222222",
         rent_expense: 100,
         unstable_housing: true,
       )

--- a/spec/validators/ten_digit_phone_number_validator_spec.rb
+++ b/spec/validators/ten_digit_phone_number_validator_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe TenDigitPhoneNumberValidator do
+  let!(:member) { OpenStruct.new(errors: { phone_number: [] }) }
+  subject { described_class.new(attributes: [:phone_number]) }
+
+  specify do
+    assert_invalid(nil)
+  end
+
+  specify do
+    assert_invalid("123456789\n0")
+  end
+
+  specify do
+    assert_valid("8177136264")
+  end
+
+  specify do
+    assert_invalid("817713626")
+  end
+
+  specify do
+    assert_invalid("81u7136264")
+  end
+
+  specify do
+    assert_invalid("81471362634343434")
+  end
+
+  specify do
+    assert_invalid("123456789\n0")
+  end
+
+  def assert_invalid(value)
+    subject.validate_each(member, :phone_number, value)
+    expect(member.errors[:phone_number]).to be_present
+  end
+
+  def assert_valid(value)
+    subject.validate_each(member, :phone_number, value)
+    expect(member.errors[:phone_number]).to eq []
+  end
+end


### PR DESCRIPTION
* Moves away from phony rails, which was not working 100% of the time
* This is better for PDF filling because we want 10 digits for the PDF
* In future, might be good to allow spaces or dashes for readability.