### PR TITLE
Don't apply mobile styles to non-mobile clients

### DIFF
--- a/app/assets/stylesheets/atoms/_layout.scss
+++ b/app/assets/stylesheets/atoms/_layout.scss
@@ -83,7 +83,7 @@
     }
   }
 
-  @include media(0) {
+  @include media(max-width $mobile-up) {
     .textwell__content {
       overflow: hidden;
       padding: 0;


### PR DESCRIPTION
I wound up accidentally pushing what I thought was a PR branch up to master; which had a bug where it hides the terms and conditions for non-mobile users.

This fixes that.