### PR TITLE
Fill out more driving pages and abstract some common patterns

### DIFF
--- a/app/views/personal_detail/edit.html.erb
+++ b/app/views/personal_detail/edit.html.erb
@@ -16,7 +16,7 @@
           layout: "inline" %>
         <%= f.mb_select :marital_status,
         'What is your marital status?',
-        ['Married', 'Never Married', 'Divorced', 'Widowed', 'Separated'],
+        ['Married', 'Never married', 'Divorced', 'Widowed', 'Separated'],
         include_blank: "Choose one" %>
       <%= f.mb_input_field :ssn,
       'What is your social security number?',

--- a/app/views/personal_detail/edit.html.erb
+++ b/app/views/personal_detail/edit.html.erb
@@ -16,7 +16,7 @@
           layout: "inline" %>
         <%= f.mb_select :marital_status,
         'What is your marital status?',
-        ['Married', 'Never married', 'Divorced', 'Widowed', 'Separated'],
+        ['Married', 'Never Married', 'Divorced', 'Widowed', 'Separated'],
         include_blank: "Choose one" %>
       <%= f.mb_input_field :ssn,
       'What is your social security number?',

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -72,7 +72,9 @@ module MiBridges
           page.fill_in_required_fields
           page.continue
         rescue StandardError => e
+          # rubocop:disable Debugger
           binding.pry if ENV["DEBUG_DRIVE"]
+          # rubocop:enable Debugger
           throw e
         end
       end

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -49,6 +49,11 @@ module MiBridges
       HousingUtilityBillsSummaryPage,
       YourOtherBillsExpensesPage,
       YourOtherBillsExpensesSummaryPage,
+      SchoolDetailsPage,
+      DebuggerPage,
+      FinishPage,
+      DebuggerPage,
+      SubmitPage,
     ].freeze
 
     def initialize(snap_application:)
@@ -61,10 +66,15 @@ module MiBridges
       page_classes = SIGN_UP_FLOW + APPLY_FLOW
 
       page_classes.each do |klass|
-        page = klass.new(@snap_application)
-        page.setup
-        page.fill_in_required_fields
-        page.continue
+        begin
+          page = klass.new(@snap_application)
+          page.setup
+          page.fill_in_required_fields
+          page.continue
+        rescue StandardError => e
+          binding.pry if ENV["DEBUG_DRIVE"]
+          throw e
+        end
       end
 
       teardown

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -44,6 +44,8 @@ module MiBridges
       OtherAssetsPage,
       OtherAssetsSummaryPage,
       HousingUtilityBillsPage,
+      HousingBillsPage,
+      UtilityBillsPage,
       HousingUtilityBillsSummaryPage,
       YourOtherBillsExpensesPage,
       YourOtherBillsExpensesSummaryPage,

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -43,6 +43,10 @@ module MiBridges
       LiquidAssetsSummaryPage,
       OtherAssetsPage,
       OtherAssetsSummaryPage,
+      HousingUtilityBillsPage,
+      HousingUtilityBillsSummaryPage,
+      YourOtherBillsExpensesPage,
+      YourOtherBillsExpensesSummaryPage,
     ].freeze
 
     def initialize(snap_application:)

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -28,6 +28,21 @@ module MiBridges
     APPLY_FLOW = [
       StartPage,
       BenefitsSelectorPage,
+      ProgramBenefitsPage,
+      PersonalInformationPage,
+      BasicInformationSummaryPage,
+      PeopleListedPage,
+      HouseholdMembersSummaryPage,
+      JobIncomeInformationPage,
+      JobIncomeSummaryPage,
+      MoneyOtherSourcesPage,
+      MoneyOtherSourcesSummaryPage,
+      HouseholdMemberQuestionsPage,
+      DisabilityOrBlindnessReviewPage,
+      LiquidAssetsPage,
+      LiquidAssetsSummaryPage,
+      OtherAssetsPage,
+      OtherAssetsSummaryPage,
     ].freeze
 
     def initialize(snap_application:)

