### PR TITLE
Add office-specific landing pages for Union and Clio

### DIFF
--- a/app/controllers/introduce_yourself_controller.rb
+++ b/app/controllers/introduce_yourself_controller.rb
@@ -6,7 +6,7 @@ class IntroduceYourselfController < StandardStepsController
 
     if @step.valid?
       app = current_or_new_snap_application
-      app.save!
+      app.update!(office_location: step_params[:office_location])
       set_current_snap_application(app)
       member.update!(member_update_params)
       redirect_to(next_path)
@@ -22,11 +22,12 @@ class IntroduceYourselfController < StandardStepsController
   end
 
   def existing_attributes
-    HashWithIndifferentAccess.new(member.attributes)
+    HashWithIndifferentAccess.new(member.attributes).
+      merge(office_location_params)
   end
 
   def member_update_params
-    step_params
+    step_params.except(:office_location)
   end
 
   def member
@@ -36,5 +37,9 @@ class IntroduceYourselfController < StandardStepsController
 
   def current_or_new_snap_application
     current_snap_application || SnapApplication.new
+  end
+
+  def office_location_params
+    { office_location: params[:office_location] }
   end
 end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -2,4 +2,12 @@ class PagesController < ApplicationController
   def index
     session[:snap_application_id] = nil
   end
+
+  def union
+    session[:snap_application_id] = nil
+  end
+
+  def clio
+    session[:snap_application_id] = nil
+  end
 end

--- a/app/jobs/fax_application_job.rb
+++ b/app/jobs/fax_application_job.rb
@@ -1,8 +1,7 @@
 class FaxApplicationJob < ApplicationJob
   def perform(export:)
     export.execute do |snap_application|
-      fax_recipient = FaxRecipient.new(residential_address:
-                                       snap_application.residential_address)
+      fax_recipient = FaxRecipient.new(snap_application: snap_application)
       Fax.send_fax(
         number: fax_recipient.number,
         file: snap_application.pdf.path,

--- a/app/models/fax_recipient.rb
+++ b/app/models/fax_recipient.rb
@@ -1,12 +1,17 @@
 class FaxRecipient
   attr_accessor :residential_address
 
-  def initialize(residential_address:)
+  def initialize(residential_address:, office_location: "")
     @residential_address = residential_address
+    @office_location = office_location
   end
 
   def number
-    self.class.find_by(zip: residential_address.zip)["fax_number"]
+    if office_location.present?
+      self.class.offices[office_location]["fax_number"]
+    else
+      self.class.find_by(zip: residential_address.zip)["fax_number"]
+    end
   end
 
   def name
@@ -43,4 +48,8 @@ class FaxRecipient
   def self.release_stage
     ENV.fetch("APP_RELEASE_STAGE", "development")
   end
+
+  private
+
+  attr_reader :office_location
 end

--- a/app/models/fax_recipient.rb
+++ b/app/models/fax_recipient.rb
@@ -1,9 +1,6 @@
 class FaxRecipient
-  attr_accessor :residential_address
-
-  def initialize(residential_address:, office_location: "")
-    @residential_address = residential_address
-    @office_location = office_location
+  def initialize(snap_application:)
+    @snap_application = snap_application
   end
 
   def number
@@ -51,5 +48,13 @@ class FaxRecipient
 
   private
 
-  attr_reader :office_location
+  attr_reader :snap_application
+
+  def residential_address
+    snap_application.residential_address
+  end
+
+  def office_location
+    snap_application.office_location
+  end
 end

--- a/app/steps/introduce_yourself.rb
+++ b/app/steps/introduce_yourself.rb
@@ -24,7 +24,7 @@ class IntroduceYourself < Step
     allow_blank: true,
     inclusion: {
       in: %w(clio union),
-      message: "Select a valid office locaton.",
+      message: "Select a valid office location.",
     },
   )
 

--- a/app/steps/introduce_yourself.rb
+++ b/app/steps/introduce_yourself.rb
@@ -7,6 +7,7 @@ class IntroduceYourself < Step
     :birthday,
     :first_name,
     :last_name,
