### PR TITLE
Fax signed applications after 30 minutes of inactivity

### DIFF
--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -21,7 +21,8 @@ class SuccessController < StandardStepsController
   private
 
   def create_and_send_pdf
-    SendApplicationJob.perform_later(snap_application: current_snap_application)
+    EmailApplicationJob.
+      perform_later(snap_application: current_snap_application)
   end
 
   def flash_notice

--- a/app/jobs/email_application_job.rb
+++ b/app/jobs/email_application_job.rb
@@ -1,0 +1,29 @@
+class EmailApplicationJob < ApplicationJob
+  def perform(snap_application:)
+    @snap_application = snap_application
+
+    create_pdf
+    send_pdf
+  ensure
+    complete_form_with_cover.try(:close)
+    complete_form_with_cover.try(:unlink)
+  end
+
+  private
+
+  attr_reader :complete_form_with_cover, :snap_application
+  delegate :residential_address, to: :snap_application
+
+  def create_pdf
+    @complete_form_with_cover = Dhs1171Pdf.new(
+      snap_application: snap_application,
+    ).completed_file
+  end
+
+  def send_pdf
+    ApplicationMailer.snap_application_notification(
+      file_name: complete_form_with_cover.path,
+      recipient_email: snap_application.email,
+    ).deliver
+  end
+end

--- a/db/migrate/20170829193351_add_faxed_at_to_snap_application.rb
+++ b/db/migrate/20170829193351_add_faxed_at_to_snap_application.rb
@@ -1,0 +1,5 @@
+class AddFaxedAtToSnapApplication < ActiveRecord::Migration[5.1]
+  def change
+    add_column :snap_applications, :faxed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170825210619) do
+ActiveRecord::Schema.define(version: 20170829193351) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,6 +127,7 @@ ActiveRecord::Schema.define(version: 20170825210619) do
     t.integer "total_money"
     t.string "interview_preference"
     t.text "additional_information"
+    t.datetime "faxed_at"
   end
 
 end

--- a/lib/tasks/queue_faxes.rake
+++ b/lib/tasks/queue_faxes.rake
@@ -1,0 +1,4 @@
+desc "Queues faxes for signed, unfaxed applicants"
+task :queue_faxes do
+  SnapApplication.enqueue_faxes
+end

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -43,14 +43,14 @@ RSpec.describe SuccessController do
         }.from("test@example.com").to("new_email@example.com")
       end
 
-      it "creates a SendApplicationJob" do
-        allow(SendApplicationJob).to receive(:perform_later).
+      it "creates a EmailApplicationJob" do
+        allow(EmailApplicationJob).to receive(:perform_later).
           with(snap_application: current_app)
         params = { step: { email: "new_email@example.com" } }
 
         put :update, params: params
 
-        expect(SendApplicationJob).to have_received(:perform_later).
+        expect(EmailApplicationJob).to have_received(:perform_later).
           with(snap_application: current_app)
       end
     end

--- a/spec/jobs/email_application_job_spec.rb
+++ b/spec/jobs/email_application_job_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe EmailApplicationJob do
+  describe "#perform" do
+    it "creates a PDF with the snap application data" do
+      snap_application = create(:snap_application, :with_member)
+      tempfile = Tempfile.new("send_application_job_spec")
+      pdf_double = double(completed_file: tempfile)
+      allow(Dhs1171Pdf).to receive(:new).
+        with(snap_application: snap_application).
+        and_return(pdf_double)
+
+      EmailApplicationJob.new.perform(snap_application: snap_application)
+
+      expect(pdf_double).to have_received(:completed_file)
+      expect(Dhs1171Pdf).to have_received(:new).
+        with(snap_application: snap_application)
+
+      tempfile.close
+      tempfile.unlink
+    end
+
+    it "sends an email" do
+      snap_application = create(:snap_application, :with_member)
+
+      expect do
+        EmailApplicationJob.new.perform(snap_application: snap_application)
+      end.to change { ActionMailer::Base.deliveries.count }.by(1)
+    end
+  end
+end

