### PR TITLE
Refactor pass for fax changes

### DIFF
--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -22,7 +22,7 @@ class SuccessController < StandardStepsController
 
   def create_and_send_pdf
     EmailApplicationJob.
-      perform_later(snap_application: current_snap_application)
+      perform_later(snap_application_id: current_snap_application.id)
   end
 
   def flash_notice

--- a/app/jobs/email_application_job.rb
+++ b/app/jobs/email_application_job.rb
@@ -1,29 +1,16 @@
 class EmailApplicationJob < ApplicationJob
-  def perform(snap_application:)
-    @snap_application = snap_application
-
-    create_pdf
-    send_pdf
+  def perform(snap_application_id:)
+    @snap_application = SnapApplication.find(snap_application_id)
+    ApplicationMailer.snap_application_notification(
+      file_name: snap_application.pdf.path,
+      recipient_email: snap_application.email,
+    ).deliver
   ensure
-    complete_form_with_cover.try(:close)
-    complete_form_with_cover.try(:unlink)
+    snap_application.pdf.try(:close)
+    snap_application.pdf.try(:unlink)
   end
 
   private
 
-  attr_reader :complete_form_with_cover, :snap_application
-  delegate :residential_address, to: :snap_application
-
-  def create_pdf
-    @complete_form_with_cover = Dhs1171Pdf.new(
-      snap_application: snap_application,
-    ).completed_file
-  end
-
-  def send_pdf
-    ApplicationMailer.snap_application_notification(
-      file_name: complete_form_with_cover.path,
-      recipient_email: snap_application.email,
-    ).deliver
-  end
+  attr_reader :snap_application
 end

--- a/app/jobs/fax_application_job.rb
+++ b/app/jobs/fax_application_job.rb
@@ -2,35 +2,24 @@ class FaxApplicationJob < ApplicationJob
   def perform(snap_application_id:)
     @snap_application = SnapApplication.find(snap_application_id)
     return if snap_application.faxed?
-    fax_pdf
+    Fax.send_fax(
+      number: fax_recipient.number,
+      file: snap_application.pdf.path,
+      recipient: fax_recipient.name,
+    )
     snap_application.update(faxed_at: Time.zone.now)
   ensure
-    pdf.try(:close)
-    pdf.try(:unlink)
+    snap_application.pdf.try(:close)
+    snap_application.pdf.try(:unlink)
   end
 
   private
 
   attr_reader :snap_application
-  delegate :pdf, :residential_address, to: :snap_application
-
-  def fax_pdf
-    Fax.send_fax(
-      number: fax_number,
-      file: pdf.path,
-      recipient: fax_recipient_name,
-    )
-  end
 
   def fax_recipient
-    FaxRecipient.new(residential_address: residential_address)
-  end
-
-  def fax_recipient_name
-    fax_recipient.name
-  end
-
-  def fax_number
-    fax_recipient.number
+    @fax_recipient ||=
+      FaxRecipient.new(residential_address:
+                         snap_application.residential_address)
   end
 end

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -14,6 +14,12 @@ class SnapApplication < ApplicationRecord
     end
   end
 
