### PR TITLE
Redirect to first step if there is no current app

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -4,7 +4,7 @@ class StepsController < ApplicationController
   layout "step"
 
   before_action :maybe_skip, only: :edit
-  before_action :ensure_application_present, only: :edit
+  before_action :ensure_application_present, only: %i(edit index)
 
   def self.to_param
     controller_path.dasherize
@@ -22,7 +22,7 @@ class StepsController < ApplicationController
 
   def ensure_application_present
     if current_snap_application.blank?
-      redirect_to root_path
+      redirect_to introduce_yourself_steps_path
     end
   end
 

--- a/spec/support/shared_examples/step_controller.rb
+++ b/spec/support/shared_examples/step_controller.rb
@@ -17,7 +17,7 @@ RSpec.shared_examples "step controller" do
 
           get :edit
 
-          expect(response).to redirect_to(root_path)
+          expect(response).to redirect_to(introduce_yourself_steps_path)
         end
       end
     end


### PR DESCRIPTION
**WHAT**: this changes redirect from root path to first step. It also
ensures that someone cannot visit '/steps' without a current snap app.

**WHY**:  Experience from new teammate that was confusing:
"If I tried to click on any of the links from /steps it kicks
back to the homepage (but it doesn’t actually throw an error)"
