### PR TITLE
Click through benefits and fill in personal info

### DIFF
--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -6,10 +6,6 @@ require "capybara/drivers/headless_chrome"
 
 module MiBridges
   class Driver
-    DEMO_SETUP = [
-      GoogleSearchPage,
-    ].freeze
-
     SIGN_UP_FLOW = [
       HomePage,
       CreateAccountPage,
@@ -41,7 +37,7 @@ module MiBridges
     def run
       setup
 
-      page_classes = DEMO_SETUP + SIGN_UP_FLOW + APPLY_FLOW
+      page_classes = SIGN_UP_FLOW + APPLY_FLOW
 
       page_classes.each do |klass|
         page = klass.new(@snap_application)

--- a/lib/mi_bridges/driver/benefits_selector_page.rb
+++ b/lib/mi_bridges/driver/benefits_selector_page.rb
@@ -10,7 +10,9 @@ module MiBridges
         click_id(no_dont_contact_my_energy_provider_radio)
       end
 
-      def continue; end
+      def continue
+        click_on "Next"
+      end
 
       private
 

--- a/lib/mi_bridges/driver/create_account_page.rb
+++ b/lib/mi_bridges/driver/create_account_page.rb
@@ -83,7 +83,9 @@ module MiBridges
       end
 
       def accept_user_agreement
-        page.execute_script("$('.ace').trigger('click')")
+        check_selector =
+          "div[aria-labelledby=\"Step4UserAcceptanceAgreement\"] input"
+        page.execute_script("$('#{check_selector}').click()")
       end
     end
   end

--- a/lib/mi_bridges/driver/personal_information_page.rb
+++ b/lib/mi_bridges/driver/personal_information_page.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class PersonalInformationPage < BasePage
+      delegate(
+        :primary_member,
+        :residential_address,
+        to: :snap_application,
+      )
+
+      def setup; end
+
+      def fill_in_required_fields
+        fill_in_name
+        click_on_gender
+        fill_in_birthday_fields
+        select_county
+        fill_in_address
+        click_same_address_answer
+        fill_in_phone_number
+      end
+
+      def continue
+        click_on "Next"
+        click_on "Next" if invalid_physical_address?
+      end
+
+      private
+
+      def fill_in_name
+        fill_in "First Name", with: primary_member.first_name
+        fill_in "Last Name", with: primary_member.last_name
+      end
+
+      def click_on_gender
+        click_id "gender_#{primary_member.sex.first.upcase}"
+      end
+
+      def fill_in_birthday_fields
+        month = padded(primary_member.birthday.month)
+        day = padded(primary_member.birthday.day)
+        year = primary_member.birthday.year
+
+        fill_in "monthgroupDateOfBirth", with: month
+        fill_in "dategroupDateOfBirth", with: day
+        fill_in "yeargroupDateOfBirth", with: year
+
+        fill_in "monthconfirmGroupDateOfBirth", with: month
+        fill_in "dateconfirmGroupDateOfBirth", with: day
+        fill_in "yearconfirmGroupDateOfBirth", with: year
+      end
+
+      def select_county
+        select residential_address.county, from: "whatCounty"
+      end
+
+      def fill_in_address
+        fill_in "Street Address",
+          with: residential_address.street_address
+        fill_in "City",
+          with: residential_address.city
+        fill_in "Zip Code",
+          with: residential_address.zip
+      end
+
+      def click_same_address_answer
+        if snap_application.mailing_address_same_as_residential_address?
+          same_address_letter = "Y"
+        else
+          same_address_letter = "N"
+        end
+
+        click_id "mailInSameAddress_#{same_address_letter}"
+      end
+
+      def fill_in_phone_number
+        return if snap_application.phone_number.blank?
+
+        phone_number = snap_application.phone_number
+        fill_in "phone1homePhone", with: phone_number[0..2]
+        fill_in "phone2homePhone", with: phone_number[3..5]
+        fill_in "phone3homePhone", with: phone_number[6..9]
+
+        select "Home Phone", from: "bestWayToGetInTouch"
+      end
+
+      def padded(int)
+        sprintf("%02d", int)
+      end
+
+      def invalid_physical_address?
+        has_content? "You've entered an invalid physical address"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/program_benefits_page.rb
+++ b/lib/mi_bridges/driver/program_benefits_page.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class ProgramBenefitsPage < BasePage
+      def setup; end
+
+      def fill_in_required_fields; end
+
+      def continue
+        click_on "Next"
+      end
+    end
+  end
+end


### PR DESCRIPTION
There are two benefit overview pages that the driver can click through
before coming to a more involved form page where they enter personal
information:

* Name
* Gender
* Birth date
* Address/Location
* Phone number

If the client has an address that MIBridges considers an invalid physical
address it will re-display that personal information page and confirm that
the client *still* wants to submit with that street address. If so, this
will confirm that this is, indeed, the address we would like to continue
with.

Also...
-------

* Use more specific selector for agreement checkbox
* Remove demo preable w/google search page. For demo purposes we had the driver
  go to Google to search for MI Bridges before starting an application. For
  purposes of actually driving the application, however, we do not need this. So,
  let's remove it.