--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -33,7 +33,25 @@ module MiBridges
 
       def click_id(id)
         id = "##{id}" unless id.include?("#")
-        page.execute_script("$('#{id}').click()")
+        js_click_selector(id)
+      end
+
+      def js_click_selector(selector)
+        page.execute_script %($("#{selector}").click())
+      end
+
+      def check_in_section(section, options = {})
+        predicate = options.fetch(:if, false)
+        name = options.fetch(:for, "")
+
+        widget = "[aria-labelledby='#{section}']"
+        selector = if predicate
+                     "#{widget} label:contains('#{name}') input"
+                   else
+                     "#{widget} label:contains('No one') input"
+                   end
+
+        js_click_selector(selector)
       end
 
       def next

--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -44,14 +44,18 @@ module MiBridges
         predicate = options.fetch(:if, false)
         name = options.fetch(:for, "")
 
-        widget = "[aria-labelledby='#{section}']"
         selector = if predicate
-                     "#{widget} label:contains('#{name}') input"
+                     selector_for_radio(name)
                    else
-                     "#{widget} label:contains('No one') input"
+                     selector_for_radio("No one")
                    end
 
-        js_click_selector(selector)
+        widget = "[aria-labelledby='#{section}']"
+        js_click_selector("#{widget} #{selector}")
+      end
+
+      def selector_for_radio(name)
+        "label:contains('#{name}') input"
       end
 
       def next

--- a/lib/mi_bridges/driver/basic_information_summary_page.rb
+++ b/lib/mi_bridges/driver/basic_information_summary_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class BasicInformationSummaryPage < ClickNextPage
+    end
+  end
+end

--- a/lib/mi_bridges/driver/click_next_page.rb
+++ b/lib/mi_bridges/driver/click_next_page.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class ClickNextPage < BasePage
+      def setup; end
+
+      def fill_in_required_fields; end
+
+      def continue
+        click_on "Next"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/debugger_page.rb
+++ b/lib/mi_bridges/driver/debugger_page.rb
@@ -6,7 +6,9 @@ module MiBridges
       def fill_in_required_fields; end
 
       def continue
+        # rubocop:disable Debugger
         binding.pry if ENV["DEBUG_DRIVE"]
+        # rubocop:enable Debugger
       end
     end
   end

--- a/lib/mi_bridges/driver/debugger_page.rb
+++ b/lib/mi_bridges/driver/debugger_page.rb
@@ -1,0 +1,13 @@
+module MiBridges
+  class Driver
+    class DebuggerPage < BasePage
+      def setup; end
+
+      def fill_in_required_fields; end
+
+      def continue
+        binding.pry if ENV["DEBUG_DRIVE"]
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/disability_or_blindness_review_page.rb
+++ b/lib/mi_bridges/driver/disability_or_blindness_review_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class DisabilityOrBlindnessReviewPage < ClickNextPage
+    end
+  end
+end

--- a/lib/mi_bridges/driver/finish_page.rb
+++ b/lib/mi_bridges/driver/finish_page.rb
@@ -1,0 +1,6 @@
+module MiBridges
+  class Driver
+    class FinishPage < ClickNextPage
+    end
+  end
+end

