### PR TITLE
Update design and flow for SMS consent

### DIFF
--- a/app/controllers/contact_confirm_phone_number_controller.rb
+++ b/app/controllers/contact_confirm_phone_number_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ContactConfirmPhoneNumberController < StandardStepsController
+  private
+
+  def skip?
+    current_snap_application && !current_snap_application.sms_subscribed?
+  end
+end

--- a/app/steps/contact_confirm_phone_number.rb
+++ b/app/steps/contact_confirm_phone_number.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class ContactConfirmPhoneNumber < Step
+  step_attributes(
+    :phone_number,
+  )
+
+  validates(
+    :phone_number,
+    ten_digit_phone_number: true,
+    presence: {
+      message: "Make sure to provide a phone number at which we can reach you",
+    },
+  )
+end

--- a/app/steps/step_navigation.rb
+++ b/app/steps/step_navigation.rb
@@ -35,6 +35,7 @@ class StepNavigation
     ],
     "General" => [
       ContactPreferenceController,
+      ContactConfirmPhoneNumberController,
       GeneralAnythingElseController,
     ],
     "Legal" => [

--- a/app/views/contact_confirm_phone_number/edit.html.erb
+++ b/app/views/contact_confirm_phone_number/edit.html.erb
@@ -1,0 +1,25 @@
+<% content_for :header_title, "Preferences" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="illustration illustration--confirmation-message"></div>
+    <div class="form-card__title">
+      Great! You'll receive a confirmation message soon.
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step,
+      as: :step,
+      builder: MbFormBuilder,
+      url: current_path,
+      method: :put do |f| %>
+      <%= f.mb_input_field :phone_number,
+        "Best number for text messages",
+        type: :tel,
+        autofocus: true,
+        options: { maxlength: 10 } %>
+
+    <%= render "shared/next_step" %>
+  <% end %>
+</div>

--- a/app/views/contact_preference/edit.html.erb
+++ b/app/views/contact_preference/edit.html.erb
@@ -5,8 +5,7 @@
     <div class="illustration illustration--section-4"></div>
     <div class="pre-title">Almost done!</div>
     <div class="form-card__title">
-      Would you like to receive reminds to help you through the enrollment
-      process?
+      Let's stay in touch so you don't miss a thing!
     </div>
   </header>
 
@@ -16,19 +15,15 @@
       builder: MbFormBuilder,
       url: current_path,
       method: :put do |f| %>
-      <%= f.mb_checkbox_set([
-        { method: :sms_subscribed, label: "Text message me" },
-        { method: :email_subscribed, label: "Email me" },
-      ],
-      label_text: "You'll receive messages about key steps and ways to submit
-      required documents. Let us know how you prefer to receive them. Select as
-      many options as you like.") %>
+    <%= f.mb_radio_set(
+      :sms_subscribed,
+      "Would you like text message reminders about key steps and documents required to help you through the enrollment process?",
+      [{ value: :true, label: "Yes" }, { value: :false, label: "No" }]) %>
 
     <p class='text--secure'>
     <i class='illustration illustration--safety'></i>
     No matter what, you will receive all official notices and legal information
-    via post mail to the address you provided. These e-mail and text message
-    reminders provide extra help.
+    via post mail.
     </p>
     <%= render "shared/next_step" %>
   <% end %>

--- a/spec/controllers/contact_confirm_phone_number_controller_spec.rb
+++ b/spec/controllers/contact_confirm_phone_number_controller_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe ContactConfirmPhoneNumberController do
+  let(:step) { assigns(:step) }
+  let(:invalid_params) { { step: { phone_number: "" } } }
+  let(:step_class) { ContactConfirmPhoneNumber }
+
+  include_examples "step controller", "param validation"
+
+  describe "#update" do
+    it "updates the phone number" do
+      session[:snap_application_id] = current_app.id
+      new_phone_number = "4443332222"
+      params = { step: { phone_number: new_phone_number } }
+
+      put :update, params: params
+
+      expect(current_app.reload.phone_number).to eq new_phone_number
+    end
+  end
+
+  def current_app
+    @_current_app ||= create(
+      :snap_application,
+      sms_subscribed: true,
+      phone_number: "2223334444",
+    )
+  end
+end

--- a/spec/controllers/contact_preference_controller_spec.rb
+++ b/spec/controllers/contact_preference_controller_spec.rb
@@ -14,32 +14,23 @@ RSpec.describe ContactPreferenceController do
       get :edit
 
       expect(step.sms_subscribed).to eq false
-      expect(step.email_subscribed).to eq true
     end
   end
 
   describe "#update" do
     context "when valid" do
       it "updates the current app and redirects to the next step" do
-        valid_params = {
-          sms_subscribed: "t",
-          email_subscribed: "f",
-        }
+        valid_params = { sms_subscribed: "true" }
 
         put :update, params: { step: valid_params }
 
         expect(current_app.reload.sms_subscribed).to eq true
-        expect(current_app.reload.email_subscribed).to eq false
-        expect(response).to redirect_to("/steps/general-anything-else")
+        expect(response).to redirect_to("/steps/contact-confirm-phone-number")
       end
     end
   end
 
   def current_app
-    @_current_app ||= create(
-      :snap_application,
-      sms_subscribed: false,
-      email_subscribed: true,
-    )
+    @_current_app ||= create(:snap_application, sms_subscribed: false)
   end
 end

--- a/spec/features/snap_app_spec.rb
+++ b/spec/features/snap_app_spec.rb
@@ -145,8 +145,14 @@ accounts?",
     submit_expenses
 
     on_page "Preferences" do
-      check "Text message me"
-      check "Email me"
+      choose_yes(
+        "Would you like text message reminders about key steps and documents" +
+        " required to help you through the enrollment process?",
+      )
+      click_on "Continue"
+    end
+
+    on_page "Preferences" do
       click_on "Continue"
     end
 
@@ -251,6 +257,10 @@ accounts?",
     submit_expense_sources(answer: "no")
 
     on_page "Preferences" do
+      choose_no(
+        "Would you like text message reminders about key steps and documents" +
+        " required to help you through the enrollment process?",
+      )
       click_on "Continue"
     end
 


### PR DESCRIPTION
**WHAT**: removing email consent option, allows client to update phone
number if they opt into SMS.
![screen shot 2017-09-11 at 10 11 14 am](https://user-images.githubusercontent.com/601515/30289941-a305a0ae-96e2-11e7-93a6-f22088b78168.png)


![screen shot 2017-09-11 at 10 22 57 am](https://user-images.githubusercontent.com/601515/30289886-7d6491ac-96e2-11e7-8af6-2855ab8f6d79.png)