+    :office_location,
   )
 
   validates :first_name,
@@ -17,6 +18,15 @@ class IntroduceYourself < Step
 
   validates :birthday,
     presence: { message: "Make sure to provide a birthday" }
+
+  validates(
+    :office_location,
+    allow_blank: true,
+    inclusion: {
+      in: %w(clio union),
+      message: "Select a valid office locaton.",
+    },
+  )
 
   # https://github.com/rails/rails/pull/8189#issuecomment-10329403
   def class_for_attribute(attr)

--- a/app/views/introduce_yourself/edit.html.erb
+++ b/app/views/introduce_yourself/edit.html.erb
@@ -14,6 +14,7 @@
         autofocus: true %>
       <%= f.mb_input_field :last_name, "What is your last name?" %>
       <%= f.mb_date_select :birthday, "What is your birthday?", { options: { start_year: 1900, end_year: Time.now.year, default: Date.new(1990,1,15), order: [:month, :day, :year] } } %>
+      <%= f.hidden_field :office_location, value: @step.office_location %>
       <%= render partial: 'shared/next_step' %>
     <% end %>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
   </head>
   <body class="<%= template_name_css_class %>">
     <div class="page-wrapper">
-      <%= content_for?(:demo_banner) ? content_for(:demo_banner) : '' %>
+      <%= content_for?(:banner) ? content_for(:demo_banner) : '' %>
       <%= content_for?(:content) ? content_for(:content) : yield %>
     </div>
     <%= capture { content_for(:javascript) } %>

--- a/app/views/pages/_home_page_bottom_section.html.erb
+++ b/app/views/pages/_home_page_bottom_section.html.erb
@@ -1,0 +1,26 @@
+<section class="slab" id="scroller-target">
+  <div class="grid">
+    <div class="grid__item width-seven-twelfths">
+      <p>
+        MichiganBenefits.org is an easy, safe and secure way to apply for
+        Michigan's Food Assistance Program. Information you provide will be
+        securely submitted as an official application with the Michigan
+        Department of Health and Human Services.
+
+        MichiganBenefits.org is a non-profit that offers online application
+        assistance to any Michigan resident. For additional assistance email our
+        team at <a href="mailto:hello@michiganbenefits.org">hello@michiganbenefits.org</a>.
+      </p>
+
+      <p>
+        To visit the official online application for food assistance, please visit
+        <%= link_to 'MI Bridges', 'https://www.michigan.gov/mibridges' %>.
+      </p>
+    </div>
+
+    <div class="grid__item width-one-fourth shift-one-sixth trust-badge">
+      <a href="http://www.michigan.gov/mdhhs/" class="illustration illustration--mi_mdhhs">MDHHS</a>
+      <p class="text--small">A registered Community Partner and digital application assister.</p>
+    </div>
+  </div>
+</section>

--- a/app/views/pages/clio.html.erb
+++ b/app/views/pages/clio.html.erb
@@ -1,6 +1,6 @@
 <% content_for :template_name, 'homepage' %>
 <% content_for :banner do
-  render "shared/banner", banner_text: "Hello! Welcome to our beta website."
+  render "shared/banner", banner_text: "Welcome to MDHHS on Clio Road!"
 end %>
 
 <%= render 'shared/flashes' %>
@@ -14,8 +14,8 @@ end %>
     <p>
       Apply for food stamps (FAP) in 15 minutes
     </p>
-    <%= link_to step_path(StepNavigation.first), class: "button button--cta button--fully-width" do %>
-      Apply now
+    <%= link_to step_path(StepNavigation.first, office_location: "clio"), class: "button button--cta button--fully-width" do %>
+      Apply now from MDHHS at Clio Rd.
       <i class="button__icon icon-arrow_forward"></i>
     <% end %>
   </div>

--- a/app/views/pages/clio.html.erb
+++ b/app/views/pages/clio.html.erb
@@ -21,53 +21,5 @@ end %>
   </div>
 </div>
 
