### PR TITLE
Make mobile layout fill width

### DIFF
--- a/app/assets/stylesheets/atoms/_base.scss
+++ b/app/assets/stylesheets/atoms/_base.scss
@@ -19,8 +19,8 @@ body {
 
 .page-wrapper {
   overflow: hidden;
-  padding-left: $site-margins/2;
-  padding-right: $site-margins/2;
+  padding-left: 0px;
+  padding-right: 0px;
 
   @include media($tablet-up) {
     padding-left: $site-margins;


### PR DESCRIPTION
Reason for Change
===================
* Make mobile layout full width
* https://trello.com/c/UliifK3D/235-sitewide-full-width-mobile-layout

Changes
=======
* Remove left/right padding on mobile

![screen shot 2017-09-08 at 10 55 37 am](https://user-images.githubusercontent.com/7483074/30222617-9a999c0a-9484-11e7-88e6-f208ac3a5985.png)

