### PR TITLE
Fill out current page based on title, not order

### DIFF
--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -67,7 +67,14 @@ module MiBridges
 
     def run
       setup
+      sign_up_for_account
+      complete_application
+      teardown
+    end
 
+    private
+
+    def sign_up_for_account
       SIGN_UP_FLOW.each do |klass|
         begin
           page = klass.new(@snap_application, logger: logger)
@@ -78,12 +85,9 @@ module MiBridges
           debug(e)
         end
       end
-
-      complete_flow_steps
-      teardown
     end
 
-    def complete_flow_steps
+    def complete_application
       while page_title != SubmitPage::TITLE
         klass = find_page_klass
         page = klass.new(@snap_application, logger: logger)
@@ -94,8 +98,6 @@ module MiBridges
     rescue StandardError => e
       debug(e)
     end
-
-    private
 
     def logger=(logger)
       return @logger = logger if logger.present?

--- a/lib/mi_bridges/driver/additional_information_page.rb
+++ b/lib/mi_bridges/driver/additional_information_page.rb
@@ -1,11 +1,7 @@
 module MiBridges
   class Driver
     class AdditionalInformationPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Additional Information",
-        )
-      end
+      TITLE = "Additional Information".freeze
 
       def fill_in_required_fields
         fill_in(

--- a/lib/mi_bridges/driver/basic_information_summary_page.rb
+++ b/lib/mi_bridges/driver/basic_information_summary_page.rb
@@ -3,11 +3,7 @@
 module MiBridges
   class Driver
     class BasicInformationSummaryPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Basic Information Summary",
-        )
-      end
+      TITLE = "Basic Information Summary"
     end
   end
 end

--- a/lib/mi_bridges/driver/benefits_overview_page.rb
+++ b/lib/mi_bridges/driver/benefits_overview_page.rb
@@ -2,15 +2,11 @@
 
 module MiBridges
   class Driver
-    class BenefitsOverviewPage < BasePage
+    class BenefitsOverviewPage < ClickNextPage
+      TITLE = "Benefits Program Overview"
+
       def setup
-        check_page_title("Benefits Program Overview")
-      end
-
-      def fill_in_required_fields; end
-
-      def continue
-        click_on "Next"
+        check_page_title(TITLE)
       end
     end
   end

--- a/lib/mi_bridges/driver/benefits_selector_page.rb
+++ b/lib/mi_bridges/driver/benefits_selector_page.rb
@@ -3,11 +3,9 @@
 module MiBridges
   class Driver
     class BenefitsSelectorPage < BasePage
-      def setup
-        check_page_title(
-          "Which Benefits Would You Like to Apply For? (All Programs)",
-        )
-      end
+      TITLE = "Which Benefits Would You Like to Apply For? (All Programs)"
+
+      def setup; end
 
       def fill_in_required_fields
         click_id(food_assistance_checkbox)

--- a/lib/mi_bridges/driver/create_account_confirmation_page.rb
+++ b/lib/mi_bridges/driver/create_account_confirmation_page.rb
@@ -3,8 +3,10 @@
 module MiBridges
   class Driver
     class CreateAccountConfirmationPage < BasePage
+      TITLE = "Congratulations"
+
       def setup
-        check_page_title("Congratulations")
+        check_page_title(TITLE)
       end
 
       def fill_in_required_fields; end

--- a/lib/mi_bridges/driver/create_account_page.rb
+++ b/lib/mi_bridges/driver/create_account_page.rb
@@ -6,9 +6,10 @@ module MiBridges
       MAXIMUM_SECRET_QUESTION_ANSWER_CHAR_COUNT = 20
       MAXIMUM_USER_ID_CHAR_COUNT = 20
       MAXIMUM_PASSWORD_CHAR_COUNT = 16
+      TITLE = "Setting Up Your Account"
 
       def setup
-        check_page_title("Setting Up Your Account")
+        check_page_title(TITLE)
       end
 
       def fill_in_required_fields

--- a/lib/mi_bridges/driver/disability_or_blindness_review_page.rb
+++ b/lib/mi_bridges/driver/disability_or_blindness_review_page.rb
@@ -3,11 +3,7 @@
 module MiBridges
   class Driver
     class DisabilityOrBlindnessReviewPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Review Your Answers: Disability or Blindness",
-        )
-      end
+      TITLE = "Review Your Answers: Disability or Blindness"
     end
   end
 end

--- a/lib/mi_bridges/driver/finish_page.rb
+++ b/lib/mi_bridges/driver/finish_page.rb
@@ -1,11 +1,7 @@
 module MiBridges
   class Driver
     class FinishPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Getting Expedited Food Assistance Program Benefits",