-<!-- <div class="slab slab--white" id="apply-for-programs">
-  <div class="card--narrow">
-    <%= render 'shared/flashes' %>
-    <label class="program-selector">
-      <div class="program-selector__checkbox">
-        <% icon_class = "illustration--icn_food" %>
-      </div>
-      <div class="<%= icon_class %> program-selector__icon illustration">
-        <h4 class="program-selector__title">
-          Food Assistance
-        </h4>
-      </div>
-      <div class="program-selector__subtitle text--smell">
-        Food Stamps, FAP or SNAP
-      </div>
-      <div class="text--help">
-        Provides benefits to buy or grow food.
-      </div>
-    </label>
-  </div>
-</div> -->
-
-<section class="slab" id="scroller-target">
-  <div class="grid">
-    <div class="grid__item width-seven-twelfths">
-      <p>
-        MichiganBenefits.org is an easy, safe and secure way to apply for
-        Michigan's Food Assistance Program. Information you provide will be
-        securely submitted as an official application with the Michigan
-        Department of Health and Human Services.
-
-        MichiganBenefits.org is a non-profit that offers online application
-        assistance to any Michigan resident. For additional assistance email our
-        team at <a href="mailto:hello@michiganbenefits.org">hello@michiganbenefits.org</a>.
-      </p>
-
-      <p>
-        To visit the official online application for food assistance, please visit
-        <%= link_to 'MI Bridges', 'https://www.michigan.gov/mibridges' %>.
-      </p>
-    </div>
-
-    <div class="grid__item width-one-fourth shift-one-sixth trust-badge">
-      <a href="http://www.michigan.gov/mdhhs/" class="illustration illustration--mi_mdhhs">MDHHS</a>
-      <p class="text--small">A registered Community Partner and digital application assister.</p>
-    </div>
-  </div>
-</section>
-
+<%= render 'pages/home_page_bottom_section' %>
 <%= render 'shared/footer' %>

--- a/app/views/pages/index.html.erb
+++ b/app/views/pages/index.html.erb
@@ -21,53 +21,5 @@ end %>
   </div>
 </div>
 
-<!-- <div class="slab slab--white" id="apply-for-programs">
-  <div class="card--narrow">
-    <%= render 'shared/flashes' %>
-    <label class="program-selector">
-      <div class="program-selector__checkbox">
-        <% icon_class = "illustration--icn_food" %>
-      </div>
-      <div class="<%= icon_class %> program-selector__icon illustration">
-        <h4 class="program-selector__title">
-          Food Assistance
-        </h4>
-      </div>
-      <div class="program-selector__subtitle text--smell">
-        Food Stamps, FAP or SNAP
-      </div>
-      <div class="text--help">
-        Provides benefits to buy or grow food.
-      </div>
-    </label>
-  </div>
-</div> -->
-
-<section class="slab" id="scroller-target">
-  <div class="grid">
-    <div class="grid__item width-seven-twelfths">
-      <p>
-        MichiganBenefits.org is an easy, safe and secure way to apply for
-        Michigan's Food Assistance Program. Information you provide will be
-        securely submitted as an official application with the Michigan
-        Department of Health and Human Services.
-
-        MichiganBenefits.org is a non-profit that offers online application
-        assistance to any Michigan resident. For additional assistance email our
-        team at <a href="mailto:hello@michiganbenefits.org">hello@michiganbenefits.org</a>.
-      </p>
-
-      <p>
-        To visit the official online application for food assistance, please visit
-        <%= link_to 'MI Bridges', 'https://www.michigan.gov/mibridges' %>.
-      </p>
-    </div>
-
-    <div class="grid__item width-one-fourth shift-one-sixth trust-badge">
-      <a href="http://www.michigan.gov/mdhhs/" class="illustration illustration--mi_mdhhs">MDHHS</a>
-      <p class="text--small">A registered Community Partner and digital application assister.</p>
-    </div>
-  </div>
-</section>
-
+<%= render 'pages/home_page_bottom_section' %>
 <%= render 'shared/footer' %>

--- a/app/views/pages/union.html.erb
+++ b/app/views/pages/union.html.erb
@@ -1,6 +1,6 @@
 <% content_for :template_name, 'homepage' %>
 <% content_for :banner do
