### PR TITLE
Check page title on each driver step

### DIFF
--- a/lib/mi_bridges/driver/additional_information_page.rb
+++ b/lib/mi_bridges/driver/additional_information_page.rb
@@ -1,6 +1,12 @@
 module MiBridges
   class Driver
     class AdditionalInformationPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Additional Information",
+        )
+      end
+
       def fill_in_required_fields
         fill_in(
           "addUsrComments",

--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -64,6 +64,11 @@ module MiBridges
 
       attr_reader :snap_application, :logger
 
+      def check_page_title(title)
+        id = title.gsub(/[^0-9A-Za-z]/, "")
+        page.find(:css, "##{id}")
+      end
+
       def log(description, *text)
         logger.tagged(self.class.to_s) do
           logger.debug("#{description.upcase}: #{text.join(', ')}")

--- a/lib/mi_bridges/driver/basic_information_summary_page.rb
+++ b/lib/mi_bridges/driver/basic_information_summary_page.rb
@@ -3,6 +3,11 @@
 module MiBridges
   class Driver
     class BasicInformationSummaryPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Basic Information Summary",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/benefits_overview_page.rb
+++ b/lib/mi_bridges/driver/benefits_overview_page.rb
@@ -3,7 +3,9 @@
 module MiBridges
   class Driver
     class BenefitsOverviewPage < BasePage
-      def setup; end
+      def setup
+        check_page_title("Benefits Program Overview")
+      end
 
       def fill_in_required_fields; end
 

--- a/lib/mi_bridges/driver/benefits_selector_page.rb
+++ b/lib/mi_bridges/driver/benefits_selector_page.rb
@@ -3,7 +3,11 @@
 module MiBridges
   class Driver
     class BenefitsSelectorPage < BasePage
-      def setup; end
+      def setup
+        check_page_title(
+          "Which Benefits Would You Like to Apply For? (All Programs)",
+        )
+      end
 
       def fill_in_required_fields
         click_id(food_assistance_checkbox)

--- a/lib/mi_bridges/driver/create_account_confirmation_page.rb
+++ b/lib/mi_bridges/driver/create_account_confirmation_page.rb
@@ -3,7 +3,9 @@
 module MiBridges
   class Driver
     class CreateAccountConfirmationPage < BasePage
-      def setup; end
+      def setup
+        check_page_title("Congratulations")
+      end
 
       def fill_in_required_fields; end
 

--- a/lib/mi_bridges/driver/create_account_page.rb
+++ b/lib/mi_bridges/driver/create_account_page.rb
@@ -7,7 +7,9 @@ module MiBridges
       MAXIMUM_USER_ID_CHAR_COUNT = 20
       MAXIMUM_PASSWORD_CHAR_COUNT = 16
 
-      def setup; end
+      def setup
+        check_page_title("Setting Up Your Account")
+      end
 
       def fill_in_required_fields
         if driver_application.blank?

--- a/lib/mi_bridges/driver/disability_or_blindness_review_page.rb
+++ b/lib/mi_bridges/driver/disability_or_blindness_review_page.rb
@@ -3,6 +3,11 @@
 module MiBridges
   class Driver
     class DisabilityOrBlindnessReviewPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Review Your Answers: Disability or Blindness",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/finish_page.rb
+++ b/lib/mi_bridges/driver/finish_page.rb
@@ -1,6 +1,11 @@
 module MiBridges
   class Driver
     class FinishPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Getting Expedited Food Assistance Program Benefits",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/fraud_penalty_affidavit_page.rb
+++ b/lib/mi_bridges/driver/fraud_penalty_affidavit_page.rb
@@ -3,7 +3,9 @@
 module MiBridges
   class Driver
     class FraudPenaltyAffidavitPage < BasePage
-      def setup; end
+      def setup
+        check_page_title("Fraud Penalty Affidavit")
+      end
 
       def fill_in_required_fields; end
 

--- a/lib/mi_bridges/driver/household_member_questions_page.rb
+++ b/lib/mi_bridges/driver/household_member_questions_page.rb
@@ -11,7 +11,11 @@ module MiBridges
 
       delegate :first_name, to: :primary_member
 
-      def setup; end
+      def setup
+        check_page_title(
+          "Household Member Questions",
+        )
+      end
 
       def fill_in_required_fields
         check_blindness_or_disability

--- a/lib/mi_bridges/driver/household_members_summary_page.rb
+++ b/lib/mi_bridges/driver/household_members_summary_page.rb
@@ -3,6 +3,11 @@
 module MiBridges
   class Driver
     class HouseholdMembersSummaryPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Household Members Summary",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/housing_utility_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_utility_bills_page.rb
@@ -10,7 +10,11 @@ module MiBridges
 
       delegate :first_name, to: :primary_member
 
-      def setup; end
+      def setup
+        check_page_title(
+          "Housing and Utility Bills",
+        )
+      end
 
       def fill_in_required_fields
         check_housing_bills

--- a/lib/mi_bridges/driver/housing_utility_bills_summary_page.rb
+++ b/lib/mi_bridges/driver/housing_utility_bills_summary_page.rb
@@ -3,6 +3,11 @@
 module MiBridges
   class Driver
     class HousingUtilityBillsSummaryPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Housing and Utility Bills Summary",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/job_income_information_page.rb
+++ b/lib/mi_bridges/driver/job_income_information_page.rb
@@ -11,7 +11,11 @@ module MiBridges
         to: :primary_member,
       )
 
