### PR TITLE
Remove undefined method call

### DIFF
--- a/lib/mi_bridges/driver/housing_utility_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_utility_bills_page.rb
@@ -31,6 +31,9 @@ module MiBridges
           condition: true,
           for_label: first_name,
         )
+      end
+
+      def check_utility_bills
         check_in_section(
           "starUtilityBills",
           condition: true,


### PR DESCRIPTION
Reason for Change
=================
* While testing a driving code PR, an error was caught.
* That error was `undefined local variable or method 'check_utility_bills' for #<MiBridges::Driver::HousingUtilityBillsPage:0x007fa7a7b31b30>`.
* This led me to realize this method was not defined.

Changes
=======
* Remove the method call.