-  render "shared/banner", banner_text: "Hello! Welcome to our beta website."
+  render "shared/banner", banner_text: "Welcome to MDHHS on Union Street!"
 end %>
 
 <%= render 'shared/flashes' %>
@@ -14,8 +14,8 @@ end %>
     <p>
       Apply for food stamps (FAP) in 15 minutes
     </p>
-    <%= link_to step_path(StepNavigation.first), class: "button button--cta button--fully-width" do %>
-      Apply now
+    <%= link_to step_path(StepNavigation.first, office_location: "union"), class: "button button--cta button--fully-width" do %>
+      Apply now from MDHHS at Union St.
       <i class="button__icon icon-arrow_forward"></i>
     <% end %>
   </div>

--- a/app/views/pages/union.html.erb
+++ b/app/views/pages/union.html.erb
@@ -21,53 +21,5 @@ end %>
   </div>
 </div>
 
-<!-- <div class="slab slab--white" id="apply-for-programs">
-  <div class="card--narrow">
-    <%= render 'shared/flashes' %>
-    <label class="program-selector">
-      <div class="program-selector__checkbox">
-        <% icon_class = "illustration--icn_food" %>
-      </div>
-      <div class="<%= icon_class %> program-selector__icon illustration">
-        <h4 class="program-selector__title">
-          Food Assistance
-        </h4>
-      </div>
-      <div class="program-selector__subtitle text--smell">
-        Food Stamps, FAP or SNAP
-      </div>
-      <div class="text--help">
-        Provides benefits to buy or grow food.
-      </div>
-    </label>
-  </div>
-</div> -->
-
-<section class="slab" id="scroller-target">
-  <div class="grid">
-    <div class="grid__item width-seven-twelfths">
-      <p>
-        MichiganBenefits.org is an easy, safe and secure way to apply for
-        Michigan's Food Assistance Program. Information you provide will be
-        securely submitted as an official application with the Michigan
-        Department of Health and Human Services.
-
-        MichiganBenefits.org is a non-profit that offers online application
-        assistance to any Michigan resident. For additional assistance email our
-        team at <a href="mailto:hello@michiganbenefits.org">hello@michiganbenefits.org</a>.
-      </p>
-
-      <p>
-        To visit the official online application for food assistance, please visit
-        <%= link_to 'MI Bridges', 'https://www.michigan.gov/mibridges' %>.
-      </p>
-    </div>
-
-    <div class="grid__item width-one-fourth shift-one-sixth trust-badge">
-      <a href="http://www.michigan.gov/mdhhs/" class="illustration illustration--mi_mdhhs">MDHHS</a>
-      <p class="text--small">A registered Community Partner and digital application assister.</p>
-    </div>
-  </div>
-</section>
-
+<%= render 'pages/home_page_bottom_section' %>
 <%= render 'shared/footer' %>

--- a/app/views/shared/_banner.html.erb
+++ b/app/views/shared/_banner.html.erb
@@ -1,0 +1,1 @@
+<div class="demo-banner"><%= banner_text %></div>

--- a/app/views/shared/_demo_banner.html.erb
+++ b/app/views/shared/_demo_banner.html.erb
@@ -1,1 +1,0 @@
-<div class="demo-banner">Hello! Welcome to our beta website.</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,8 +11,10 @@ Rails.application.routes.draw do
   end
 
   root "pages#index"
-  get "/terms" => "pages#terms"
+  get "/clio" => "pages#clio"
   get "/privacy" => "pages#privacy"
+  get "/terms" => "pages#terms"
+  get "/union" => "pages#union"
 
   resource :confirmations, only: %i[show]
   resources :documents, only: %i[index new create destroy]

--- a/db/migrate/20170911213216_add_office_location_to_snap_applications.rb
+++ b/db/migrate/20170911213216_add_office_location_to_snap_applications.rb
@@ -1,0 +1,5 @@
+class AddOfficeLocationToSnapApplications < ActiveRecord::Migration[5.1]
+  def change
+    add_column :snap_applications, :office_location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170911184535) do
+ActiveRecord::Schema.define(version: 20170911213216) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 20170911184535) do
     t.integer "total_money"
     t.text "additional_information"
     t.datetime "faxed_at"
