### PR TITLE
Fix padding on bulleted lists

### DIFF
--- a/app/assets/stylesheets/atoms/_typography.scss
+++ b/app/assets/stylesheets/atoms/_typography.scss
@@ -129,6 +129,9 @@ ol, ul {
   li {
     margin-bottom: .5em;
   }
+  p {
+    margin-bottom: 0px;
+  }
 }
 
 .list--numbered {


### PR DESCRIPTION
Reason for Change
===================
* Reduce padding on bulleted lists
* https://trello.com/c/h97Zmaja/233-household-introduction-fix-padding-on-subheaders

![screen shot 2017-09-08 at 11 07 30 am](https://user-images.githubusercontent.com/7483074/30222969-2756408e-9486-11e7-8c94-e6302334292d.png)

