### PR TITLE
Add error message for small photo sizes

### DIFF
--- a/app/assets/javascripts/upload_setup.js
+++ b/app/assets/javascripts/upload_setup.js
@@ -6,7 +6,7 @@ var uploadSetup = function (previewTemplate) {
     clickable: '#click-to-upload',
     previewTemplate: previewTemplate,
     acceptedFiles: '.pdf,.jpg,.jpeg,.png,.gif',
-    maxFilesize: 3, // MB
+    maxFilesize: 8, // MB
     error: function (file, msg) {
       window.alert(msg)
       $(file.previewElement).remove()

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -16,4 +16,8 @@ end
   </div>
   <div class="doc-preview__thumb" style="background-image: url('<%= doc_url %>')">
   </div>
+  <p class="text--error">
+    <i class="icon-warning"></i>
+    The image you uploaded is less than 2MB, and may not be readable. Please be aware that you may be asked to provide the document again.
+  </p>
 </div>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -16,7 +16,7 @@ end
   </div>
   <div class="doc-preview__thumb" style="background-image: url('<%= doc_url %>')">
   </div>
-  <p class="text--error">
+  <p data='error-type-too-large' class="text--error hide">
     <i class="icon-warning"></i>
     The image you uploaded is less than 2MB, and may not be readable. Please be aware that you may be asked to provide the document again.
   </p>


### PR DESCRIPTION
Reason for Change
===================
* Notify users when they upload a file smaller than 2MB
* https://trello.com/b/aBqTrqaJ/the-digital-assister-michiganbenefitsorg

Changes
=======
* Add error message

Note
=====
* This is only the copy and styles for the error message. These error messages still need to be implemented

cc: @jessieay 

![image](https://user-images.githubusercontent.com/7483074/30227455-fe63e1ca-9496-11e7-8932-0ea79fe71f12.png)
