### PR TITLE
Use the correct region when retrieving files

### DIFF
--- a/app/models/remote_document.rb
+++ b/app/models/remote_document.rb
@@ -60,6 +60,7 @@ class RemoteDocument
     @_s3 ||= Aws::S3::Client.new(
       access_key_id: Rails.application.secrets.aws_key,
       secret_access_key: Rails.application.secrets.aws_secret,
+      region: Rails.application.secrets.aws_region,
     )
   end
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -24,6 +24,7 @@ from_environment: &deployable_settings
   aws_key: <%= ENV.fetch("AWS_ACCESS_KEY_ID", ENV["BUCKETEER_AWS_ACCESS_KEY_ID"]) %>
   aws_secret: <%= ENV.fetch("AWS_SECRET_ACCESS_KEY", ENV["BUCKETEER_AWS_SECRET_ACCESS_KEY"]) %>
   aws_bucket: <%= ENV.fetch("AWS_BUCKET", ENV["BUCKETEER_BUCKET_NAME"]) %>
+  aws_region: <%= ENV.fetch("AWS_REGION", ENV["BUCKETEER_REGION"]) %>
 
 development:
   <<: *deployable_settings


### PR DESCRIPTION
Reason for Change
===================
* AWS requires us to tell it which region to check against when downloading files; however Bucketeer's `BUCKETEER_REGION` isn't picked up automatically by the S3 gem.
* https://trello.com/c/G9MsDFD1/325-awsregion-missing-on-staging-prod