### PR TITLE
Send email to field office after submission

### DIFF
--- a/app/assets/stylesheets/michigan-benefits/administrate-extensions.scss
+++ b/app/assets/stylesheets/michigan-benefits/administrate-extensions.scss
@@ -12,5 +12,5 @@
 }
 
 .main-content__funnel__stage {
-  flex: 1 4 25%;
+  flex: 1 5 20%;
 }

--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -21,12 +21,17 @@ class SuccessController < StandardStepsController
       destination: :sms,
       snap_application: current_snap_application,
     )
+
+    ExportFactory.create(
+      destination: :office_email,
+      snap_application: current_snap_application,
+    )
   end
 
   def after_successful_update_hook
     flash[:notice] = flash_notice
     ExportFactory.create(
-      destination: :email,
+      destination: :client_email,
       snap_application: current_snap_application,
     )
   end

--- a/app/jobs/client_email_application_job.rb
+++ b/app/jobs/client_email_application_job.rb
@@ -1,4 +1,4 @@
-class EmailApplicationJob < ApplicationJob
+class ClientEmailApplicationJob < ApplicationJob
   def perform(export:)
     export.execute do |snap_application, logger|
       ApplicationMailer.snap_application_notification(

--- a/app/jobs/office_email_application_job.rb
+++ b/app/jobs/office_email_application_job.rb
@@ -1,0 +1,12 @@
+class OfficeEmailApplicationJob < ApplicationJob
+  def perform(export:)
+    export.execute do |snap_application|
+      ApplicationMailer.office_application_notification(
+        file_name: snap_application.pdf.path,
+        recipient_email: snap_application.receiving_office_email,
+      ).deliver
+
+      "Emailed to #{snap_application.receiving_office_email}"
+    end
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -8,4 +8,9 @@ class ApplicationMailer < ActionMailer::Base
     attachments["snap_application.pdf"] = File.read(file_name)
     mail to: recipient_email, subject: "Your SNAP application"
   end
+
+  def office_application_notification(file_name:, recipient_email:)
+    attachments["snap_application.pdf"] = File.read(file_name)
+    mail to: recipient_email, subject: "Newly submitted SNAP application"
+  end
 end

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -1,15 +1,32 @@
 class Export < ApplicationRecord
+  VALID_STATUS = %i(
+    new
+    queued
+    in_process
+    succeeded
+    failed
+    unnecessary
+  ).freeze
+
+  VALID_DESTINATIONS = %i(
+    client_email
+    office_email
+    fax
+    sms
+    mi_bridges
+  ).freeze
+
   belongs_to :snap_application
-  validates :status, inclusion: { in: %i(new queued in_process succeeded failed
-                                         unnecessary) }
-  validates :destination, inclusion: { in: %i(fax email sms mi_bridges) }
+  validates :status, inclusion: { in: VALID_STATUS }
+  validates :destination, inclusion: { in: VALID_DESTINATIONS }
 
   attribute :destination, :symbol
   attribute :status, :symbol
 
   default_scope { order(updated_at: :desc) }
   scope :faxed, -> { where(destination: :fax) }
-  scope :emailed, -> { where(destination: :email) }
+  scope :emailed_client, -> { where(destination: :client_email) }
+  scope :emailed_office, -> { where(destination: :office_email) }
   scope :succeeded, -> { where(status: :succeeded) }
   scope :for_destination, ->(destination) { where(destination: destination) }
   scope :completed, -> { where.not(completed_at: nil) }

--- a/app/models/export_factory.rb
+++ b/app/models/export_factory.rb
@@ -35,8 +35,10 @@ class ExportFactory
       case export.destination
       when :fax
         FaxApplicationJob.perform_later(export: export)
-      when :email
-        EmailApplicationJob.perform_later(export: export)
+      when :client_email
+        ClientEmailApplicationJob.perform_later(export: export)
+      when :office_email
+        OfficeEmailApplicationJob.perform_later(export: export)
       when :sms
         ApplicationSubmittedSmsJob.perform_later(export: export)
       when :mi_bridges

--- a/app/models/office_recipient.rb
+++ b/app/models/office_recipient.rb
@@ -1,4 +1,4 @@
-class FaxRecipient
+class OfficeRecipient
   def initialize(snap_application:)
     @snap_application = snap_application
   end
@@ -9,6 +9,10 @@ class FaxRecipient
 
   def name
     office["name"]
+  end
+
+  def email
+    office["email"]
   end
 
   def office

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -22,12 +22,16 @@ class SnapApplication < ApplicationRecord
     where.not(id: Export.faxed.succeeded.application_ids)
   end)
 