--- a/lib/mi_bridges/driver/household_member_questions_page.rb
+++ b/lib/mi_bridges/driver/household_member_questions_page.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class HouseholdMemberQuestionsPage < BasePage
+      delegate(
+        :anyone_disabled?,
+        :primary_member,
+        to: :snap_application,
+      )
+
+      delegate :first_name, to: :primary_member
+
+      def setup; end
+
+      def fill_in_required_fields
+        check_blindness_or_disability
+        check_drug_felonies
+        check_probation_or_parole
+        check_other_food_assistence_benefits
+        check_ssi_benefit
+        check_cash_benefit_from_mdhhs
+        check_refugee_asylee_or_victim
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      def check_blindness_or_disability
+        check_in_section(
+          "starBlindnessorDisability",
+          if: anyone_disabled?,
+          for: first_name,
+        )
+      end
+
+      def check_drug_felonies
+        check_in_section "starDrugFelonies"
+      end
+
+      def check_probation_or_parole
+        check_in_section "starProbationorParole"
+      end
+
+      def check_other_food_assistence_benefits
+        check_in_section "starOtherFoodAssistanceBenefits"
+      end
+
+      def check_ssi_benefit
+        check_in_section(
+          "starSSIBenefit",
+          if: anyone_disabled?,
+          for: first_name,
+        )
+      end
+
+      def check_cash_benefit_from_mdhhs
+        check_in_section "starCashBenefitfromMDHHS"
+      end
+
+      def check_refugee_asylee_or_victim
+        check_in_section "starRefugeeAsyleeorVictimofTraffickingInformation"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/household_members_summary_page.rb
+++ b/lib/mi_bridges/driver/household_members_summary_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class HouseholdMembersSummaryPage < ClickNextPage
+    end
+  end
+end

--- a/lib/mi_bridges/driver/housing_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_bills_page.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class HousingBillsPage < BasePage
+      delegate(
+        :primary_member,
+        to: :snap_application,
+      )
+
+      delegate :first_name, to: :primary_member
+
+      def setup; end
+
+      def fill_in_required_fields
+        check_housing_bills
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def check_housing_bills
+        check_in_section section_name, if: true, for: "None"
+      end
+
+      def section_name
+        "star#{first_name.capitalize}sHousingBills"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/housing_utility_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_utility_bills_page.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class HousingUtilityBillsPage < BasePage
+      delegate(
+        :primary_member,
+        to: :snap_application,
+      )
+
+      delegate :first_name, to: :primary_member
+
+      def setup; end
+
+      def fill_in_required_fields
+        check_housing_bills
+        check_utility_bills
+        check_room_and_meals
+        select_home_heating_payment
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def check_housing_bills
+        check_in_section "starHousingBills", for: first_name
+      end
+
+      def check_utility_bills
+        check_in_section "starUtilityBills", for: first_name
+      end
+
+      def check_room_and_meals
+        check_in_section "starRoomandMeals"
+      end
+
+      def select_home_heating_payment
+        check_in_section "heatingResponseGroup", if: true, for: "No"
+        check_in_section "meapReceivedGroup", if: true, for: "No"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/housing_utility_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_utility_bills_page.rb
@@ -26,11 +26,11 @@ module MiBridges
       private
 
       def check_housing_bills
-        check_in_section "starHousingBills", for: first_name
+        check_in_section "starHousingBills", if: true, for: first_name
       end
 
       def check_utility_bills
-        check_in_section "starUtilityBills", for: first_name
+        check_in_section "starUtilityBills", if: true, for: first_name
       end
 
       def check_room_and_meals

--- a/lib/mi_bridges/driver/housing_utility_bills_summary_page.rb
+++ b/lib/mi_bridges/driver/housing_utility_bills_summary_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class HousingUtilityBillsSummaryPage < ClickNextPage
+    end
+  end
+end

--- a/lib/mi_bridges/driver/job_income_information_page.rb
+++ b/lib/mi_bridges/driver/job_income_information_page.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class JobIncomeInformationPage < BasePage
+      delegate :primary_member, to: :snap_application
+
+      delegate(
+        :employment_status,
+        :first_name,
+        to: :primary_member,
+      )
+
+      def setup; end
+
+      def fill_in_required_fields
+        check_fulltime_employment_status
+        check_self_employment_status
+        check_fap_program_benefits
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def check_fulltime_employment_status
+        check_in_section(
+          "starCurrentorRecentJob",
+          if: employment_status == "employed",
+          for: first_name,
+        )
+      end
+
+      def check_self_employment_status
+        check_in_section(
+          "starSelfEmployment",
+          if: employment_status == "self_employed",
+          for: first_name,
+        )
+      end
+
+      def check_fap_program_benefits
+        check_in_section "starInKindIncome"
+        check_in_section "starRefusaltoWork"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/job_income_summary_page.rb
+++ b/lib/mi_bridges/driver/job_income_summary_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class JobIncomeSummaryPage < ClickNextPage
+    end
+  end
+end

