### PR TITLE
Fix the document uploading UX

### DIFF
--- a/app/assets/javascripts/upload_setup.js
+++ b/app/assets/javascripts/upload_setup.js
@@ -7,12 +7,11 @@ var uploadSetup = function (previewTemplate) {
     previewTemplate: previewTemplate,
     acceptedFiles: '.pdf,.jpg,.jpeg,.png,.gif',
     maxFilesize: 3, // MB
-    error: function (_file, msg) {
+    error: function (file, msg) {
       window.alert(msg)
+      $(file.previewElement).remove()
     },
-    success: function (f) {
-      $('.button--next').removeAttr('disabled')
-
+    success: function (file) {
       var button = $('#click-to-upload')
       var buttonHtml = button.html()
       button.html(buttonHtml.replace('Upload documents', 'Upload more documents'))
@@ -20,11 +19,19 @@ var uploadSetup = function (previewTemplate) {
       var source = $('#form-card__documents__handlebars_template').html()
       var template = window.Handlebars.compile(source)
       var context = {
-        url: f.s3url,
-        filename: f.s3url.split('/').reverse()[0]
+        url: file.s3url,
+        filename: file.s3url.split('/').reverse()[0]
       }
+
       var html = template(context)
+      $(file.previewElement).remove()
       $('#form-card__documents').append(html)
+    },
+    addedfile: function () {
+      $('[data-done-uploading]').attr('disabled', true)
+    },
+    queuecomplete: function () {
+      $('[data-done-uploading]').removeAttr('disabled')
     }
   })
 

--- a/app/assets/stylesheets/atoms/_buttons.scss
+++ b/app/assets/stylesheets/atoms/_buttons.scss
@@ -41,6 +41,11 @@
   &:active {
     background-color: shade($button-cta-color, 15%);
   }
+
+  &[disabled] {
+    opacity: .5;
+    cursor: not-allowed;
+  }
 }
 
 .button--primary {

--- a/app/assets/stylesheets/organisms/_document-preview.scss
+++ b/app/assets/stylesheets/organisms/_document-preview.scss
@@ -16,13 +16,14 @@
 }
 
 .doc-preview__thumb {
-  position: absolute;
-  top: 0;
-  right: 0;
-  width: 75px;
-  height: 75px;
+  background-size: cover;
   border: 1px solid $color-tan;
   border-radius: $border-radius;
+  height: 75px;
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: 75px;
 }
 
 .document-upload {

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -43,7 +43,7 @@
           Upload documents
         </button>
 
-        <button class="button button--next button--cta button--full-width" type="submit">
+        <button class="button button--next button--cta button--full-width" type="submit" data-done-uploading>
           Done uploading documents
         </button>
       </div>


### PR DESCRIPTION
## Problem

When adding documents to an application, there is a duplication of
elements - the first being the "preview" and the second being the final
uploaded image/file.

## Solution

When an upload is sucessful or results in an error, the preview element
is removed from the DOM.

## Problem

As files are being uploaded, the "done uploading" button is able to be
clicked before things are completely finished uploading. This will
occasionally result in the form being submitted before a/some file(s)
are completely uploaded.

## Solution
The "DONE" button is disabled until uploading is finished.

# Demo

![](http://g.recordit.co/Yqu8Kw9eou.gif)