### PR TITLE
Do not display newly uploaded file post-upload

### DIFF
--- a/app/assets/javascripts/upload_setup.js
+++ b/app/assets/javascripts/upload_setup.js
@@ -1,4 +1,4 @@
-/*global uploadSetup */
+/*global $,uploadSetup,Shubox */
 
 var uploadSetup = function (previewTemplate) {
   new Shubox('#document-drop', {
@@ -14,18 +14,11 @@ var uploadSetup = function (previewTemplate) {
     success: function (file) {
       var button = $('#click-to-upload')
       var buttonHtml = button.html()
+      var titleH4 = $(file.previewElement).find('h4')
+      var titleText = titleH4.html()
+
       button.html(buttonHtml.replace('Upload documents', 'Upload more documents'))
-
-      var source = $('#form-card__documents__handlebars_template').html()
-      var template = window.Handlebars.compile(source)
-      var context = {
-        url: file.s3url,
-        filename: file.s3url.split('/').reverse()[0]
-      }
-
-      var html = template(context)
-      $(file.previewElement).remove()
-      $('#form-card__documents').append(html)
+      titleH4.html(titleText.replace('Uploading', 'Uploaded'))
     },
     addedfile: function () {
       $('[data-done-uploading]').attr('disabled', true)

--- a/app/assets/javascripts/upload_setup.js
+++ b/app/assets/javascripts/upload_setup.js
@@ -6,10 +6,10 @@ var uploadSetup = function (previewTemplate) {
     clickable: '#click-to-upload',
     previewTemplate: previewTemplate,
     acceptedFiles: '.pdf,.jpg,.jpeg,.png,.gif',
-    maxFilesize: 3, // MB
+    maxFilesize: 8, // MB
     error: function (file, msg) {
-      window.alert(msg)
-      $(file.previewElement).remove()
+      var error = '<i class="icon-warning"></i> ' + msg
+      $(file.previewElement).find('.text--error').html(error).show()
     },
     success: function (file) {
       var button = $('#click-to-upload')
@@ -19,6 +19,7 @@ var uploadSetup = function (previewTemplate) {
 
       button.html(buttonHtml.replace('Upload documents', 'Upload more documents'))
       titleH4.html(titleText.replace('Uploading', 'Uploaded'))
+      $(file.previewElement).find('input[type="hidden"]').val(file.s3url)
     },
     addedfile: function () {
       $('[data-done-uploading]').attr('disabled', true)

--- a/app/assets/stylesheets/atoms/_utilities.scss
+++ b/app/assets/stylesheets/atoms/_utilities.scss
@@ -75,6 +75,10 @@
   }
 }
 
+.is-hidden {
+  display: none;
+}
+
 .is-mobile-hidden {
   display: none !important;
   @include media($mobile-up) {

--- a/app/assets/stylesheets/organisms/_document-preview.scss
+++ b/app/assets/stylesheets/organisms/_document-preview.scss
@@ -13,6 +13,10 @@
   display: block;
   margin-right: 150px;
   min-height: 75px;
+
+  .dz-filename {
+    display: inline;
+  }
 }
 
 .doc-preview__thumb {

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -16,4 +16,8 @@ end
   </div>
   <div class="doc-preview__thumb" style="background-image: url('<%= doc_url %>')">
   </div>
+  <p class="text--error">
+    <i class="icon-warning"></i>
+    The image you uploaded is less than 2MB, and may not be readable. Please be aware that you may be asked to provide the document again.
+  </p>
 </div>

--- a/app/views/documents/_document.html.erb
+++ b/app/views/documents/_document.html.erb
@@ -1,23 +1,7 @@
-<%
-if url
-  doc_title = File.basename(url)
-  doc_url = url
-else
-  doc_title = "{{filename}}"
-  doc_url = "{{url}}"
-end
-%>
-
 <div class="doc-preview">
   <div class="doc-preview__info">
-    <h4><%= doc_title %></h4>
-    <%= hidden_field_tag 'documents', doc_url, name: 'step[documents][]' %>
-    <p class="text--help"><%= link_to 'Delete', '#', class: "link--subtle  link--delete" %></p>
+    <h4><%= File.basename(url) %></h4>
+    <%= hidden_field_tag 'documents', url, name: 'step[documents][]' %>
+    <p class="text--help"><%= link_to 'Delete', '#', class: "link--subtle link--delete" %></p>
   </div>
-  <div class="doc-preview__thumb" style="background-image: url('<%= doc_url %>')">
-  </div>
-  <p class="text--error">
-    <i class="icon-warning"></i>
-    The image you uploaded is less than 2MB, and may not be readable. Please be aware that you may be asked to provide the document again.
-  </p>
 </div>

--- a/app/views/documents/_uploading.html.erb
+++ b/app/views/documents/_uploading.html.erb
@@ -1,10 +1,13 @@
 <div class="doc-preview dz-preview dz-file-preview dz-details">
   <div class="doc-preview__info">
-    <h4>
-      Uploading <div class="dz-filename"><span data-dz-name></span></div>
-    </h4>
+    <h4>Uploading <div class="dz-filename"><span data-dz-name></span></div></h4>
+
+    <%= hidden_field_tag 'documents', '#', name: 'step[documents][]' %>
+
+    <p class="text--help">
+      <%= link_to 'Delete', '#', class: "link--subtle link--delete" %>
+    </p>
   </div>
-  <div class="doc-preview__thumb">
-    <img data-dz-thumbnail />
-  </div>
+  <p class="text--error is-hidden"></p>
+  <div class="doc-preview__thumb"><img data-dz-thumbnail /></div>
 </div>

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -31,10 +31,6 @@
         <%= render partial: 'document',
           collection: current_snap_application.documents,
           as: :url %>
-
-        <script id="form-card__documents__handlebars_template" type="text/x-handlebars-template">
-          <%= render "document", url: nil %>
-        </script>
       </div>
 
       <div class="form-card__documents__ctas">


### PR DESCRIPTION
As a step towards locking down access to files uploaded to S3 we must no
longer display the successful image URL after the file is uploaded.
Instead, let's just keep the preview element there and let the JS show the
contents of the file that way.

Also pull in the work Rachel and Zee did to display upload errors inline
within the preview element. Including:

* Allow files up to 8Mb in size
* Don't show the warning by default
* Add error message for small photo sizes

![](http://g.recordit.co/Aww0Ft0Xaz.gif)