-      def setup; end
+      def setup
+        check_page_title(
+          "Job Income Information",
+        )
+      end
 
       def fill_in_required_fields
         check_fulltime_employment_status

--- a/lib/mi_bridges/driver/job_income_summary_page.rb
+++ b/lib/mi_bridges/driver/job_income_summary_page.rb
@@ -3,6 +3,11 @@
 module MiBridges
   class Driver
     class JobIncomeSummaryPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Job Income Summary",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/liquid_assets_page.rb
+++ b/lib/mi_bridges/driver/liquid_assets_page.rb
@@ -12,7 +12,11 @@ module MiBridges
 
       delegate :first_name, to: :primary_member
 
-      def setup; end
+      def setup
+        check_page_title(
+          "Liquid Assets",
+        )
+      end
 
       def fill_in_required_fields
         check_cash_on_hand

--- a/lib/mi_bridges/driver/liquid_assets_summary_page.rb
+++ b/lib/mi_bridges/driver/liquid_assets_summary_page.rb
@@ -3,6 +3,11 @@
 module MiBridges
   class Driver
     class LiquidAssetsSummaryPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Liquid Assets Summary",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/money_other_sources_page.rb
+++ b/lib/mi_bridges/driver/money_other_sources_page.rb
@@ -12,7 +12,11 @@ module MiBridges
 
       delegate :first_name, to: :primary_member
 
-      def setup; end
+      def setup
+        check_page_title(
+          "Money From Other Sources",
+        )
+      end
 
       def fill_in_required_fields
         check_retirement_survivors_disability_insurance

--- a/lib/mi_bridges/driver/money_other_sources_summary_page.rb
+++ b/lib/mi_bridges/driver/money_other_sources_summary_page.rb
@@ -3,6 +3,11 @@
 module MiBridges
   class Driver
     class MoneyOtherSourcesSummaryPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Other Income Summary",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/other_assets_page.rb
+++ b/lib/mi_bridges/driver/other_assets_page.rb
@@ -13,7 +13,11 @@ module MiBridges
 
       delegate :first_name, to: :primary_member
 
-      def setup; end
+      def setup
+        check_page_title(
+          "Other Assets",
+        )
+      end
 
       def fill_in_required_fields
         check_vehicles

--- a/lib/mi_bridges/driver/other_assets_summary_page.rb
+++ b/lib/mi_bridges/driver/other_assets_summary_page.rb
@@ -3,6 +3,11 @@
 module MiBridges
   class Driver
     class OtherAssetsSummaryPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Other Assets Summary",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/other_information_page.rb
+++ b/lib/mi_bridges/driver/other_information_page.rb
@@ -1,6 +1,11 @@
 module MiBridges
   class Driver
     class OtherInformationPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Other Information",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/other_information_summary_page.rb
+++ b/lib/mi_bridges/driver/other_information_summary_page.rb
@@ -1,6 +1,11 @@
 module MiBridges
   class Driver
     class OtherInformationSummaryPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Other Information Summary",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/people_listed_page.rb
