### PR TITLE
Handle failed attempts getting non-existent S3 object

### DIFF
--- a/app/models/dhs1171_pdf.rb
+++ b/app/models/dhs1171_pdf.rb
@@ -84,8 +84,8 @@ class Dhs1171Pdf
       VerificationDocument.new(
         url: document,
         snap_application: snap_application,
-      ).file.path
-    end
+      ).file&.path
+    end.reject(&:nil?)
   end
 
   def client_data

--- a/app/models/remote_document.rb
+++ b/app/models/remote_document.rb
@@ -11,9 +11,8 @@ class RemoteDocument
   def download
     open(url) { |url_file| tempfile.write(url_file.read) }
     self
-  rescue OpenURI::HTTPError => _e
-    s3_download
-    self
+  rescue OpenURI::HTTPError
+    return self if s3_download
   ensure
     rotate if landscape_image?
   end
@@ -54,6 +53,9 @@ class RemoteDocument
       },
       target: tempfile.path,
     )
+    true
+  rescue Aws::S3::Errors::NoSuchKey
+    false
   end
 
   def s3

--- a/app/models/verification_document.rb
+++ b/app/models/verification_document.rb
@@ -6,6 +6,7 @@ class VerificationDocument
 
   def file
     downloaded_document = RemoteDocument.new(url).download
+    return if downloaded_document.nil?
     return downloaded_document.tempfile if downloaded_document.pdf?
 
     tempfile = Tempfile.new([SecureRandom.hex, ".pdf"])

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe PagesController, type: :controller do
     it "sets the snap_application_id to nil" do
       get :index
 
-      expect(session[:snap_application_id]).to eq nil
+      expect(session[:snap_application_id]).to be_nil
     end
   end
 end

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe SuccessController do
   context "in order to not allow going back" do
     describe "#previous_path" do
       it "returns nil" do
-        expect(subject.previous_path).to eq nil
+        expect(subject.previous_path).to be_nil
       end
     end
   end

--- a/spec/models/remote_document_spec.rb
+++ b/spec/models/remote_document_spec.rb
@@ -10,7 +10,7 @@ describe RemoteDocument do
 
         downloaded = RemoteDocument.new(document_url).download
 
-        expect(downloaded).not_to eq nil
+        expect(downloaded).not_to be_nil
         expect(file_type(downloaded.tempfile.path)).to eq "image/jpeg"
       end
 
@@ -25,7 +25,7 @@ describe RemoteDocument do
         downloaded = RemoteDocument.new(document_url).download
         imagemagick_file = MiniMagick::Image.open(downloaded.tempfile.path)
 
-        expect(downloaded).not_to eq nil
+        expect(downloaded).not_to be_nil
         expect(imagemagick_file.width < imagemagick_file.height).to eq true
       end
     end
@@ -45,7 +45,7 @@ describe RemoteDocument do
 
         downloaded = remote_document.download
 
-        expect(downloaded).not_to eq nil
+        expect(downloaded).not_to be_nil
         expect(s3_fake).to have_received(:get_object).with(
           {
             bucket: bucket,
@@ -69,7 +69,7 @@ describe RemoteDocument do
         stub_request(:get, document_url).
           to_raise(OpenURI::HTTPError.new("Error", nil))
 
-        expect(remote_document.download).to eq nil
+        expect(remote_document.download).to be_nil
       end
     end
   end

--- a/spec/models/verification_document_spec.rb
+++ b/spec/models/verification_document_spec.rb
@@ -44,6 +44,20 @@ describe VerificationDocument do
       end
     end
 
+    context "file does not successfully download" do
+      it "returns nil" do
+        remote_document = double("remote_document", download: nil)
+        allow(RemoteDocument).to receive(:new).and_return(remote_document)
+
+        document = VerificationDocument.new(
+          url: "doc url",
+          snap_application: "snap application",
+        )
+
+        expect(document.file).to eq nil
+      end
+    end
+
     def temp_image_file
       Tempfile.new(["image", ".jpg"]).tap do |f|
         f.write(File.read("spec/fixtures/image.jpg"))

--- a/spec/models/verification_document_spec.rb
+++ b/spec/models/verification_document_spec.rb
@@ -54,7 +54,7 @@ describe VerificationDocument do
           snap_application: "snap application",
         )
 
-        expect(document.file).to eq nil
+        expect(document.file).to be_nil
       end
     end
 

--- a/spec/steps/success_spec.rb
+++ b/spec/steps/success_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe PersonalDetail do
       it "returns nil" do
         step = Success.new(signed_at: nil)
 
-        expect(step.submitted_date).to eq nil
+        expect(step.submitted_date).to be_nil
       end
     end
   end


### PR DESCRIPTION
In the cases where an object in S3 no longer exists we need to handle
the effects that has in our system. This means we should NOT try to
attach this non-existent document.

This commit rescues the error from the AWS SDK and bubbles up the
resulting nils to the DHS1171Pdf class where it does not include them if
they are nil.