--- a/lib/mi_bridges/driver/liquid_assets_page.rb
+++ b/lib/mi_bridges/driver/liquid_assets_page.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class LiquidAssetsPage < BasePage
+      delegate(
+        :financial_accounts,
+        :primary_member,
+        :total_money?,
+        to: :snap_application,
+      )
+
+      delegate :first_name, to: :primary_member
+
+      def setup; end
+
+      def fill_in_required_fields
+        check_cash_on_hand
+        check_savings_account
+        check_checking_account
+        check_other_liquid_assets
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def check_cash_on_hand
+        check_in_section "starCashonHand", if: total_money?, for: first_name
+      end
+
+      def check_savings_account
+        check_in_section(
+          "starSavingsAccount",
+          if: financial_accounts.include?("savings_account"),
+          for: first_name,
+        )
+      end
+
+      def check_checking_account
+        check_in_section(
+          "starCheckingAccount",
+          if: financial_accounts.include?("checking_account"),
+          for: first_name,
+        )
+      end
+
+      def check_other_liquid_assets
+        check_in_section "starOtherLiquidAssets"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/liquid_assets_summary_page.rb
+++ b/lib/mi_bridges/driver/liquid_assets_summary_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class LiquidAssetsSummaryPage < ClickNextPage
+    end
+  end
+end

--- a/lib/mi_bridges/driver/mailing_address_page.rb
+++ b/lib/mi_bridges/driver/mailing_address_page.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class MailingAddressPage < BasePage
+      delegate(
+        :primary_member,
+        :mailing_address,
+        to: :snap_application,
+      )
+
+      def setup; end
+
+      def fill_in_required_fields
+        fill_in "Street Address or P.O. Box Number",
+          with: mailing_address.street_address
+        select mailing_address.county, from: "mailingAdrCounty"
+        fill_in "City", with: mailing_address.city
+        fill_in "Zip Code", with: mailing_address.zip
+      end
+
+      def continue
+        click_on "Next"
+        click_on "Next" if invalid_physical_address?
+      end
+
+      private
+
+      def invalid_physical_address?
+        has_content? "You have entered an invalid mailing address"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/money_other_sources_page.rb
+++ b/lib/mi_bridges/driver/money_other_sources_page.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class MoneyOtherSourcesPage < BasePage
+      delegate(
+        :income_other?,
+        :income_ssi_or_disability?,
+        :primary_member,
+        to: :snap_application,
+      )
+
+      delegate :first_name, to: :primary_member
+
+      def setup; end
+
+      def fill_in_required_fields
+        check_retirement_survivors_disability_insurance
+        check_other_income
+        check_supplemental_security_income
+        check_room_and_meals
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def check_retirement_survivors_disability_insurance
+        check_in_section "starRetirementSurvivorsDisabilityInsuranceRSDI"
+      end
+
+      def check_other_income
+        check_in_section(
+          "starOtherIncome",
+          if: income_other?,
+          for: first_name,
+        )
+      end
+
+      def check_supplemental_security_income
+        check_in_section(
+          "starSupplementalSecurityIncomeSSI",
+          if: income_ssi_or_disability?,
+          for: first_name,
+        )
+      end
+
+      def check_room_and_meals
+        check_in_section "starRoomandMeals"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/money_other_sources_summary_page.rb
+++ b/lib/mi_bridges/driver/money_other_sources_summary_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class MoneyOtherSourcesSummaryPage < ClickNextPage
+    end
+  end
+end