+    t.string "office_location"
   end
 
   add_foreign_key "driver_applications", "snap_applications"

--- a/spec/controllers/introduce_yourself_controller_spec.rb
+++ b/spec/controllers/introduce_yourself_controller_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe IntroduceYourselfController do
   include_examples "step controller", "param validation"
 
   describe "#edit" do
+    context "office location in params" do
+      it "assigns office location" do
+        get :edit, params: { office_location: "clio" }
+
+        expect(step.office_location).to eq "clio"
+      end
+    end
+
     it "assigns the name and birthday to the step" do
       get :edit
 
@@ -32,25 +40,44 @@ RSpec.describe IntroduceYourselfController do
   end
 
   describe "#update" do
-    context "valid params" do
-      it "updates the application" do
-        expect do
+    context "no office location present" do
+      context "valid params" do
+        it "updates the application" do
+          expect do
+            put :update, params: valid_params
+          end.to(
+            change do
+              current_app.primary_member.reload.attributes.slice(
+                "first_name",
+                "last_name",
+                "birthday",
+              )
+            end,
+          )
+        end
+
+        it "redirects to the next step" do
           put :update, params: valid_params
-        end.to(
-          change do
-            current_app.primary_member.reload.attributes.slice(
-              "first_name",
-              "last_name",
-              "birthday",
-            )
-          end,
-        )
+
+          expect(response).to redirect_to("/steps/contact-information")
+        end
       end
+    end
 
-      it "redirects to the next step" do
-        put :update, params: valid_params
+    context "office location present" do
+      it "updates the office location for the snap application" do
+        params = { step: {
+          first_name: "RJ",
+          last_name: "D2",
+          "birthday(3i)" => "31",
+          "birthday(2i)" => "1",
+          "birthday(1i)" => "1950",
+          office_location: "union",
+        } }
 
-        expect(response).to redirect_to("/steps/contact-information")
+        put :update, params: params
+
+        expect(current_app.reload.office_location).to eq "union"
       end
     end
   end

--- a/spec/features/office_specific_landing_pages_spec.rb
+++ b/spec/features/office_specific_landing_pages_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.feature "Office-specific landing pages" do
+  scenario "clio road" do
+    visit "/clio"
+    click_on "Apply now from MDHHS at Clio Rd."
+
+    expect(current_path).to eq "/steps/introduce-yourself"
+    expect(find("#step_office_location", visible: false).value).to eq("clio")
+  end
+
+  scenario "union street" do
+    visit "/union"
+    click_on "Apply now from MDHHS at Union St."
+
+    expect(current_path).to eq "/steps/introduce-yourself"
+    expect(find("#step_office_location", visible: false).value).to eq("union")
+  end
+
+  scenario "regular home page" do
+    visit root_path
+    click_on "Apply now"
+
+    expect(current_path).to eq "/steps/introduce-yourself"
+    expect(find("#step_office_location", visible: false).value).to eq(nil)
+  end
+end

--- a/spec/jobs/fax_application_job_spec.rb
+++ b/spec/jobs/fax_application_job_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe FaxApplicationJob do
       job = FaxApplicationJob.new
 
       allow(Fax).to receive(:send_fax)
-      recipient = FaxRecipient.new(residential_address:
-                                   snap_application.residential_address)
+      recipient = FaxRecipient.new(snap_application: snap_application)
 
       job.perform(export: export)
 

--- a/spec/models/fax_recipient_spec.rb
+++ b/spec/models/fax_recipient_spec.rb
@@ -5,9 +5,13 @@ RSpec.describe FaxRecipient do
     context "address is in clio" do
       it "uses the sandbox fax number" do
         residential_address = double(zip: "48415")
