### PR TITLE
Typo Fix

### DIFF
--- a/app/models/dhs1171_pdf.rb
+++ b/app/models/dhs1171_pdf.rb
@@ -2,9 +2,9 @@ class Dhs1171Pdf
   PDF_DIRECTORY = "lib/pdfs".freeze
   SOURCE_PDF = "#{PDF_DIRECTORY}/DHS_1171.pdf".freeze
   COVERSHEET_PDF = "#{PDF_DIRECTORY}/michigan_snap_fax_cover_letter.pdf".freeze
-  MAXIMUMUM_HOUSEHOLD_MEMBERS = 6
-  MAXIMUMUM_EMPLOYED_MEMBERS = 2
-  MAXIMUMUM_SELF_EMPLOYED_MEMBERS = 2
+  MAXIMUM_HOUSEHOLD_MEMBERS = 6
+  MAXIMUM_EMPLOYED_MEMBERS = 2
+  MAXIMUM_SELF_EMPLOYED_MEMBERS = 2
 
   def initialize(snap_application:)
     @snap_application = snap_application
@@ -50,7 +50,7 @@ class Dhs1171Pdf
   end
 
   def additional_household_member_pages
-    if application_members.length > MAXIMUMUM_HOUSEHOLD_MEMBERS
+    if application_members.length > MAXIMUM_HOUSEHOLD_MEMBERS
       SnapApplicationExtraMemberPdf.new(
         members: additional_members,
         attributes_class: ExtraMemberAttributes,
@@ -60,7 +60,7 @@ class Dhs1171Pdf
   end
 
   def additional_employed_pages
-    if employed_members.length > MAXIMUMUM_EMPLOYED_MEMBERS
+    if employed_members.length > MAXIMUM_EMPLOYED_MEMBERS
       SnapApplicationExtraMemberPdf.new(
         members: additional_employed_members,
         attributes_class: ExtraEmployedMemberAttributes,
@@ -70,7 +70,7 @@ class Dhs1171Pdf
   end
 
   def additional_self_employed_pages
-    if self_employed_members.length > MAXIMUMUM_SELF_EMPLOYED_MEMBERS
+    if self_employed_members.length > MAXIMUM_SELF_EMPLOYED_MEMBERS
       SnapApplicationExtraMemberPdf.new(
         members: additional_self_employed_members,
         attributes_class: ExtraSelfEmployedMemberAttributes,

--- a/app/models/snap_application_attributes.rb
+++ b/app/models/snap_application_attributes.rb
@@ -212,42 +212,42 @@ class SnapApplicationAttributes
 
   def more_than_six_members_yes
     bool_to_checkbox(
-      snap_application.members.length > Dhs1171Pdf::MAXIMUMUM_HOUSEHOLD_MEMBERS,
+      snap_application.members.length > Dhs1171Pdf::MAXIMUM_HOUSEHOLD_MEMBERS,
     )
   end
 
   def more_than_six_members_no
     bool_to_checkbox(
       snap_application.members.length <=
-        Dhs1171Pdf::MAXIMUMUM_HOUSEHOLD_MEMBERS,
+        Dhs1171Pdf::MAXIMUM_HOUSEHOLD_MEMBERS,
     )
   end
 
   def more_than_two_self_employed_yes
     bool_to_checkbox(
       self_employed_household_members.length >
-        Dhs1171Pdf::MAXIMUMUM_SELF_EMPLOYED_MEMBERS,
+        Dhs1171Pdf::MAXIMUM_SELF_EMPLOYED_MEMBERS,
     )
   end
 
   def more_than_two_self_employed_no
     bool_to_checkbox(
       self_employed_household_members.length <=
-        Dhs1171Pdf::MAXIMUMUM_SELF_EMPLOYED_MEMBERS,
+        Dhs1171Pdf::MAXIMUM_SELF_EMPLOYED_MEMBERS,
     )
   end
 
   def more_than_two_employed_yes
     bool_to_checkbox(
       employed_household_members.length >
-        Dhs1171Pdf::MAXIMUMUM_EMPLOYED_MEMBERS,
+        Dhs1171Pdf::MAXIMUM_EMPLOYED_MEMBERS,
     )
   end
 
   def more_than_two_employed_no
     bool_to_checkbox(
       employed_household_members.length <=
-        Dhs1171Pdf::MAXIMUMUM_EMPLOYED_MEMBERS,
+        Dhs1171Pdf::MAXIMUM_EMPLOYED_MEMBERS,
     )
   end
 


### PR DESCRIPTION
Reason for Change
=================
* `MAXIMUMUM` is a misspelling

Changes
=======
* Correct typo.
