### PR TITLE
Remove dead code/fields since data migrations ran

### DIFF
--- a/app/dashboards/snap_application_dashboard.rb
+++ b/app/dashboards/snap_application_dashboard.rb
@@ -19,7 +19,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     emailed_at: Field::DateTime,
     everyone_a_citizen: Field::Boolean,
     fax_metadata: Field::String,
-    faxed_at: Field::DateTime,
+    faxed_successfully_at: Field::DateTime,
     financial_accounts: Field::String,
     income_change: Field::Boolean,
     income_change_explanation: Field::Text,
@@ -68,7 +68,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     email
     zip
     signed_at
-    faxed_at
+    faxed_successfully_at
     fax_metadata
     created_at
     emailed_at

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -85,8 +85,8 @@ class SnapApplication < ApplicationRecord
     exports.faxed.succeeded.any?
   end
 
-  def faxed_at
-    super || exports.faxed.succeeded.latest&.completed_at
+  def faxed_successfully_at
+    exports.faxed.succeeded.latest&.completed_at
   end
 
   def fax_metadata

--- a/db/migrate/20170912170418_remove_faxed_at_from_snap_applications.rb
+++ b/db/migrate/20170912170418_remove_faxed_at_from_snap_applications.rb
@@ -1,0 +1,5 @@
+class RemoveFaxedAtFromSnapApplications < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :snap_applications, :faxed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170911213216) do
+ActiveRecord::Schema.define(version: 20170912170418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,7 +153,6 @@ ActiveRecord::Schema.define(version: 20170911213216) do
     t.string "financial_accounts", default: [], array: true
     t.integer "total_money"
     t.text "additional_information"
-    t.datetime "faxed_at"
     t.string "office_location"
   end
 

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -2,21 +2,6 @@
 namespace :one_offs do
   desc "runs all one_offs, remove things from here after they are deployed"
   task run_all: :environment do
-    migrate_faxed_at_to_exports
-  end
-
-  def migrate_faxed_at_to_exports
-    applications = SnapApplication.where.not(faxed_at: nil)
-    applications.find_each do |application|
-      recipient = FaxRecipient.new(snap_application: application)
-
-      metadata = "Faxed to #{recipient.name} (#{recipient.number})"
-
-      application.exports.create(destination: :fax, status: :succeeded,
-                                 completed_at: application.faxed_at,
-                                 metadata: metadata)
-
-      application.update(faxed_at: nil)
-    end
+    # Noop for now! Put things that should happen on deploy in here!
   end
 end


### PR DESCRIPTION
Reason for Change
===================
* faxed_at is no longer a necessary field, since we record each fax attempt.
* This also removes dead data migration code and fields
