### PR TITLE
Make it easier to drive a given application

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,13 +228,8 @@ should get this set up for you automatically.
 
 ### How to Drive Applications
 
-To run the driver code, use `rails console` and (where
-`<id>` is the id of a snap application record) run:
-
-```ruby
-snap_application = SnapApplication.find(<id>)
-MiBridges::Driver.new(snap_application: snap_application).run
-```
+To run the driver code, use `bin/drive <id>` (where
+`<id>` is the id of a snap application record):
 
 There are three extra environment variables you can set to modify the behavior
 of the script.
@@ -249,6 +244,6 @@ Example:
 
 ```sh
 DRIVER_SPEED=slow \
-             WEB_DRIVER=chrome \
-             DEBUG_DRIVE=true \
-             ./bin/rails runner "MiBridges::Driver.new(snap_application: SnapApplication.find(ID)).run"
+  WEB_DRIVER=chrome \
+  DEBUG_DRIVE=true \
+  bin/drive 1234

--- a/bin/drive
+++ b/bin/drive
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+./bin/rails runner "app = SnapApplication.find($1);
+app.driver_applications.destroy_all; MiBridges::Driver.new(snap_application: SnapApplication.find($1)).run"

--- a/bin/drive_demo
+++ b/bin/drive_demo
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+export DRIVER_SPEED="slow"
 ./bin/rails runner "app = SnapApplication.find($1);
 app.driver_applications.destroy_all; MiBridges::Driver.new(snap_application: SnapApplication.find($1)).run"

--- a/bin/drive_dev
+++ b/bin/drive_dev
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+
+export DEBUG_DRIVE="true"
+./bin/rails runner "app = SnapApplication.find($1);
+app.driver_applications.destroy_all; MiBridges::Driver.new(snap_application: SnapApplication.find($1)).run"

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -89,7 +89,6 @@ module MiBridges
     attr_reader :snap_application
 
     def setup
-      DriverApplication.destroy_all
       Capybara.default_driver = ENV.fetch("WEB_DRIVER", "chrome").to_sym
     end
 


### PR DESCRIPTION
Reason for Change
===================
* I kept having to look up docs on how to run the driver against a particular app, so I scripted it?

Minor
=====
* I got rid of that `destroy_all` in the Driver setup, since I don't think we actually want to be destroying all?