--- a/lib/mi_bridges/driver/other_assets_page.rb
+++ b/lib/mi_bridges/driver/other_assets_page.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class OtherAssetsPage < BasePage
+      delegate(
+        :financial_accounts,
+        :primary_member,
+        :real_estate_income?,
+        :vehicle_income?,
+        to: :snap_application,
+      )
+
+      delegate :first_name, to: :primary_member
+
+      def setup; end
+
+      def fill_in_required_fields
+        check_vehicles
+        check_real_estate
+        check_burial_assets
+        check_life_insurance
+        check_additional_assets
+        check_selling_or_giving_away
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def check_vehicles
+        check_in_section(
+          "starVehicles",
+          if: vehicle_income?,
+          for: first_name,
+        )
+      end
+
+      def check_real_estate
+        check_in_section(
+          "starRealEstate",
+          if: real_estate_income?,
+          for: first_name,
+        )
+      end
+
+      def check_burial_assets
+        check_in_section "starBurialAssets"
+      end
+
+      def check_life_insurance
+        check_in_section(
+          "starLifeInsurance",
+          if: financial_accounts.include?("life_insurance"),
+          for: first_name,
+        )
+      end
+
+      def check_additional_assets
+        check_in_section "starAdditionalAssets"
+      end
+
+      def check_selling_or_giving_away
+        check_in_section "starSellingorGivingAwayAssets"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/other_assets_summary_page.rb
+++ b/lib/mi_bridges/driver/other_assets_summary_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class OtherAssetsSummaryPage < ClickNextPage
+    end
+  end
+end

--- a/lib/mi_bridges/driver/people_listed_page.rb
+++ b/lib/mi_bridges/driver/people_listed_page.rb
@@ -8,7 +8,7 @@ module MiBridges
       def setup; end
 
       def fill_in_required_fields
-        select primary_member.marital_status, from: "maritalStatus"
+        select primary_member.marital_status.titleize, from: "maritalStatus"
         fill_in "peopleInYourHome", with: snap_application.members.size
       end
 

--- a/lib/mi_bridges/driver/people_listed_page.rb
+++ b/lib/mi_bridges/driver/people_listed_page.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class PeopleListedPage < BasePage
+      delegate :primary_member, to: :snap_application
+
+      def setup; end
+
+      def fill_in_required_fields
+        select primary_member.marital_status, from: "maritalStatus"
+        fill_in "peopleInYourHome", with: snap_application.members.size
+      end
+
+      def continue
+        click_on "Next"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/school_details_page.rb
+++ b/lib/mi_bridges/driver/school_details_page.rb
@@ -1,0 +1,24 @@
+module MiBridges
+  class Driver
+    class SchoolDetailsPage < ClickNextPage
+      def fill_in_required_fields
+        choose_enrollment_time_for(snap_application.primary_member)
+        choose_highest_grade_completion_for(snap_application.primary_member)
+      end
+
+      def choose_enrollment_time_for(member)
+        selector = if member.in_college
+                     selector_for_radio("Full time")
+                   else
+                     selector_for_radio("Not in school")
+                   end
+
+        js_click_selector(selector)
+      end
+
+      def choose_highest_grade_completion_for(_member)
+        select("Unknown", from: "highestGradeInSchool")
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/submit_page.rb
+++ b/lib/mi_bridges/driver/submit_page.rb
@@ -1,0 +1,7 @@
+
+module MiBridges
+  class Driver
+    class SubmitPage < DebuggerPage
+    end
+  end
+end