+++ b/lib/mi_bridges/driver/people_listed_page.rb
@@ -5,7 +5,11 @@ module MiBridges
     class PeopleListedPage < BasePage
       delegate :primary_member, to: :snap_application
 
-      def setup; end
+      def setup
+        check_page_title(
+          "People Listed On Your Application",
+        )
+      end
 
       def fill_in_required_fields
         select primary_member.marital_status.titleize, from: "maritalStatus"

--- a/lib/mi_bridges/driver/personal_information_page.rb
+++ b/lib/mi_bridges/driver/personal_information_page.rb
@@ -9,7 +9,11 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup; end
+      def setup
+        check_page_title(
+          "Getting Started With Your Application",
+        )
+      end
 
       def fill_in_required_fields
         fill_in_name

--- a/lib/mi_bridges/driver/privacy_pin_page.rb
+++ b/lib/mi_bridges/driver/privacy_pin_page.rb
@@ -3,7 +3,11 @@
 module MiBridges
   class Driver
     class PrivacyPinPage < BasePage
-      def setup; end
+      def setup
+        check_page_title(
+          "Privacy PIN",
+        )
+      end
 
       def fill_in_required_fields
         click_id(this_is_a_private_computer_id)

--- a/lib/mi_bridges/driver/program_benefits_page.rb
+++ b/lib/mi_bridges/driver/program_benefits_page.rb
@@ -3,7 +3,9 @@
 module MiBridges
   class Driver
     class ProgramBenefitsPage < BasePage
-      def setup; end
+      def setup
+        check_page_title("More About Benefits")
+      end
 
       def fill_in_required_fields; end
 

--- a/lib/mi_bridges/driver/school_details_page.rb
+++ b/lib/mi_bridges/driver/school_details_page.rb
@@ -1,6 +1,12 @@
 module MiBridges
   class Driver
     class SchoolDetailsPage < ClickNextPage
+      def setup
+        check_page_title(
+          "School Enrollment",
+        )
+      end
+
       def fill_in_required_fields
         choose_enrollment_time_for(snap_application.primary_member)
         choose_highest_grade_completion_for(snap_application.primary_member)

--- a/lib/mi_bridges/driver/start_page.rb
+++ b/lib/mi_bridges/driver/start_page.rb
@@ -3,7 +3,11 @@
 module MiBridges
   class Driver
     class StartPage < BasePage
-      def setup; end
+      def setup
+        check_page_title(
+          "Help With Filing MI Bridges Application",
+        )
+      end
 
       def fill_in_required_fields
         click_id(a_staff_person_or_volunteer_at_an_agency)

--- a/lib/mi_bridges/driver/submit_page.rb
+++ b/lib/mi_bridges/driver/submit_page.rb
@@ -2,6 +2,11 @@
 module MiBridges
   class Driver
     class SubmitPage < DebuggerPage
+      def setup
+        check_page_title(
+          "Before You Submit the Application",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/veteran_information_page.rb
+++ b/lib/mi_bridges/driver/veteran_information_page.rb
@@ -1,6 +1,11 @@
 module MiBridges
   class Driver
     class VeteranInformationPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Veteran Information",
+        )
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
+++ b/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
@@ -12,7 +12,11 @@ module MiBridges
 
       delegate :first_name, to: :primary_member
 
-      def setup; end
+      def setup
+        check_page_title(
+          "Your Other Bills / Expenses",
+        )
+      end
 
       def fill_in_required_fields
         check_child_spousal_payments

--- a/lib/mi_bridges/driver/your_other_bills_expenses_summary_page.rb
+++ b/lib/mi_bridges/driver/your_other_bills_expenses_summary_page.rb
@@ -3,6 +3,11 @@
 module MiBridges
   class Driver
     class YourOtherBillsExpensesSummaryPage < ClickNextPage
+      def setup
+        check_page_title(
+          "Other Bills / Expenses Summary",
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
**WHY**: This helps with debugging and is an incremental step toward
filling out pages based on which page you are on rather than assuming a
certain order (which would be tricky since it's possible that there are
many different page orders depending on snap app data)