### PR TITLE
OK, maybe this won't fail on first build?

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "michigan-benefits",
   "description": "Providing SNAP better, stronger, and faster",
   "scripts": {
-    "postdeploy": "bin/rails db:setup"
+    "postdeploy": "bin/rails db:migrate db:seed"
   },
   "env": {
     "ADMIN_PASSWORD": {


### PR DESCRIPTION
Reason for Change
===================
* Heroku kept saying deploys failed, which was making me worried we can't use review apps very effectively when they are useful. I think it's because `db:setup` does a create operation which fails.