### PR TITLE
Install foreman as part of bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -8,8 +8,12 @@ chdir APP_ROOT do
   # Add necessary setup steps to this file.
 
   step "Installing dependencies" do
-    system! "gem install bundler --conservative"
+    system!("gem install bundler --conservative")
     system("bundle check") || system!("bundle install")
+  end
+
+  step "Installing foreman for controlling local servers" do
+    system!("gem install foreman")
   end
 
   step "Installing pdftk, a PDF library (requires Homebrew)" do


### PR DESCRIPTION
Reason for Change
=================
* It is required for local development but NOT in the Gemfile.
* This could be confusing.
* Why not just set it up in `bin/setup`?

Changes
=======
* Add a step to install the `foreman` gem.