-        )
-      end
+      TITLE = "Getting Expedited Food Assistance Program Benefits".freeze
     end
   end
 end

--- a/lib/mi_bridges/driver/fraud_penalty_affidavit_page.rb
+++ b/lib/mi_bridges/driver/fraud_penalty_affidavit_page.rb
@@ -2,15 +2,11 @@
 
 module MiBridges
   class Driver
-    class FraudPenaltyAffidavitPage < BasePage
+    class FraudPenaltyAffidavitPage < ClickNextPage
+      TITLE = "Fraud Penalty Affidavit"
+
       def setup
-        check_page_title("Fraud Penalty Affidavit")
-      end
-
-      def fill_in_required_fields; end
-
-      def continue
-        click_on "Next"
+        check_page_title(TITLE)
       end
     end
   end

--- a/lib/mi_bridges/driver/household_member_questions_page.rb
+++ b/lib/mi_bridges/driver/household_member_questions_page.rb
@@ -3,17 +3,15 @@
 module MiBridges
   class Driver
     class HouseholdMemberQuestionsPage < BasePage
+      TITLE = "Household Member Questions"
+
       delegate(
         :anyone_disabled?,
         :primary_member,
         to: :snap_application,
       )
 
-      def setup
-        check_page_title(
-          "Household Member Questions",
-        )
-      end
+      def setup; end
 
       def fill_in_required_fields
         check_blindness_or_disability

--- a/lib/mi_bridges/driver/household_members_summary_page.rb
+++ b/lib/mi_bridges/driver/household_members_summary_page.rb
@@ -3,11 +3,7 @@
 module MiBridges
   class Driver
     class HouseholdMembersSummaryPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Household Members Summary",
-        )
-      end
+      TITLE = "Household Members Summary"
     end
   end
 end

--- a/lib/mi_bridges/driver/housing_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_bills_page.rb
@@ -3,10 +3,9 @@
 module MiBridges
   class Driver
     class HousingBillsPage < BasePage
-      delegate(
-        :primary_member,
-        to: :snap_application,
-      )
+      TITLE = "Housing Bills"
+
+      delegate :primary_member, to: :snap_application
 
       def setup; end
 

--- a/lib/mi_bridges/driver/housing_utility_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_utility_bills_page.rb
@@ -3,16 +3,11 @@
 module MiBridges
   class Driver
     class HousingUtilityBillsPage < BasePage
-      delegate(
-        :primary_member,
-        to: :snap_application,
-      )
+      TITLE = "Housing and Utility Bills"
 
-      def setup
-        check_page_title(
-          "Housing and Utility Bills",
-        )
-      end
+      delegate :primary_member, to: :snap_application
+
+      def setup; end
 
       def fill_in_required_fields
         check_housing_bills

--- a/lib/mi_bridges/driver/housing_utility_bills_summary_page.rb
+++ b/lib/mi_bridges/driver/housing_utility_bills_summary_page.rb
@@ -3,11 +3,7 @@
 module MiBridges
   class Driver
     class HousingUtilityBillsSummaryPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Housing and Utility Bills Summary",
-        )
-      end
+      TITLE = "Housing and Utility Bills Summary"
     end
   end
 end

--- a/lib/mi_bridges/driver/job_income_information_page.rb
+++ b/lib/mi_bridges/driver/job_income_information_page.rb
@@ -3,18 +3,12 @@
 module MiBridges
   class Driver
     class JobIncomeInformationPage < BasePage
+      TITLE = "Job Income Information"
+
       delegate :primary_member, to: :snap_application
+      delegate :employment_status, to: :primary_member
 
-      delegate(
-        :employment_status,
-        to: :primary_member,
-      )
-
-      def setup
-        check_page_title(
-          "Job Income Information",
-        )
-      end
+      def setup; end
 
       def fill_in_required_fields
         check_fulltime_employment_status

--- a/lib/mi_bridges/driver/job_income_summary_page.rb
+++ b/lib/mi_bridges/driver/job_income_summary_page.rb
@@ -3,11 +3,7 @@
 module MiBridges
   class Driver
     class JobIncomeSummaryPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Job Income Summary",
-        )
-      end
+      TITLE = "Job Income Summary"
     end
   end
 end

--- a/lib/mi_bridges/driver/liquid_assets_page.rb
+++ b/lib/mi_bridges/driver/liquid_assets_page.rb
@@ -3,6 +3,8 @@
 module MiBridges
   class Driver
     class LiquidAssetsPage < BasePage
