### PR TITLE
Fix bin/setup chromedriver check

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -25,7 +25,9 @@ chdir APP_ROOT do
   end
 
   step "Installing ChromeDriver - a separate executable that WebDriver uses to control Chrome" do
-    if cli_installed?("chromedriver")
+    # use --version flag because running `chromedriver` will start
+    # chromedriver, which stops the script indefinitely if already installed.
+    if cli_installed?("chromedriver --version")
       puts "chromedriver already installed."
     else
       system!("brew install chromedriver")

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 dependencies:
   pre:
     - sudo apt-get update; sudo apt-get install pdftk
-    - wget https://chromedriver.storage.googleapis.com/2.30/chromedriver_linux64.zip
+    - wget https://chromedriver.storage.googleapis.com/2.32/chromedriver_linux64.zip
     - unzip chromedriver_linux64.zip
     - sudo cp chromedriver /usr/local/bin/chromedriver
     - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb


### PR DESCRIPTION
**WHY**: The system command `chromedriver` starts up chromedriver, which
causes the setup script to hang indefinitely if chromedriver is already
installed.