-  scope :emailed, (lambda do
-    where(id: Export.emailed.succeeded.application_ids)
+  scope :emailed_office, (lambda do
+    where(id: Export.emailed_office.succeeded.application_ids)
   end)
 
-  scope :unemailed, (lambda do
-    where.not(id: Export.emailed.succeeded.application_ids)
+  scope :emailed_client, (lambda do
+    where(id: Export.emailed_client.succeeded.application_ids)
+  end)
+
+  scope :unemailed_client, (lambda do
+    where.not(id: Export.emailed_client.succeeded.application_ids)
   end)
 
   def pdf
@@ -80,8 +84,12 @@ class SnapApplication < ApplicationRecord
     receiving_office.name
   end
 
+  def receiving_office_email
+    receiving_office.email
+  end
+
   def receiving_office
-    @receiving_office ||= FaxRecipient.new(snap_application: self)
+    @receiving_office ||= OfficeRecipient.new(snap_application: self)
   end
 
   def full_name

--- a/app/views/admin/snap_applications/index.html.erb
+++ b/app/views/admin/snap_applications/index.html.erb
@@ -54,7 +54,8 @@ It renders the `_table` partial to display details about the resources.
   <%= render "funnel_stage", stage: FunnelStage.new(previous_cohort: [], cohort: all_resources, name: "Created") %>
   <%= render "funnel_stage", stage: FunnelStage.new(previous_cohort: all_resources, cohort: all_resources.signed, name: "Signed") %>
   <%= render "funnel_stage", stage: FunnelStage.new(previous_cohort: all_resources, cohort: all_resources.faxed, name: "Faxed") %>
-  <%= render "funnel_stage", stage: FunnelStage.new(previous_cohort: all_resources, cohort: all_resources.emailed, name: "Emailed") %>
+  <%= render "funnel_stage", stage: FunnelStage.new(previous_cohort: all_resources, cohort: all_resources.emailed_office, name: "Emailed Office") %>
+  <%= render "funnel_stage", stage: FunnelStage.new(previous_cohort: all_resources, cohort: all_resources.emailed_client, name: "Emailed Client") %>
 </section>
 
 <section class="main-content__body main-content__body--flush">

--- a/app/views/application_mailer/office_application_notification.html.erb
+++ b/app/views/application_mailer/office_application_notification.html.erb
@@ -1,0 +1,3 @@
+Hello!
+
+A new SNAP application has been submitted and is attached here.

--- a/config/offices.yml
+++ b/config/offices.yml
@@ -45,19 +45,25 @@ defaults: &defaults
 development:
   <<: *defaults
   offices:
-    staging_sfax: # Technically this is to our sfax production fax; cuz you
-                  # can't fax urself
+    staging_sfax: # Technically this is to our sfax production fax;
+                  # because you can't fax yourself
       fax_number: "+18448487565"
+      email: "staging@example.com"
     union:
       fax_number: "+16173963015"
+      email: "union@example.com"
     clio:
       fax_number: "+16173963015"
+      email: "clio@example.com"
 production:
   <<: *defaults
   offices:
     staging_sfax:
       fax_number: "+18888433549"
+      email: "gcfengineering+heroku@codeforamerica.org"
     union:
       fax_number: "+18107607372"
+      email: "MDHHS-Genesee-UnionSt-DigitalAssisterApp@michigan.gov"
     clio:
       fax_number: "+18107602310"
+      email: "MDHHS-Genesee-Clio-App@michigan.gov"

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -59,6 +59,7 @@ RSpec.describe SuccessController do
     context "no sms consent present" do
       it "does not send an SMS" do
         Delayed::Worker.delay_jobs = false
+
         with_modified_env TWILIO_PHONE_NUMBER: "8005551212" do
           current_app.update(
             sms_consented: false,
@@ -110,7 +111,7 @@ RSpec.describe SuccessController do
         put :update, params: params
 
         expect(ExportFactory).to have_received(:create).
-          with(snap_application: current_app, destination: :email)
+          with(snap_application: current_app, destination: :client_email)
       end
     end
 

--- a/spec/factories/exports.rb
+++ b/spec/factories/exports.rb
@@ -2,14 +2,18 @@ FactoryGirl.define do
   factory :export do
     snap_application
 
-    destination :email
+    destination :client_email
 
     trait :faxed do
       destination :fax
     end
 
-    trait :emailed do
-      destination :email
+    trait :emailed_client do
+      destination :client_email
+    end
+
+    trait :emailed_office do
+      destination :office_email
     end
 
     trait :succeeded do

--- a/spec/factories/snap_applications.rb
+++ b/spec/factories/snap_applications.rb
@@ -17,9 +17,15 @@ FactoryGirl.define do
       end
     end
 
-    trait :emailed do
+    trait :emailed_client do
       after :create do |app|
-        create(:export, :emailed, :succeeded, snap_application: app)
+        create(:export, :emailed_client, :succeeded, snap_application: app)
+      end
+    end
+
+    trait :emailed_office do
+      after :create do |app|
+        create(:export, :emailed_office, :succeeded, snap_application: app)
       end
     end
   end

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -1,18 +1,21 @@
 require "rails_helper"
+
 RSpec.feature "Submit application with minimal information" do
   before do
     page.driver.browser.current_session.basic_authorize("admin", "password")
   end
   scenario "The stats are accurate", javascript: true do
     10.times { create(:snap_application, signed_at: nil) }
-    1.times { create(:snap_application, :emailed, signed_at: nil) }
+    1.times { create(:snap_application, :emailed_client, signed_at: nil) }
+    1.times { create(:snap_application, :emailed_office, signed_at: nil) }
     9.times { create(:snap_application, signed_at: 5.days.ago) }
     1.times { create(:snap_application, :faxed, signed_at: 5.days.ago) }
     visit admin_root_path
-    expect(page).to have_content "21 Created"
-    expect(page).to have_content "10 Signed (47.6%)"
-    expect(page).to have_content "1 Emailed (4.8%)"
-    expect(page).to have_content "1 Faxed (4.8%)"
+    expect(page).to have_content "22 Created"
+    expect(page).to have_content "10 Signed (45.5%)"
+    expect(page).to have_content "1 Emailed Client (4.5%)"
+    expect(page).to have_content "1 Emailed Office (4.5%)"
+    expect(page).to have_content "1 Faxed (4.5%)"
   end
 
   scenario "resending a fax", javascript: true do

--- a/spec/jobs/client_email_application_job_spec.rb
+++ b/spec/jobs/client_email_application_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe EmailApplicationJob do
+RSpec.describe ClientEmailApplicationJob do
   describe "#perform" do
     it "creates a PDF with the snap application data" do
       snap_application = create(:snap_application, :with_member)
@@ -11,7 +11,7 @@ RSpec.describe EmailApplicationJob do
       allow(ApplicationMailer).to receive(:snap_application_notification).
         and_return(fake_mailer)
 
-      EmailApplicationJob.new.perform(export: export)
+      ClientEmailApplicationJob.new.perform(export: export)
 
       expect(ApplicationMailer).to(
         have_received(:snap_application_notification).

--- a/spec/models/export_factory_spec.rb
+++ b/spec/models/export_factory_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe ExportFactory do
   describe "#enqueue" do
     before do
       allow(FaxApplicationJob).to receive(:perform_later)
-      allow(EmailApplicationJob).to receive(:perform_later)
+      allow(ClientEmailApplicationJob).to receive(:perform_later)
     end
 
     it "sends fax" do
@@ -55,11 +55,11 @@ RSpec.describe ExportFactory do
         with(export: export)
     end
 
-    it "sends email" do
+    it "sends email to client" do
       enqueuer = ExportFactory.new
-      export = build(:export, destination: :email)
+      export = build(:export, destination: :client_email)
       enqueuer.enqueue(export)
-      expect(EmailApplicationJob).to have_received(:perform_later).
+      expect(ClientEmailApplicationJob).to have_received(:perform_later).
         with(export: export)
     end
 
@@ -85,7 +85,7 @@ RSpec.describe ExportFactory do
       end.to raise_error(ActiveRecord::RecordInvalid)
       expect(export).not_to be_persisted
       expect(FaxApplicationJob).not_to have_received(:perform_later)
-      expect(EmailApplicationJob).not_to have_received(:perform_later)
+      expect(ClientEmailApplicationJob).not_to have_received(:perform_later)
     end
   end
 end

--- a/spec/models/export_spec.rb
+++ b/spec/models/export_spec.rb
@@ -48,14 +48,14 @@ RSpec.describe Export do
     end
 
     it "doesn't care if destination is a symbol" do
-      export = build(:export, destination: :email)
+      export = build(:export, destination: :client_email)
       expect(export).to be_valid
     end
 
     it "doesn't run when another export for the given destination is in " \
       "process or has succeeded" do
-      previous = create(:export, destination: :email)
-      export = build(:export, destination: :email,
+      previous = create(:export, destination: :client_email)
+      export = build(:export, destination: :client_email,
                               snap_application: previous.snap_application)
       export.execute { "It's unnecessary!" }
 
@@ -65,8 +65,8 @@ RSpec.describe Export do
     it "does run if another export for the given destination is in process " \
       "or succeeded when forced" do
 
-      previous = create(:export, destination: :email)
-      export = build(:export, destination: :email,
+      previous = create(:export, destination: :client_email)
+      export = build(:export, destination: :client_email,
                               force: true,
                               snap_application: previous.snap_application)
 

--- a/spec/models/office_recipient_spec.rb
+++ b/spec/models/office_recipient_spec.rb
@@ -1,18 +1,19 @@
 require "rails_helper"
 
-RSpec.describe FaxRecipient do
+RSpec.describe OfficeRecipient do
   describe "#office" do
     before { stub_const("ENV", "APP_RELEASE_STAGE" => "production") }
 
     context "office location is present" do
       it "priotizes to office location over residential address" do
-        fax_recipient = described_class.new(
-          snap_application: app(from_zip_covered_by: :clio,
-                                office_location: "union"),
-        )
+        application = app(from_zip_covered_by: :clio, office_location: "union")
+        fax_recipient = described_class.new(snap_application: application)
 
-        expect(fax_recipient.office).to eq("name" => "Union",
-                                           "fax_number" => union_fax_number)
+        expect(fax_recipient.office).to eq(
+          "email" => "MDHHS-Genesee-UnionSt-DigitalAssisterApp@michigan.gov",
+          "name" => "Union",
+          "fax_number" => union_fax_number,
+        )
       end
     end
 
@@ -21,8 +22,11 @@ RSpec.describe FaxRecipient do
         snap_application: app(from_zip_covered_by: :clio),
       )
 
-      expect(fax_recipient.office).to eq("name" => "Clio",
-                                         "fax_number" => clio_fax_number)
+      expect(fax_recipient.office).to eq(
+        "email" => "MDHHS-Genesee-Clio-App@michigan.gov",
+        "name" => "Clio",
+        "fax_number" => clio_fax_number,
+      )
     end
 
     it "uses the real fax number when the address is in union" do
@@ -30,8 +34,11 @@ RSpec.describe FaxRecipient do
         snap_application: app(from_zip_covered_by: :union),
       )
 
-      expect(fax_recipient.office).to eq("name" => "Union",
-                                         "fax_number" => union_fax_number)
+      expect(fax_recipient.office).to eq(
+        "email" => "MDHHS-Genesee-UnionSt-DigitalAssisterApp@michigan.gov",
+        "name" => "Union",
+        "fax_number" => union_fax_number,
+      )
     end
 
     it "falls back to the clio office" do
@@ -39,8 +46,11 @@ RSpec.describe FaxRecipient do
         snap_application: app(from_zip_covered_by: :nobody),
       )
 
-      expect(fax_recipient.office).to eq("name" => "Clio",
-                                         "fax_number" => clio_fax_number)
+      expect(fax_recipient.office).to eq(
+        "email" => "MDHHS-Genesee-Clio-App@michigan.gov",
+        "name" => "Clio",
+        "fax_number" => clio_fax_number,
+      )
     end
 
     it "allows for testing via zip 12345" do
@@ -48,8 +58,11 @@ RSpec.describe FaxRecipient do
         snap_application: app(from_zip_covered_by: :testing),
       )
 
-      expect(fax_recipient.office).to eq("name" => "Staging Sfax",
-                                         "fax_number" => staging_fax_number)
+      expect(fax_recipient.office).to eq(
+        "email" => "gcfengineering+heroku@codeforamerica.org",
+        "name" => "Staging Sfax",
+        "fax_number" => staging_fax_number,
+      )
     end
   end
 


### PR DESCRIPTION
Once a snap application is submitted, in order to make the review of the
application as quick as possible we should email the field office that best
corresponds to the address of the submitting client.

In order to do so:

* Change :email to :client_email and add :office_email. Until now we've only
  emailed the application to a client, but now want to email the application to
  the appropriate field office when the application is done. This changes
  :email to :client_email to be more specific, and adds :office_email as a
  possible destination for the export process.
* Rename `EmailApplicationJob` to `ClientEmailApplicationJob`.  This is one use
  case for emailing the generate PDF and should be qualified as such. The next
  commit will introduce an `OfficeEmailApplicationJob` that will send an email
  to an MDHHS office for their use instead of receiving a Fax.
* SnapApplication admin index updated w/addtl funnel