### PR TITLE
Make Next button full width on mobile

### DIFF
--- a/app/assets/stylesheets/atoms/_buttons.scss
+++ b/app/assets/stylesheets/atoms/_buttons.scss
@@ -27,6 +27,14 @@
   }
 }
 
+.button--next {
+  width: 100%;
+
+  @include media($tablet-up) {
+    width: auto;
+  }
+}
+
 .button--cta {
   color: #FFFFFF;
   background-color: $button-cta-color;


### PR DESCRIPTION
Reason for Change
===================
* https://trello.com/c/dk9B6ndW/303-full-width-continue-button-on-mobile
* Make Next button full width on mobile

![image](https://user-images.githubusercontent.com/7483074/30502480-9f19a96a-9a23-11e7-9268-a55703db67de.png)
