### PR TITLE
Load the environment when using Rails models in rake tasks

### DIFF
--- a/lib/tasks/queue_faxes.rake
+++ b/lib/tasks/queue_faxes.rake
@@ -1,4 +1,4 @@
 desc "Queues faxes for signed, unfaxed applicants"
-task :queue_faxes do
+task queue_faxes: :environment do
   SnapApplication.enqueue_faxes
 end


### PR DESCRIPTION
This is what happens when you test via the command line and not the actual rake task.