+      TITLE = "Liquid Assets"
+
       delegate(
         :financial_accounts,
         :primary_member,
@@ -10,11 +12,7 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup
-        check_page_title(
-          "Liquid Assets",
-        )
-      end
+      def setup; end
 
       def fill_in_required_fields
         check_cash_on_hand

--- a/lib/mi_bridges/driver/liquid_assets_summary_page.rb
+++ b/lib/mi_bridges/driver/liquid_assets_summary_page.rb
@@ -3,11 +3,7 @@
 module MiBridges
   class Driver
     class LiquidAssetsSummaryPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Liquid Assets Summary",
-        )
-      end
+      TITLE = "Liquid Assets Summary"
     end
   end
 end

--- a/lib/mi_bridges/driver/money_other_sources_page.rb
+++ b/lib/mi_bridges/driver/money_other_sources_page.rb
@@ -3,6 +3,8 @@
 module MiBridges
   class Driver
     class MoneyOtherSourcesPage < BasePage
+      TITLE = "Money From Other Sources"
+
       delegate(
         :income_other?,
         :income_ssi_or_disability?,
@@ -10,11 +12,7 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup
-        check_page_title(
-          "Money From Other Sources",
-        )
-      end
+      def setup; end
 
       def fill_in_required_fields
         check_retirement_survivors_disability_insurance

--- a/lib/mi_bridges/driver/money_other_sources_summary_page.rb
+++ b/lib/mi_bridges/driver/money_other_sources_summary_page.rb
@@ -3,11 +3,7 @@
 module MiBridges
   class Driver
     class MoneyOtherSourcesSummaryPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Other Income Summary",
-        )
-      end
+      TITLE = "Other Income Summary"
     end
   end
 end

--- a/lib/mi_bridges/driver/other_assets_page.rb
+++ b/lib/mi_bridges/driver/other_assets_page.rb
@@ -3,6 +3,8 @@
 module MiBridges
   class Driver
     class OtherAssetsPage < BasePage
+      TITLE = "Other Assets"
+
       delegate(
         :financial_accounts,
         :primary_member,
@@ -11,11 +13,7 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup
-        check_page_title(
-          "Other Assets",
-        )
-      end
+      def setup; end
 
       def fill_in_required_fields
         check_vehicles

--- a/lib/mi_bridges/driver/other_assets_summary_page.rb
+++ b/lib/mi_bridges/driver/other_assets_summary_page.rb
@@ -3,11 +3,7 @@
 module MiBridges
   class Driver
     class OtherAssetsSummaryPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Other Assets Summary",
-        )
-      end
+      TITLE = "Other Assets Summary"
     end
   end
 end

--- a/lib/mi_bridges/driver/other_information_page.rb
+++ b/lib/mi_bridges/driver/other_information_page.rb
@@ -1,11 +1,7 @@
 module MiBridges
   class Driver
     class OtherInformationPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Other Information",
-        )
-      end
+      TITLE = "Other Information".freeze
     end
   end
 end

--- a/lib/mi_bridges/driver/other_information_summary_page.rb
+++ b/lib/mi_bridges/driver/other_information_summary_page.rb
@@ -1,11 +1,7 @@
 module MiBridges
   class Driver
     class OtherInformationSummaryPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Other Information Summary",
-        )
-      end
+      TITLE = "Other Information Summary".freeze
     end
   end
 end

--- a/lib/mi_bridges/driver/people_listed_page.rb
+++ b/lib/mi_bridges/driver/people_listed_page.rb
@@ -3,13 +3,11 @@
 module MiBridges
   class Driver
     class PeopleListedPage < BasePage
+      TITLE = "People Listed On Your Application"
+
       delegate :primary_member, to: :snap_application
 
-      def setup
-        check_page_title(
-          "People Listed On Your Application",
-        )
-      end
+      def setup; end
 
       def fill_in_required_fields
         select primary_member.marital_status.titleize, from: "maritalStatus"

--- a/lib/mi_bridges/driver/personal_information_page.rb
+++ b/lib/mi_bridges/driver/personal_information_page.rb
@@ -3,17 +3,15 @@
 module MiBridges
   class Driver
     class PersonalInformationPage < BasePage
+      TITLE = "Getting Started With Your Application"
+
       delegate(
         :primary_member,
         :residential_address,
         to: :snap_application,
       )
 
-      def setup
-        check_page_title(
-          "Getting Started With Your Application",
-        )
-      end
+      def setup; end
 
       def fill_in_required_fields
         fill_in_name