--- a/spec/jobs/fax_application_job_spec.rb
+++ b/spec/jobs/fax_application_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe SendApplicationJob do
+RSpec.describe FaxApplicationJob do
   describe "#perform" do
     it "creates a PDF with the snap application data" do
       snap_application = create(:snap_application, :with_member)
@@ -10,7 +10,7 @@ RSpec.describe SendApplicationJob do
         with(snap_application: snap_application).
         and_return(pdf_double)
 
-      SendApplicationJob.new.perform(snap_application: snap_application)
+      FaxApplicationJob.new.perform(snap_application_id: snap_application.id)
 
       expect(pdf_double).to have_received(:completed_file)
       expect(Dhs1171Pdf).to have_received(:new).
@@ -18,14 +18,6 @@ RSpec.describe SendApplicationJob do
 
       tempfile.close
       tempfile.unlink
-    end
-
-    it "sends an email" do
-      snap_application = create(:snap_application, :with_member)
-
-      expect do
-        SendApplicationJob.new.perform(snap_application: snap_application)
-      end.to change { ActionMailer::Base.deliveries.count }.by(1)
     end
 
     it "sends a fax" do
@@ -37,16 +29,39 @@ RSpec.describe SendApplicationJob do
         with(snap_application: snap_application).
         and_return(pdf_double)
 
-      job = SendApplicationJob.new
+      job = FaxApplicationJob.new
       allow(job).to receive(:fax_number).and_return("+15550001111")
       allow(job).to receive(:fax_recipient_name).and_return("John Doe")
 
       allow(Fax).to receive(:send_fax).
         with(number: "+15550001111", file: file_path, recipient: "John Doe")
 
-      job.perform(snap_application: snap_application)
+      job.perform(snap_application_id: snap_application.id)
 
       expect(Fax).to have_received(:send_fax).
+        with(number: "+15550001111", file: file_path, recipient: "John Doe")
+    end
+
+    it "doesnt send a fax if application has already been sent" do
+      snap_application = create(:snap_application, :with_member)
+      tempfile = Tempfile.new("send_application_job_spec")
+      file_path = tempfile.path
+      pdf_double = double(completed_file: tempfile)
+      allow(Dhs1171Pdf).to receive(:new).
+        with(snap_application: snap_application).
+        and_return(pdf_double)
+
+      job = FaxApplicationJob.new
+      allow(job).to receive(:fax_number).and_return("+15550001111")
+      allow(job).to receive(:fax_recipient_name).and_return("John Doe")
+
+      allow(Fax).to receive(:send_fax).
+        with(number: "+15550001111", file: file_path, recipient: "John Doe")
+
+      snap_application.update(faxed_at: Time.zone.now)
+      job.perform(snap_application_id: snap_application.id)
+
+      expect(Fax).not_to have_received(:send_fax).
         with(number: "+15550001111", file: file_path, recipient: "John Doe")
     end
   end

--- a/spec/jobs/fax_application_job_spec.rb
+++ b/spec/jobs/fax_application_job_spec.rb
@@ -38,6 +38,9 @@ RSpec.describe FaxApplicationJob do
 
       job.perform(snap_application_id: snap_application.id)
 
+      snap_application.reload
+      expect(snap_application).to be_faxed
+
       expect(Fax).to have_received(:send_fax).
         with(number: "+15550001111", file: file_path, recipient: "John Doe")
     end


### PR DESCRIPTION
Reason for Change
===================
Previously, we had tied together the notion of faxing the office an application with emailing the applicant. This changes it so that signed applications are automatically faxed after 30 minutes.

Changes
=======
* Split out SendApplicationJob into EmailApplicationJob and FaxApplicationJob
* Add to `SnapApplication` `#faxed_at`, `#faxed?`, and `.faxable` methods
* Write rake task to enqueue faxes `:queue_faxes`

Minor
=====
* N/A?

Risks
=====
* If we do not add a worker with a schedule, we will not send faxes
* If the queues get super backed up it's possible we could queue multiple faxes for the same application; and if both of those execute at the same time we may double fax.