### PR TITLE
Update style of success page

### DIFF
--- a/app/assets/stylesheets/michigan-benefits/atoms/_typography.scss
+++ b/app/assets/stylesheets/michigan-benefits/atoms/_typography.scss
@@ -2,3 +2,8 @@
   color: $color-sky;
   font-weight: 600;
 }
+
+.text--little-help {
+  font-size: 14px;
+  color: $color-grey;
+}

--- a/app/steps/success.rb
+++ b/app/steps/success.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 class Success < Step
-  step_attributes :email, :faxed_at
+  step_attributes :email, :signed_at
 
   validates :email,
     presence: { message: "Make sure to provide an email address" }
 
   def submitted_date
-    if faxed_at.present?
-      faxed_at.strftime("%m-%d-%Y")
+    if signed_at.present?
+      signed_at.strftime("%m-%d-%Y")
     end
   end
 end

--- a/app/steps/success.rb
+++ b/app/steps/success.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
 class Success < Step
-  step_attributes :email
+  step_attributes :email, :faxed_at
 
   validates :email,
     presence: { message: "Make sure to provide an email address" }
+
+  def submitted_date
+    if faxed_at.present?
+      faxed_at.strftime("%m-%d-%Y")
+    end
+  end
 end

--- a/app/views/success/edit.html.erb
+++ b/app/views/success/edit.html.erb
@@ -3,9 +3,22 @@
 <div class="form-card">
   <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
     <header class="form-card__header">
+      <div class="illustration illustration--success"></div>
+      <div class="pre-title">Congratulations</div>
       <div class="form-card__title">
-        Your Michigan Benefits application is ready to be submitted!
+        Your application has been successfully submitted.
       </div>
+      <div class="text--help text--centered">
+        Submitted to MDHHS on <%= @step.submitted_date %>.
+      </div>
+
+      <div class="text--caps text--centered text--little-help nudge--med">
+        You applied for
+      </div>
+      <label class="program-selector program-selector__unbordered">
+        <div class="illustration illustration--icn_food"></div>
+        <h4 class="program-selector__title">Food Assistance</h4>
+      </label>
     </header>
 
     <div class="form-card__content form-card__expect_next">

--- a/spec/steps/success_spec.rb
+++ b/spec/steps/success_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 RSpec.describe PersonalDetail do
   describe "#submitted_date" do
-    context "faxed_at present" do
+    context "signed_at present" do
       it "returns a formatted date" do
-        step = Success.new(faxed_at: DateTime.parse("January 30, 1900"))
+        step = Success.new(signed_at: DateTime.parse("January 30, 1900"))
 
         expect(step.submitted_date).to eq "01-30-1900"
       end
     end
 
-    context "faxed_at not present" do
+    context "signed_at not present" do
       it "returns nil" do
-        step = Success.new(faxed_at: nil)
+        step = Success.new(signed_at: nil)
 
         expect(step.submitted_date).to eq nil
       end

--- a/spec/steps/success_spec.rb
+++ b/spec/steps/success_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe PersonalDetail do
+  describe "#submitted_date" do
+    context "faxed_at present" do
+      it "returns a formatted date" do
+        step = Success.new(faxed_at: DateTime.parse("January 30, 1900"))
+
+        expect(step.submitted_date).to eq "01-30-1900"
+      end
+    end
+
+    context "faxed_at not present" do
+      it "returns nil" do
+        step = Success.new(faxed_at: nil)
+
+        expect(step.submitted_date).to eq nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Iconography/Illustration at the top
- "Blue Text" that says "Congratulations"
- Change the headline text
- Include subheader text that gives the client the date submitted.
- Include the specification of which program was submitted, using the icons that represent the FAP program (found on the homepage as well).

<img width="861" alt="screen shot 2017-08-30 at 10 45 20 am" src="https://user-images.githubusercontent.com/601515/29887171-6bb048e0-8d71-11e7-93bf-8afb084c0d12.png">