--- a/lib/mi_bridges/driver/privacy_pin_page.rb
+++ b/lib/mi_bridges/driver/privacy_pin_page.rb
@@ -3,11 +3,9 @@
 module MiBridges
   class Driver
     class PrivacyPinPage < BasePage
-      def setup
-        check_page_title(
-          "Privacy PIN",
-        )
-      end
+      TITLE = "Privacy PIN"
+
+      def setup; end
 
       def fill_in_required_fields
         click_id(this_is_a_private_computer_id)

--- a/lib/mi_bridges/driver/program_benefits_page.rb
+++ b/lib/mi_bridges/driver/program_benefits_page.rb
@@ -2,16 +2,8 @@
 
 module MiBridges
   class Driver
-    class ProgramBenefitsPage < BasePage
-      def setup
-        check_page_title("More About Benefits")
-      end
-
-      def fill_in_required_fields; end
-
-      def continue
-        click_on "Next"
-      end
+    class ProgramBenefitsPage < ClickNextPage
+      TITLE = "More About Benefits"
     end
   end
 end

--- a/lib/mi_bridges/driver/school_details_page.rb
+++ b/lib/mi_bridges/driver/school_details_page.rb
@@ -1,11 +1,7 @@
 module MiBridges
   class Driver
     class SchoolDetailsPage < ClickNextPage
-      def setup
-        check_page_title(
-          "School Enrollment",
-        )
-      end
+      TITLE = "School Enrollment".freeze
 
       def fill_in_required_fields
         choose_enrollment_time_for(snap_application.primary_member)

--- a/lib/mi_bridges/driver/start_page.rb
+++ b/lib/mi_bridges/driver/start_page.rb
@@ -3,11 +3,9 @@
 module MiBridges
   class Driver
     class StartPage < BasePage
-      def setup
-        check_page_title(
-          "Help With Filing MI Bridges Application",
-        )
-      end
+      TITLE = "Help With Filing MI Bridges Application"
+
+      def setup; end
 
       def fill_in_required_fields
         click_id(a_staff_person_or_volunteer_at_an_agency)

--- a/lib/mi_bridges/driver/submit_page.rb
+++ b/lib/mi_bridges/driver/submit_page.rb
@@ -2,11 +2,7 @@
 module MiBridges
   class Driver
     class SubmitPage < DebuggerPage
-      def setup
-        check_page_title(
-          "Before You Submit the Application",
-        )
-      end
+      TITLE = "Before You Submit the Application".freeze
     end
   end
 end

--- a/lib/mi_bridges/driver/utility_bills_page.rb
+++ b/lib/mi_bridges/driver/utility_bills_page.rb
@@ -3,6 +3,8 @@
 module MiBridges
   class Driver
     class UtilityBillsPage < BasePage
+      TITLE = "Utility Bills"
+
       delegate(
         :primary_member,
         :utility_cooling?,

--- a/lib/mi_bridges/driver/veteran_information_page.rb
+++ b/lib/mi_bridges/driver/veteran_information_page.rb
@@ -1,11 +1,7 @@
 module MiBridges
   class Driver
     class VeteranInformationPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Veteran Information",
-        )
-      end
+      TITLE = "Veteran Information".freeze
     end
   end
 end

--- a/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
+++ b/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
@@ -3,6 +3,8 @@
 module MiBridges
   class Driver
     class YourOtherBillsExpensesPage < BasePage
+      TITLE = "Your Other Bills / Expenses"
+
       delegate(
         :court_ordered?,
         :monthly_medical_expenses?,
@@ -10,11 +12,7 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup
-        check_page_title(
-          "Your Other Bills / Expenses",
-        )
-      end
+      def setup; end
 
       def fill_in_required_fields
         check_child_spousal_payments

--- a/lib/mi_bridges/driver/your_other_bills_expenses_summary_page.rb
+++ b/lib/mi_bridges/driver/your_other_bills_expenses_summary_page.rb
@@ -3,11 +3,7 @@
 module MiBridges
   class Driver
     class YourOtherBillsExpensesSummaryPage < ClickNextPage
-      def setup
-        check_page_title(
-          "Other Bills / Expenses Summary",
-        )
-      end
+      TITLE = "Other Bills / Expenses Summary"
     end
   end
 end


### PR DESCRIPTION
**WHY**: If we know what page we're on, we know what to do on that page.
This way, our MI Bridges flow is not dependent on a specific order and
will be more flexible as we add more of the pages found during Gap
analysis.

