### PR TITLE
Tighten up that release diff

### DIFF
--- a/bin/release-diff
+++ b/bin/release-diff
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-git fetch --all
-
-staging_sha=$(git log --oneline staging/master | head -n 1 | cut -d " " -f1)
-prod_sha=$(git log --oneline production/master | head -n 1 | cut -d " " -f1)
-
+staging_sha=$(heroku releases -a michigan-benefits-staging | head -n 2 | tail -n 1 | cut -d " " -f 4)
+prod_sha=$(heroku releases -a michigan-benefits-production | head -n 2 | tail -n 1 | cut -d " " -f 4)
 open "https://github.com/codeforamerica/michigan-benefits/compare/$prod_sha...$staging_sha"

--- a/bin/release-diff
+++ b/bin/release-diff
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-staging_sha=$(heroku releases -a michigan-benefits-staging | head -n 2 | tail -n 1 | cut -d " " -f 4)
-prod_sha=$(heroku releases -a michigan-benefits-production | head -n 2 | tail -n 1 | cut -d " " -f 4)
+staging_sha=$(heroku releases -r staging | head -n 2 | tail -n 1 | cut -d " " -f 4)
+prod_sha=$(heroku releases -r production | head -n 2 | tail -n 1 | cut -d " " -f 4)
 open "https://github.com/codeforamerica/michigan-benefits/compare/$prod_sha...$staging_sha"


### PR DESCRIPTION
Reason for Change
===================
* Our deploy script opens up a giant diff every time because the production server hadn't had a real git push in a long long time. This wasn't very usable because it had lots of noise and stuff outside of the actual changes between production and staging. This tightens it up to comparing the latest production deploy to the latest staging deploy.
* https://trello.com/c/fZg67unC/306-improve-readability-of-deploy-diffs