### PR TITLE
Fix rake tasks that got overlooked in refactor passes

### DIFF
--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -8,8 +8,7 @@ namespace :one_offs do
   def migrate_faxed_at_to_exports
     applications = SnapApplication.where.not(faxed_at: nil)
     applications.find_each do |application|
-      recipient = FaxRecipient.new(residential_address:
-                                   application.residential_address)
+      recipient = FaxRecipient.new(snap_application: application)
 
       metadata = "Faxed to #{recipient.name} (#{recipient.number})"
 

--- a/lib/tasks/queue_faxes.rake
+++ b/lib/tasks/queue_faxes.rake
@@ -1,4 +1,4 @@
 desc "Queues faxes for signed, unfaxed applicants"
 task queue_faxes: :environment do
-  SnapApplication.enqueue_faxes
+  Export.enqueue_faxes
 end


### PR DESCRIPTION
*Why* Because the 30m enqueue job is currently not working.

See https://trello.com/c/0uVGs3b3/275-the-rake-task-that-queues-up-unsent-faxes-should-not-fail

Sentry: https://sentry.io/app73768247herokucom-6k/app73768247herokucom/issues/347534988/?referrer=slack