### PR TITLE
Enforce SSL on production-like environments

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,6 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception. For APIs, you may want to use
   # :null_session instead.
   protect_from_forgery with: :exception
-  force_ssl if: -> { Feature.ssl? }
 
   respond_to :html
 

--- a/app/lib/feature.rb
+++ b/app/lib/feature.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class Feature
-  def self.ssl?
-    enabled? "SSL"
-  end
-
   def self.enabled?(feature)
     ENV["#{feature}_ENABLED"] == "true"
   end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,6 +3,8 @@
 require Rails.root.join("config/smtp")
 
 Rails.application.configure do
+  config.force_ssl = true
+
   config.cache_classes = true
   config.eager_load = true
   config.consider_all_requests_local       = false
@@ -34,14 +36,4 @@ Rails.application.configure do
   end
 
   config.active_record.dump_schema_after_migration = false
-
-  config.paperclip_defaults = {
-    storage: :s3,
-    s3_region: ENV["BUCKETEER_REGION"],
-    s3_credentials: {
-      bucket: ENV["BUCKETEER_BUCKET_NAME"],
-      access_key_id: ENV["BUCKETEER_AWS_ACCESS_KEY_ID"],
-      secret_access_key: ENV["BUCKETEER_AWS_SECRET_ACCESS_KEY"],
-    },
-  }
 end


### PR DESCRIPTION
**Why?** Because we're dealing with hella sensitive data here; so HTTPS should be the de-rigor.