### PR TITLE
Replace hello@michiganbenefits.org

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: "hello@#{ENV['EMAIL_DOMAIN']}"
+  default from: "hello@#{ENV['EMAIL_DOMAIN']}",
+          reply_to: "alanw@codeforamerica.org"
+
   layout "mailer"
 
   def snap_application_notification(file_name:, recipient_email:)


### PR DESCRIPTION
Reason for Change
=================
* We are launching shortly with a non-functioning customer service email address (hello@michiganbenefits.org).
* For now, sending email to Alan is fine.

Changes
=======
* Replace the default "from" email address.