### PR TITLE
Expose the office name in the dashboard

### DIFF
--- a/app/dashboards/snap_application_dashboard.rb
+++ b/app/dashboards/snap_application_dashboard.rb
@@ -39,7 +39,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     monthly_care_expenses: Field::String,
     monthly_court_ordered_expenses: Field::String,
     monthly_medical_expenses: Field::String,
-    office_location: Field::String,
+    receiving_office_name: Field::String,
     phone_number: Field::String,
     property_tax_expense: Field::Number,
     real_estate_income: Field::Boolean,
@@ -68,7 +68,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     phone_number
     email
     zip
-    office_location
+    receiving_office_name
     signed_at
     faxed_successfully_at
     fax_metadata

--- a/app/jobs/fax_application_job.rb
+++ b/app/jobs/fax_application_job.rb
@@ -1,14 +1,15 @@
 class FaxApplicationJob < ApplicationJob
   def perform(export:)
     export.execute do |snap_application|
-      fax_recipient = FaxRecipient.new(snap_application: snap_application)
+      receiving_office = snap_application.receiving_office
+
       Fax.send_fax(
-        number: fax_recipient.number,
+        number: receiving_office.number,
         file: snap_application.pdf.path,
-        recipient: fax_recipient.name,
+        recipient: receiving_office.name,
       )
 
-      "Faxed to #{fax_recipient.name} (#{fax_recipient.number})"
+      "Faxed to #{receiving_office.name} (#{receiving_office.number})"
     end
   end
 end

--- a/app/models/fax_recipient.rb
+++ b/app/models/fax_recipient.rb
@@ -12,12 +12,23 @@ class FaxRecipient
   end
 
   def name
-    ENV.fetch("FAX_RECIPIENT", "Michigan Bridges")
+    office["name"].to_s.titleize
+  end
+
+  def office
+    if office_location.present?
+      office = self.class.offices[office_location]
+      office["name"] = office_location
+      office
+    else
+      self.class.find_by(zip: residential_address.zip)
+    end
   end
 
   def self.find_by(zip:)
     name = covered_zip_codes[zip] || configuration["fallback_office"]
     Rails.logger.debug("Mapped zip #{zip} to office #{name}")
+    offices[name]["name"] = name
     offices[name]
   end
 

--- a/app/models/fax_recipient.rb
+++ b/app/models/fax_recipient.rb
@@ -4,31 +4,24 @@ class FaxRecipient
   end
 
   def number
-    if office_location.present?
-      self.class.offices[office_location]["fax_number"]
-    else
-      self.class.find_by(zip: residential_address.zip)["fax_number"]
-    end
+    office["fax_number"]
   end
 
   def name
-    office["name"].to_s.titleize
+    office["name"]
   end
 
   def office
     if office_location.present?
-      office = self.class.offices[office_location]
-      office["name"] = office_location
-      office
+      self.class.offices[office_location]
     else
       self.class.find_by(zip: residential_address.zip)
     end
   end
 
   def self.find_by(zip:)
-    name = covered_zip_codes[zip] || configuration["fallback_office"]
+    name = covered_zip_codes[zip.to_s] || configuration["fallback_office"]
     Rails.logger.debug("Mapped zip #{zip} to office #{name}")
-    offices[name]["name"] = name
     offices[name]
   end
 
@@ -45,8 +38,20 @@ class FaxRecipient
   end
 
   def self.full_configuration
-    @full_configuration ||= YAML.safe_load(configuration_file, [Symbol], [],
+    return @full_configuration if @full_configuration.present?
+    @full_configuration = YAML.safe_load(configuration_file, [Symbol], [],
                                            true)
+    add_names_to_offices(@full_configuration)
+    @full_configuration
+  end
+
+  def self.add_names_to_offices(configuration)
+    configuration.keys.each do |stage|
+      next unless configuration[stage].key?("offices")
+      configuration[stage]["offices"].keys.each do |office|
+        configuration[stage]["offices"][office]["name"] = office.to_s.titleize
+      end
+    end
   end
 
   def self.configuration_file

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -65,6 +65,18 @@ class SnapApplication < ApplicationRecord
     addresses.where.not(mailing: true).first || NullAddress.new
   end
 
+  def zip
+    residential_address.zip
+  end
+
+  def receiving_office
+    @receiving_office ||= FaxRecipient.new(snap_application: self)
+  end
+
+  def receiving_office_name
+    receiving_office.name
+  end
+
   def full_name
     primary_member.full_name
   end

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -69,12 +69,12 @@ class SnapApplication < ApplicationRecord
     residential_address.zip
   end
 
-  def receiving_office
-    @receiving_office ||= FaxRecipient.new(snap_application: self)
-  end
-
   def receiving_office_name
     receiving_office.name
+  end
+
+  def receiving_office
+    @receiving_office ||= FaxRecipient.new(snap_application: self)
   end
 
   def full_name

--- a/config/offices.yml
+++ b/config/offices.yml
@@ -2,7 +2,7 @@
 defaults: &defaults
   # Which office to send the fax to in the event the submitted
   # zip code is not in our mapping
-  fallback_office: "union"
+  fallback_office: "clio"
   covered_zip_codes:
     "12345": "staging_sfax"
     # Clio Zip Codes
@@ -54,7 +54,6 @@ development:
       fax_number: "+16173963015"
 production:
   <<: *defaults
-  fallback_office: "clio"
   offices:
     staging_sfax:
       fax_number: "+18888433549"

--- a/spec/jobs/fax_application_job_spec.rb
+++ b/spec/jobs/fax_application_job_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe FaxApplicationJob do
       job = FaxApplicationJob.new
 
       allow(Fax).to receive(:send_fax)
-      recipient = FaxRecipient.new(snap_application: snap_application)
 
       job.perform(export: export)
 
@@ -19,8 +18,8 @@ RSpec.describe FaxApplicationJob do
       expect(snap_application).to be_faxed
 
       expect(Fax).to have_received(:send_fax).
-        with(hash_including(number: recipient.number,
-                            recipient: recipient.name))
+        with(hash_including(number: snap_application.receiving_office.number,
+                            recipient: snap_application.receiving_office.name))
     end
 
     it "does not send a fax if application has already been sent" do

--- a/spec/models/fax_recipient_spec.rb
+++ b/spec/models/fax_recipient_spec.rb
@@ -72,9 +72,6 @@ RSpec.describe FaxRecipient do
       expect(fax_recipient.name).to eq fax_recipient.office["name"]
     end
   end
-  def sandbox_fax_number
-    "+16173963015"
-  end
 
   def clio_fax_number
     "+18107602310"


### PR DESCRIPTION
Reason for Change
===================
* When working on another ticket, I had noticed that we said "Michigan Bridges" as the recipient which is... annoying at best and misleading at worst. I wanted to make sure we could more easily answer the question of "Which office did the fax go to?" and "Which office did should the fax go to?"

##### Before
<img width="479" alt="screen shot 2017-09-14 at 1 18 57 pm" src="https://user-images.githubusercontent.com/50284/30454628-cb9acad2-9951-11e7-920d-d73893281930.png">

##### After
<img width="835" alt="screen shot 2017-09-14 at 1 32 50 pm" src="https://user-images.githubusercontent.com/50284/30454636-d22932da-9951-11e7-8352-0dfee552964e.png">

