### PR TITLE
Ignore lib/mi_bridges directory for coverage

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,10 @@ if ENV["CI"]
   SimpleCov.coverage_dir(File.join(ENV["CIRCLE_ARTIFACTS"], "coverage"))
 end
 
-SimpleCov.start "rails"
+SimpleCov.start("rails") do
+  add_filter "/lib/mi_bridges/"
+end
+
 WebMock.disable_net_connect!(allow_localhost: true)
 
 RSpec.configure do |config|


### PR DESCRIPTION
Reason for Change
=================
* Our code coverage number is quite low (~45%).
* This is representative of a great deal of experimental code around driving applications on the mibridges.org site.
* We shouldn't include this code in our coverage calculations as of now.

Changes
=======
* Filter against files matching `lib/mi_bridges/`.
