### PR TITLE
Add visibility into delayed job queues

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,6 +4,8 @@
 
 APP_RELEASE_STAGE=development
 
+ADMIN_USER="admin"
+ADMIN_PASSWORD="password"
 PORT=3000
 FORM_RECIPIENT=test@example.com
 MAILER_FROM=from@example.com

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem "aws-sdk"
 gem "bourbon", "~> 4.2.0" # to keep in sync with getcalfresh
 gem "capybara"
 gem "delayed_job_active_record"
+gem "delayed_job_web"
 gem "faraday"
 gem "jquery-rails"
 gem "mimemagic"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,10 @@ GEM
     delayed_job_active_record (4.1.2)
       activerecord (>= 3.0, < 5.2)
       delayed_job (>= 3.0, < 5)
+    delayed_job_web (1.4)
+      activerecord (> 3.0.0)
+      delayed_job (> 2.0.3)
+      sinatra (>= 1.4.4)
     diff-lcs (1.3)
     docile (1.1.5)
     dotenv (2.2.1)
@@ -395,6 +399,7 @@ DEPENDENCIES
   codeclimate-test-reporter
   database_cleaner
   delayed_job_active_record
+  delayed_job_web
   dotenv-rails
   factory_girl_rails
   faraday

--- a/config.ru
+++ b/config.ru
@@ -4,4 +4,15 @@
 
 require_relative "config/environment"
 
+if Rails.env.production?
+  DelayedJobWeb.use Rack::Auth::Basic do |username, password|
+    # rubocop:disable LineLength
+    username_match = ActiveSupport::SecurityUtils.variable_size_secure_compare(ENV["ADMIN_USER"], username)
+    password_match = ActiveSupport::SecurityUtils.variable_size_secure_compare(ENV["ADMIN_PASSWORD"], password)
+    # rubocop:enable LineLength
+
+    username_match && password_match
+  end
+end
+
 run Rails.application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  match "/delayed_job" => DelayedJobWeb, anchor: false, via: %i(get post)
+
   namespace :admin do
     resources :snap_applications do
       post "resend_fax", on: :member


### PR DESCRIPTION
Admins and developers should have some visibility into what the delayed
job queues look like, both currently and historically.

This commit adds the delayed_job_web gem and configures it to be
password protected with the same credentials as the administrate section
of the app.