+  def pdf
+    @pdf ||= Dhs1171Pdf.new(
+      snap_application: self,
+    ).completed_file
+  end
+
   def monthly_gross_income
     [
       monthly_additional_income,

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -44,14 +44,14 @@ RSpec.describe SuccessController do
       end
 
       it "creates a EmailApplicationJob" do
-        allow(EmailApplicationJob).to receive(:perform_later).
-          with(snap_application: current_app)
+        allow(EmailApplicationJob).to receive(:perform_later)
+
         params = { step: { email: "new_email@example.com" } }
 
         put :update, params: params
 
         expect(EmailApplicationJob).to have_received(:perform_later).
-          with(snap_application: current_app)
+          with(snap_application_id: current_app.id)
       end
     end
 

--- a/spec/jobs/fax_application_job_spec.rb
+++ b/spec/jobs/fax_application_job_spec.rb
@@ -2,70 +2,37 @@ require "rails_helper"
 
 RSpec.describe FaxApplicationJob do
   describe "#perform" do
-    it "creates a PDF with the snap application data" do
+    it "sends a fax when the application hasn't been faxed already" do
       snap_application = create(:snap_application, :with_member)
-      tempfile = Tempfile.new("send_application_job_spec")
-      pdf_double = double(completed_file: tempfile)
-      allow(Dhs1171Pdf).to receive(:new).
-        with(snap_application: snap_application).
-        and_return(pdf_double)
-
-      FaxApplicationJob.new.perform(snap_application_id: snap_application.id)
-
-      expect(pdf_double).to have_received(:completed_file)
-      expect(Dhs1171Pdf).to have_received(:new).
-        with(snap_application: snap_application)
-
-      tempfile.close
-      tempfile.unlink
-    end
-
-    it "sends a fax" do
-      snap_application = create(:snap_application, :with_member)
-      tempfile = Tempfile.new("send_application_job_spec")
-      file_path = tempfile.path
-      pdf_double = double(completed_file: tempfile)
-      allow(Dhs1171Pdf).to receive(:new).
-        with(snap_application: snap_application).
-        and_return(pdf_double)
 
       job = FaxApplicationJob.new
-      allow(job).to receive(:fax_number).and_return("+15550001111")
-      allow(job).to receive(:fax_recipient_name).and_return("John Doe")
 
-      allow(Fax).to receive(:send_fax).
-        with(number: "+15550001111", file: file_path, recipient: "John Doe")
+      allow(Fax).to receive(:send_fax)
+      recipient = FaxRecipient.new(residential_address:
+                                   snap_application.residential_address)
 
       job.perform(snap_application_id: snap_application.id)
 
       snap_application.reload
+
       expect(snap_application).to be_faxed
 
       expect(Fax).to have_received(:send_fax).
-        with(number: "+15550001111", file: file_path, recipient: "John Doe")
+        with(hash_including(number: recipient.number,
+                            recipient: recipient.name))
     end
 
     it "doesnt send a fax if application has already been sent" do
       snap_application = create(:snap_application, :with_member)
-      tempfile = Tempfile.new("send_application_job_spec")
-      file_path = tempfile.path
-      pdf_double = double(completed_file: tempfile)
-      allow(Dhs1171Pdf).to receive(:new).
-        with(snap_application: snap_application).
-        and_return(pdf_double)
-
       job = FaxApplicationJob.new
-      allow(job).to receive(:fax_number).and_return("+15550001111")
-      allow(job).to receive(:fax_recipient_name).and_return("John Doe")
 
-      allow(Fax).to receive(:send_fax).
-        with(number: "+15550001111", file: file_path, recipient: "John Doe")
+      allow(Fax).to receive(:send_fax)
 
       snap_application.update(faxed_at: Time.zone.now)
+
       job.perform(snap_application_id: snap_application.id)
 
-      expect(Fax).not_to have_received(:send_fax).
-        with(number: "+15550001111", file: file_path, recipient: "John Doe")
+      expect(Fax).not_to have_received(:send_fax)
     end
   end
 end

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -1,6 +1,17 @@
 require "rails_helper"
 
 RSpec.describe SnapApplication do
+  describe "#pdf" do
+    it "delegates to the Dhs1171Pdf class" do
+      app = build(:snap_application)
+
+      fake_pdf_builder = double(completed_file: "I am fake. It's OK")
+      allow(Dhs1171Pdf).to receive(:new).with(snap_application: app).
+        and_return(fake_pdf_builder)
+
+      expect(app.pdf).to eql(fake_pdf_builder.completed_file)
+    end
+  end
   describe "#gross_income" do
     context "no members" do
       it "adds all sources of income" do


### PR DESCRIPTION
@jessieay made the good point that we want our export jobs to be consistent; so I took some time to:

1. Pull up the shared behavior of PDF generation into the SnapApplication (and test it there)
2. Simplify the tests to focus on the behavior of the export
3. Simplify the Jobs themselves now that the SnapApplication owns the PDF itself.