### PR TITLE
Filter out ssns from logging statements in params

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,6 @@ module MichiganBenefits
     config.active_job.queue_adapter = :delayed_job
 
     config.autoload_paths << Rails.root.join("app/steps")
+    config.filter_parameters += [:ssn]
   end
 end


### PR DESCRIPTION
### Why?
Logging social security numbers is A Bad Idea