### PR TITLE
Use numeric keyboard on mobile for number fields

### DIFF
--- a/app/views/contact_information/edit.html.erb
+++ b/app/views/contact_information/edit.html.erb
@@ -9,7 +9,11 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_input_field :phone_number, "What is the best phone number to reach you?" %>
+      <%= f.mb_input_field :phone_number,
+        "What is the best phone number to reach you?",
+        type: :tel,
+        autofocus: true,
+        options: { maxlength: 10 } %>
       <%= f.mb_radio_set :sms_subscribed,
           'May we send text messages to that phone number help you through the enrollment process?',
           [{ value: true, label: "Yes" }, { value: false, label: "No" }],

--- a/app/views/expenses_additional/edit.html.erb
+++ b/app/views/expenses_additional/edit.html.erb
@@ -21,7 +21,8 @@
 
           <fieldset class="form-group">
             <%= f.mb_money_field :monthly_care_expenses,
-              "In total, how much do you pay in care expenses each month?" %>
+              "In total, how much do you pay in care expenses each month?",
+              autofocus: true %>
 
             <%= f.mb_checkbox_set [
               { method: :childcare, label: "Childcare" },

--- a/app/views/expenses_housing/edit.html.erb
+++ b/app/views/expenses_housing/edit.html.erb
@@ -19,7 +19,8 @@
           url: current_path,
           method: :put do |f| %>
         <%= f.mb_money_field :rent_expense,
-        "How much does your household pay in rent or mortgage each month?" %>
+          "How much does your household pay in rent or mortgage each month?",
+          autofocus: true %>
 
         <%= f.mb_money_field :property_tax_expense,
         "How much do you pay in property tax each month?" %>

--- a/app/views/household_add_member/edit.html.erb
+++ b/app/views/household_add_member/edit.html.erb
@@ -26,6 +26,8 @@
       <%= f.mb_date_select :birthday, "What is their birthday?", { options: { start_year: 1900, end_year: Time.now.year, default: Date.new(1990,1,15), order: [:month, :day, :year] } } %>
       <%= f.mb_input_field :ssn,
         'What is their social security number?',
+        type: :tel,
+        options: { maxlength: 9 },
         notes: ["If they don’t have one or you don’t know it you can skip this"],
         append_html: "<p class='text--secure'><i class='illustration illustration--safety'></i>Social security numbers help ensure you receive the correct benefits. MDHSS maintains strict security guidelines to protect the identities of our residents.</p>" %>
       <%= f.mb_radio_set :requesting_food_assistance,

--- a/app/views/household_add_member/edit.html.erb
+++ b/app/views/household_add_member/edit.html.erb
@@ -12,7 +12,9 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path(member_id: member_id), method: :put do |f| %>
-      <%= f.mb_input_field :first_name, "What is their first name?" %>
+      <%= f.mb_input_field :first_name,
+        "What is their first name?",
+        autofocus: true %>
       <%= f.mb_input_field :last_name, "What is their last name?" %>
       <%= f.mb_radio_set :sex,
         'What is their sex?',

--- a/app/views/income_details_per_member/edit.html.erb
+++ b/app/views/income_details_per_member/edit.html.erb
@@ -16,7 +16,9 @@
               <p class="text--section-header"><%= member.full_name %> (<%= member.employment_status.titleize %>)</p>
               <% if member.employed? %>
                 <%= ff.mb_input_field :employed_employer_name, "Employer name" %>
-                <%= ff.mb_input_field :employed_hours_per_week, "Usual hours per week" %>
+                <%= ff.mb_input_field :employed_hours_per_week,
+                  "Usual hours per week",
+                  type: :tel %>
                 <%= ff.mb_money_field :employed_pay_quantity,
                   "Pay (before tax)",
                   notes: ["This includes money withheld from paychecks"] %>

--- a/app/views/income_other_assets_continued/edit.html.erb
+++ b/app/views/income_other_assets_continued/edit.html.erb
@@ -15,7 +15,8 @@
       method: :put do |f| %>
 
       <%= f.mb_money_field :total_money,
-        "In total, how much money does your household have in cash and accounts?" %>
+        "In total, how much money does your household have in cash and accounts?",
+        autofocus: true %>
 
       <%= f.mb_checkbox_set [
         { method: :checking_account, label: 'Checking account' },

--- a/app/views/introduce_yourself/edit.html.erb
+++ b/app/views/introduce_yourself/edit.html.erb
@@ -9,7 +9,9 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_input_field :first_name, "What is your first name?" %>
+      <%= f.mb_input_field :first_name,
+        "What is your first name?",
+        autofocus: true %>
       <%= f.mb_input_field :last_name, "What is your last name?" %>
       <%= f.mb_date_select :birthday, "What is your birthday?", { options: { start_year: 1900, end_year: Time.now.year, default: Date.new(1990,1,15), order: [:month, :day, :year] } } %>
       <%= render partial: 'shared/next_step' %>

--- a/app/views/mailing_address/edit.html.erb
+++ b/app/views/mailing_address/edit.html.erb
@@ -9,9 +9,7 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_input_field :street_address, "Address", options:  { placeholder: "123 Main St." } %>
-      <%= f.mb_input_field :city, "City", options:  { placeholder: "Flint" } %>
-      <%= f.mb_input_field :zip, "ZIP code", options:  { placeholder: "12345" } %>
+      <%= render "shared/address", f: f %>
       <%= f.mb_radio_set :mailing_address_same_as_residential_address,
           'Is this address the same as your home address?',
           [{ value: true, label: "Yes" }, { value: false, label: "No" }],

--- a/app/views/personal_detail/edit.html.erb
+++ b/app/views/personal_detail/edit.html.erb
@@ -20,6 +20,8 @@
         include_blank: "Choose one" %>
       <%= f.mb_input_field :ssn,
       'What is your social security number?',
+      type: :tel,
+      options: { maxlength: 9 },
       notes: ["If you don't have one or don't want to answer now it's okay to skip this"],
       append_html: "<p class='text--secure'><i class='illustration illustration--safety'></i>Social security numbers help ensure you receive the correct benefits. MDHSS maintains strict security guidelines to protect the identities of our residents.</p>" %>
 

--- a/app/views/residential_address/edit.html.erb
+++ b/app/views/residential_address/edit.html.erb
@@ -9,9 +9,7 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_input_field :street_address, "Address" %>
-      <%= f.mb_input_field :city, "City" %>
-      <%= f.mb_input_field :zip, "ZIP code", options: { maxlength: 5 } %>
+      <%= render "shared/address", f: f %>
       <%= f.mb_checkbox_set [{ label: 'Check this box if you do not have a stable address', method: :unstable_housing }],
         label_text: '' %>
       <%= render 'shared/next_step' %>

--- a/app/views/shared/_address.html.erb
+++ b/app/views/shared/_address.html.erb
@@ -1,0 +1,3 @@
+<%= f.mb_input_field :street_address, "Address", autofocus: true %>
+<%= f.mb_input_field :city, "City" %>
+<%= f.mb_input_field :zip, "ZIP code", type: :tel, options: { maxlength: 5 } %>

--- a/app/views/sign_and_submit/edit.html.erb
+++ b/app/views/sign_and_submit/edit.html.erb
@@ -13,7 +13,10 @@
       FAP, that you have been honest on this application.
     </p>
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_input_field :signature, "Your signature", options: { placeholder: "Your full legal name" } %>
+      <%= f.mb_input_field :signature,
+        "Your signature",
+        autofocus: true,
+        options: { placeholder: "Your full legal name" } %>
       <%= render 'shared/next_step', button_label: "Sign and submit" %>
     <% end %>
   </div>


### PR DESCRIPTION
**WHY**: easier to use!

Note that money fields already use this because we set `type: tel` in
the money input helper method (I confirmed that this worked on mobile)

Minor: extracted shared partial for addresses since I noticed that our
two address forms were already diverging in some small ways.
