### PR TITLE
Update Office homepage copy and links

### DIFF
--- a/app/assets/stylesheets/templates/_homepage.scss
+++ b/app/assets/stylesheets/templates/_homepage.scss
@@ -100,13 +100,17 @@
       background: linear-gradient(242deg, rgba(#FFFFFF, 0) 0%, rgba(#000000, .5) 99%);
       padding: {
         top: 1em;
-        bottom: 1em;
+        bottom: 3em;
       }
     }
 
     h1 {
       max-width: 10em;
       margin-top: 15rem;
+    }
+
+    p {
+      clear: both;
     }
 
     &:before {
@@ -121,11 +125,25 @@
       background-size: cover;
       background-position: top center;
     }
+  }
 
-    p {
-      margin-bottom: 2em;
-      font-weight: 500;
+  .hero--header {
+    @include clearfix;
+    display: block;
+  }
+
+  .hero--subheader {
+    margin-bottom: 2em;
+    font-weight: 500;
+
+    @include media($tablet-up) {
+      @include span-columns(6);
+      clear: both;
     }
+  }
+
+  .hero--cta {
+    float: left;
   }
 
   @for $i from 1 through 3 {

--- a/app/views/pages/clio.html.erb
+++ b/app/views/pages/clio.html.erb
@@ -8,16 +8,24 @@ end %>
 <div class="slab--hero-<%= rand(1..3) %> slab slab--hero">
   <div class="grid">
     <div class="logo-hero">MichiganBenefits.org</div>
-    <h1>
-      Get the support your family needs
-    </h1>
-    <p>
-      Apply for food stamps (FAP) in 15 minutes
-    </p>
-    <%= link_to step_path(StepNavigation.first, office_location: "clio"), class: "button button--cta button--fully-width" do %>
-      Apply now from MDHHS at Clio Rd.
+    <div class="hero--header">
+      <h1>
+        Get the support your family needs
+      </h1>
+      <p class="hero--subheader">
+        Complete an application for food stamps (FAP) here, and get interviewed
+        at the Clio Rd office within 30 minutes.
+      </p>
+    </div>
+
+    <%= link_to step_path(StepNavigation.first, office_location: "clio"), class: "button button--cta button--fully-width hero--cta" do %>
+      Apply at this office
       <i class="button__icon icon-arrow_forward"></i>
     <% end %>
+    <p class="text--small">
+      Not at the Clio Road office? <%= link_to "Apply anywhere", root_path %>.
+    </p>
+
   </div>
 </div>
 

--- a/app/views/pages/union.html.erb
+++ b/app/views/pages/union.html.erb
@@ -8,16 +8,23 @@ end %>
 <div class="slab--hero-<%= rand(1..3) %> slab slab--hero">
   <div class="grid">
     <div class="logo-hero">MichiganBenefits.org</div>
-    <h1>
-      Get the support your family needs
-    </h1>
-    <p>
-      Apply for food stamps (FAP) in 15 minutes
-    </p>
-    <%= link_to step_path(StepNavigation.first, office_location: "union"), class: "button button--cta button--fully-width" do %>
-      Apply now from MDHHS at Union St.
+    <div class="hero--header">
+      <h1>
+        Get the support your family needs
+      </h1>
+      <p class="hero--subheader">
+        Complete an application for food stamps (FAP) here, and get interviewed
+        at the Union office within 30 minutes.
+      </p>
+    </div>
+
+    <%= link_to step_path(StepNavigation.first, office_location: "union"), class: "button button--cta button--fully-width hero--cta" do %>
+      Apply at this office
       <i class="button__icon icon-arrow_forward"></i>
     <% end %>
+    <p class="text--small">
+      Not at the Union Road office? <%= link_to "Apply anywhere", root_path %>.
+    </p>
   </div>
 </div>
 

--- a/spec/features/office_specific_landing_pages_spec.rb
+++ b/spec/features/office_specific_landing_pages_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Office-specific landing pages" do
   scenario "clio road" do
     visit "/clio"
-    click_on "Apply now from MDHHS at Clio Rd."
+    click_on "Apply at this office"
 
     expect(current_path).to eq "/steps/introduce-yourself"
     expect(find("#step_office_location", visible: false).value).to eq("clio")
@@ -11,7 +11,7 @@ RSpec.feature "Office-specific landing pages" do
 
   scenario "union street" do
     visit "/union"
-    click_on "Apply now from MDHHS at Union St."
+    click_on "Apply at this office"
 
     expect(current_path).to eq "/steps/introduce-yourself"
     expect(find("#step_office_location", visible: false).value).to eq("union")


### PR DESCRIPTION
Reason for Change
===================
* Updates to Office home pages
* https://trello.com/c/8KhTAItA/248-as-a-client-i-want-to-visit-an-office-homepage-so-that-i-can-be-seen-immediately

Changes
=======
* Update subheader and button copy
* Add link back to main homepage

![image](https://user-images.githubusercontent.com/7483074/30337491-a9b2ed76-97a5-11e7-928c-600439077e16.png)