+        snap_application = double(
+          residential_address: residential_address,
+          office_location: nil,
+        )
 
         fax_recipient = described_class.new(
-          residential_address: residential_address,
+          snap_application: snap_application,
         )
 
         expect(fax_recipient.number).to eq sandbox_fax_number
@@ -17,9 +21,13 @@ RSpec.describe FaxRecipient do
     context "address is in union" do
       it "uses the sandbox fax number" do
         residential_address = double(zip: "48411")
+        snap_application = double(
+          residential_address: residential_address,
+          office_location: nil,
+        )
 
         fax_recipient = described_class.new(
-          residential_address: residential_address,
+          snap_application: snap_application,
         )
 
         expect(fax_recipient.number).to eq sandbox_fax_number
@@ -29,8 +37,13 @@ RSpec.describe FaxRecipient do
     context "address outside of clio or union" do
       it "falls back to sandbox number" do
         residential_address = double(zip: "98765")
-        fax_recipient = described_class.new(
+        snap_application = double(
           residential_address: residential_address,
+          office_location: nil,
+        )
+
+        fax_recipient = described_class.new(
+          snap_application: snap_application,
         )
 
         expect(fax_recipient.number).to eq sandbox_fax_number
@@ -44,10 +57,13 @@ RSpec.describe FaxRecipient do
         it "defaults to office location over residential address" do
           residential_address = double(zip: "12345")
           office_location = "clio"
-
-          fax_recipient = described_class.new(
+          snap_application = double(
             residential_address: residential_address,
             office_location: office_location,
+          )
+
+          fax_recipient = described_class.new(
+            snap_application: snap_application,
           )
 
           expect(fax_recipient.number).to eq clio_fax_number
@@ -56,10 +72,13 @@ RSpec.describe FaxRecipient do
         it "defaults to office location over residential address" do
           residential_address = double(zip: "12345")
           office_location = "union"
-
-          fax_recipient = described_class.new(
+          snap_application = double(
             residential_address: residential_address,
             office_location: office_location,
+          )
+
+          fax_recipient = described_class.new(
+            snap_application: snap_application,
           )
 
           expect(fax_recipient.number).to eq union_fax_number
@@ -68,9 +87,13 @@ RSpec.describe FaxRecipient do
 
       it "uses the appropriate fax number when the address is in clio" do
         residential_address = double(zip: "48415")
+        snap_application = double(
+          residential_address: residential_address,
+          office_location: nil,
+        )
 
         fax_recipient = described_class.new(
-          residential_address: residential_address,
+          snap_application: snap_application,
         )
 
         expect(fax_recipient.number).to eq clio_fax_number
@@ -78,9 +101,13 @@ RSpec.describe FaxRecipient do
 
       it "uses the appropriate fax number when the address is in union" do
         residential_address = double(zip: "48411")
+        snap_application = double(
+          residential_address: residential_address,
+          office_location: nil,
+        )
 
         fax_recipient = described_class.new(
-          residential_address: residential_address,
+          snap_application: snap_application,
         )
 
         expect(fax_recipient.number).to eq union_fax_number
@@ -89,8 +116,13 @@ RSpec.describe FaxRecipient do
       it "falls back to the clio office" do
         residential_address = double(zip: "123456")
 
-        fax_recipient = described_class.new(
+        snap_application = double(
           residential_address: residential_address,
+          office_location: nil,
+        )
+
+        fax_recipient = described_class.new(
+          snap_application: snap_application,
         )
 
         expect(fax_recipient.number).to eq clio_fax_number

--- a/spec/models/fax_recipient_spec.rb
+++ b/spec/models/fax_recipient_spec.rb
@@ -2,49 +2,111 @@ require "rails_helper"
 
 RSpec.describe FaxRecipient do
   describe "#number" do
-    it "uses the appropriate fax number when the address is in clio" do
-      residential_address = double(zip: "48415")
-      fax_recipient = described_class.new(residential_address:
-                                            residential_address)
-      expect(fax_recipient.number).to eql "+16173963015"
+    context "address is in clio" do
+      it "uses the sandbox fax number" do
+        residential_address = double(zip: "48415")
+
+        fax_recipient = described_class.new(
+          residential_address: residential_address,
+        )
+
+        expect(fax_recipient.number).to eq sandbox_fax_number
+      end
     end
 
-    it "uses the appropriate fax number when the address is in union" do
-      residential_address = double(zip: "48411")
-      fax_recipient = described_class.new(residential_address:
-                                            residential_address)
-      expect(fax_recipient.number).to eql "+16173963015"
+    context "address is in union" do
+      it "uses the sandbox fax number" do
+        residential_address = double(zip: "48411")
+
+        fax_recipient = described_class.new(
+          residential_address: residential_address,
+        )
+
+        expect(fax_recipient.number).to eq sandbox_fax_number
+      end
     end
 
-    it "falls back to union when the address is outside of clio or union" do
-      residential_address = double(zip: "98765")
-      fax_recipient = described_class.new(residential_address:
-                                            residential_address)
-      expect(fax_recipient.number).to eql "+16173963015"
+    context "address outside of clio or union" do
+      it "falls back to sandbox number" do
+        residential_address = double(zip: "98765")
+        fax_recipient = described_class.new(
+          residential_address: residential_address,
+        )
+
+        expect(fax_recipient.number).to eq sandbox_fax_number
+      end
     end
 
     context "when the app release stage is production" do
       before { stub_const("ENV", "APP_RELEASE_STAGE" => "production") }
+
+      context "office location is present" do
+        it "defaults to office location over residential address" do
+          residential_address = double(zip: "12345")
+          office_location = "clio"
+
+          fax_recipient = described_class.new(
+            residential_address: residential_address,
+            office_location: office_location,
+          )
+
+          expect(fax_recipient.number).to eq clio_fax_number
+        end
+
+        it "defaults to office location over residential address" do
+          residential_address = double(zip: "12345")
+          office_location = "union"
+
+          fax_recipient = described_class.new(
+            residential_address: residential_address,
+            office_location: office_location,
+          )
+
+          expect(fax_recipient.number).to eq union_fax_number
+        end
+      end
+
       it "uses the appropriate fax number when the address is in clio" do
         residential_address = double(zip: "48415")
-        fax_recipient = described_class.new(residential_address:
-                                              residential_address)
-        expect(fax_recipient.number).to eql "+18107602310"
+
+        fax_recipient = described_class.new(
+          residential_address: residential_address,
+        )
+
+        expect(fax_recipient.number).to eq clio_fax_number
       end
 
       it "uses the appropriate fax number when the address is in union" do
         residential_address = double(zip: "48411")
-        fax_recipient = described_class.new(residential_address:
-                                              residential_address)
-        expect(fax_recipient.number).to eql "+18107607372"
+
+        fax_recipient = described_class.new(
+          residential_address: residential_address,
+        )
+
+        expect(fax_recipient.number).to eq union_fax_number
       end
 
       it "falls back to the clio office" do
         residential_address = double(zip: "123456")
-        fax_recipient = described_class.new(residential_address:
-                                              residential_address)
-        expect(fax_recipient.number).to eql "+18107602310"
+
+        fax_recipient = described_class.new(
+          residential_address: residential_address,
+        )
+
+        expect(fax_recipient.number).to eq clio_fax_number
       end
     end
+  end
+
+  def sandbox_fax_number
+    "+16173963015"
+  end
+
+  def clio_fax_number
+    "+18107602310"
+  end
+
+  def union_fax_number
+    "+18107607372"
   end
 end

--- a/spec/routing/pages_routing_spec.rb
+++ b/spec/routing/pages_routing_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe "Pages routing" do
+  specify do
+    expect(get: "/").to route_to "pages#index"
+    expect(get: "/clio").to route_to "pages#clio"
+    expect(get: "/union").to route_to "pages#union"
+  end
+end


### PR DESCRIPTION
* Starting an app from either of these pages sets the "office location"
attribute, which receives highest priority when deciding who to fax.

![screen shot 2017-09-11 at 2 23 18 pm](https://user-images.githubusercontent.com/601515/30298846-bf381c06-9701-11e7-8a79-ebe80038ad7c.png)
