### PR TITLE
Fallback office is clio, fix unions number

### DIFF
--- a/config/offices.yml
+++ b/config/offices.yml
@@ -49,8 +49,9 @@ development:
       fax_number: "+16173963015"
 production:
   <<: *defaults
+  fallback_office: "clio"
   offices:
     union:
-      fax_number: "+18107602021"
+      fax_number: "+18107607372"
     clio:
       fax_number: "+18107602310"

--- a/spec/models/fax_recipient_spec.rb
+++ b/spec/models/fax_recipient_spec.rb
@@ -36,14 +36,14 @@ RSpec.describe FaxRecipient do
         residential_address = double(zip: "48411")
         fax_recipient = described_class.new(residential_address:
                                               residential_address)
-        expect(fax_recipient.number).to eql "+18107602021"
+        expect(fax_recipient.number).to eql "+18107607372"
       end
 
-      it "falls back to the union office" do
+      it "falls back to the clio office" do
         residential_address = double(zip: "123456")
         fax_recipient = described_class.new(residential_address:
                                               residential_address)
-        expect(fax_recipient.number).to eql "+18107602021"
+        expect(fax_recipient.number).to eql "+18107602310"
       end
     end
   end


### PR DESCRIPTION
#### Why?
Because [Lena said that union doesn't frequently check their fax and hasn't had training](https://cfa.slack.com/archives/C4BRQQEUU/p1504196503000049), while Clio has.

Also, because Unions fax number was wrong :X :X :X