### PR TITLE
Change log level to 'info' in prod env

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -10,7 +10,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
   config.assets.js_compressor = :uglifier
   config.assets.compile = false
-  config.log_level = :debug
+  config.log_level = :info
   config.log_tags = [:request_id]
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
**WHY**: `debug` is the most verbose level of logging and includes SQL
logs, which was resulting in logging of our `encrypted_ssn_in`, which is
a potential security risk.

With `info`, the second most verbose level, there is no SQL logging. It
is also the default for production in Rails, so that seems like a good
place to go.

Reference:
* http://guides.rubyonrails.org/v3.2/debugging_rails_applications.html#log-levels