--- a/lib/mi_bridges/driver/utility_bills_page.rb
+++ b/lib/mi_bridges/driver/utility_bills_page.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class UtilityBillsPage < BasePage
+      delegate(
+        :primary_member,
+        :utility_cooling?,
+        :utility_electrity?,
+        :utility_heat?,
+        :utility_phone?,
+        :utility_trash?,
+        :utility_water_sewer?,
+        to: :snap_application,
+      )
+
+      delegate :first_name, to: :primary_member
+
+      def setup; end
+
+      def fill_in_required_fields
+        check_heat
+        check_cooling
+        check_electricity
+        check_water_sewer
+        check_trash
+        check_phone
+        check_none
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def section_name
+        "star#{first_name.capitalize}sUtilityBills"
+      end
+
+      def check_heat
+        check_in_section(
+          section_name,
+          if: utility_heat?,
+          for: "Heat(gas,electric, propane,wood,etc)",
+        )
+      end
+
+      def check_cooling
+        check_in_section(
+          section_name,
+          if: utility_cooling?,
+          for: "Cooling (including room air conditioner)",
+        )
+      end
+
+      def check_electricity
+        check_in_section(
+          section_name,
+          if: utility_electrity?,
+          for: "Electricity(non heat)",
+        )
+      end
+
+      def check_water_sewer
+        check_in_section(
+          section_name,
+          if: utility_water_sewer?,
+          for: "Water/Sewer",
+        )
+      end
+
+      def check_trash
+        check_in_section(
+          section_name,
+          if: utility_trash?,
+          for: "Garbage/trash pick up",
+        )
+      end
+
+      def check_phone
+        check_in_section(
+          section_name,
+          if: utility_phone?,
+          for: "Telephone",
+        )
+      end
+
+      def check_none
+        check_in_section(
+          section_name,
+          if: nothing_checked?,
+          for: "None",
+        )
+      end
+
+      def nothing_checked?
+        !utility_phone? &&
+          !utility_trash? &&
+          !utility_water_sewer? &&
+          !utility_cooling? &&
+          !utility_electrity? &&
+          !utility_cooling?
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
+++ b/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class YourOtherBillsExpensesPage < BasePage
+      delegate(
+        :court_ordered?,
+        :monthly_medical_expenses?,
+        :primary_member,
+        to: :snap_application,
+      )
+
+      delegate :first_name, to: :primary_member
+
+      def setup; end
+
+      def fill_in_required_fields
+        check_child_spousal_payments
+        check_medical_bills
+        check_medicare
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def check_child_spousal_payments
+        check_in_section(
+          "starChildSpousalSupportPayments",
+          if: court_ordered?,
+          for: first_name,
+        )
+      end
+
+      def check_medical_bills
+        check_in_section(
+          "starMedicalBills",
+          if: monthly_medical_expenses?,
+          for: first_name,
+        )
+      end
+
+      def check_medicare
+        check_in_section "starMedicarePartAorPartB"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/your_other_bills_expenses_summary_page.rb
+++ b/lib/mi_bridges/driver/your_other_bills_expenses_summary_page.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class YourOtherBillsExpensesSummaryPage < ClickNextPage
+    end
+  end
+end


### PR DESCRIPTION
Quick-start to trying this
-------------------------

```
$ bundle exec rake db:seed
Creating minimal snap application...
Minimal application created (or found) with id: 3
Creating a more complete snap application...
More complete application created (or found) with id: 4
```

Take note of the "minimal application" id (3) as it will be used when you test the driving.

```
$ bundle exec rails runner "DriverApplication.destroy_all"
$ WEB_DRIVER=chrome DEBUG_DRIVE=true ./bin/rails runner "MiBridges::Driver.new(snap_application: SnapApplication.find(3)).run"
```

Destroying all the `driver_applications` records ensures you are creating a brand new MIBridges application instead of signing in with an existing one.

Abstract the conditional checking of boxes
==========================================

The questions on these pages are constructed in a slightly confusing manner:

The best way to scope each question is to hook into an aria attribute and check
the boxes by executing javacript against a selector that works thanks to
jQuery. That is how `check_in_section` works. For a better example -- and
please note that `aria-labelledby-section-name` is the value for the html
property `aria-labelledby`:

```ruby
check_in_section("aria-labelledby-section-name") # checks "No one"
check_in_section("aria-labelledby-section-name", if: predicate?, name: "John") # checks the box next to "John" if the predicate method returns
true
```

***

Add common "Click Next Page" super class
========================================

There are more than a fair share of "review" or "summary" pages on MI Bridges
that need only to have a "Next" button clicked. To represent the behavioral
needs of these pages a super class in the form of a "ClickNextPage" class is
made in this commit for other classes to inherit from.

This allows us to

1. Change the behavior in only one place if need be
2. Give the inheriting classes their own descriptive class name so viewing the
   queue of pages in `driver.rb` self-documents.

***

Change "Never married" option to "Never Married"
================================================

This small capitalization is necessary to match the options provided in the
Michigan Bridges application.