### PR TITLE
Refactor js that warns when exiting application

### DIFF
--- a/app/assets/javascripts/form_exit.js.erb
+++ b/app/assets/javascripts/form_exit.js.erb
@@ -5,10 +5,20 @@
     if(outsideOfSteps) return;
 
     for(var i=0; i<links.length; i++){
-      var stepsLink = links[i].href.indexOf('steps') >= 0
-      var skipLink = links[i].href.indexOf('skip_') >= 0
+      var isAnExternalLink = true
+      var whiteList = [
+        '/privacy',
+        '/steps',
+        '/terms',
+        'skip_'
+      ]
+      for(var j=0; j<whiteList.length; j++){
+        if(links[i].href.indexOf(whiteList[j]) >= 0){
+          isAnExternalLink = false
+        }
+      }
 
-      if(!stepsLink && !skipLink){
+      if(isAnExternalLink){
         links[i].addEventListener('click', function(event){
           if (!w.confirm('<%= I18n.t("javascript.exit_app_confirmation")%>')) {
             event.preventDefault()


### PR DESCRIPTION
Since we have several new links that need to be accounted for -- namely
privacy and terms -- this JS can/should be changed to be more amenable
to changes.

This update creates a whitelist of strings that the js will look for
and, if the link contains any of those strings, it will not consider it
an external link.

TLDR, if these are substrings of something you click, the warning
message won't pop up.

![](http://g.recordit.co/CDQlsa6XlJ.gif)