### PR TITLE
Don't close PDFs if they haven't been opened

### DIFF
--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -36,6 +36,13 @@ class SnapApplication < ApplicationRecord
     ).completed_file
   end
 
+  def close_pdf
+    if @pdf.exists?
+      @pdf.close
+      @pdf.unlink
+    end
+  end
+
   def monthly_gross_income
     [
       monthly_additional_income,

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -37,7 +37,7 @@ class SnapApplication < ApplicationRecord
   end
 
   def close_pdf
-    if @pdf.exists?
+    if @pdf.present? && @pdf.respond_to?(:close)
       @pdf.close
       @pdf.unlink
     end

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Export do
 
     it "frees up the snap applications PDF" do
       export = build(:export)
-      export.execute { "I'm a noop" }
+      export.execute { export.snap_application.pdf }
       expect(export.snap_application.pdf).to be_closed
     end
 
@@ -88,6 +88,19 @@ RSpec.describe Export do
       expect(export.metadata).to include "An info line"
       expect(export.metadata).to include "A warning line"
       expect(export.metadata).to include "An error line"
+    end
+
+    it "fails exports that happen in the ensure block" do
+      export = build(:export)
+      allow(export.snap_application).to receive(:close_pdf) { raise "Oh nooo" }
+
+      export.execute do |_snap_application, logger|
+        logger.info("I succeeded!")
+      end
+
+      expect(export.status).to eq :failed
+      expect(export.metadata).to include "I succeeded!"
+      expect(export.metadata).to include "Oh nooo"
     end
   end
 end


### PR DESCRIPTION


Reason for Change
===================
* Closing the PDF also opened it, which seems unnecessary.
* Debugging exports was weird because we would say the export succeeded, even if the Job still existed because an exception was raised as part of our ensure statement.
* https://trello.com/c/pcoLnZzS/326-fail-exports-appropriately-when-ensure-fails

Minor Changes
=======
* If we fail at any time, let's mark the export as failed.