### PR TITLE
Pages for mailing addr, pregnancy, self-employment

### DIFF
--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -23,10 +23,13 @@ module MiBridges
       BenefitsSelectorPage,
       ProgramBenefitsPage,
       PersonalInformationPage,
+      MailingAddressPage,
       BasicInformationSummaryPage,
       PeopleListedPage,
+      PregnancyInformationPage,
       HouseholdMembersSummaryPage,
       JobIncomeInformationPage,
+      MoreAboutSelfEmploymentPage,
       JobIncomeSummaryPage,
       MoneyOtherSourcesPage,
       MoneyOtherSourcesSummaryPage,
@@ -124,7 +127,8 @@ module MiBridges
 
     def find_page_klass
       APPLY_FLOW.detect do |page|
-        page::TITLE == page_title
+        page_title == page::TITLE ||
+          page_title.match?(page::TITLE)
       end
     end
 

--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -52,6 +52,10 @@ module MiBridges
         js_click_selector("#{widget} #{selector}")
       end
 
+      def check_no_one_in_section(section)
+        check_in_section(section)
+      end
+
       def selector_for_radio(name)
         "label:contains('#{name}') input"
       end

--- a/lib/mi_bridges/driver/mailing_address_page.rb
+++ b/lib/mi_bridges/driver/mailing_address_page.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class MailingAddressPage < BasePage
+      TITLE = "Mailing Address"
+
+      delegate :mailing_address, to: :snap_application
+      delegate(
+        :city,
+        :county,
+        :state,
+        :street_address,
+        :zip,
+        to: :mailing_address,
+      )
+
+      def setup; end
+
+      def fill_in_required_fields
+        fill_in "Street Address or P.O. Box Number", with: street_address
+        select county, from: "County"
+        fill_in "City", with: city
+        fill_in "Zip Code", with: zip
+      end
+
+      def continue
+        click_on "Next"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/more_about_self_employment_page.rb
+++ b/lib/mi_bridges/driver/more_about_self_employment_page.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class MoreAboutSelfEmploymentPage < BasePage
+      TITLE = /More About .*'s Self-Employment/
+
+      delegate :members, to: :snap_application
+
+      def setup; end
+
+      def fill_in_required_fields
+        members.each do |member|
+          fill_in_all_programs_for(member)
+          fill_in_fap_program_benefits_for(member)
+        end
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def fill_in_all_programs_for(member)
+        name = member.first_name_and_age
+        question_type = "What type of self-employment does #{name} have?"
+        select "Other", from: question_type
+        question_other = "If self-employment type is Other, "\
+          "what type of work does #{name} do?"
+        fill_in question_other, with: member.self_employed_profession
+      end
+
+      def fill_in_fap_program_benefits_for(member)
+        name = member.first_name_and_age
+        question_income = "What is the gross monthly income amount "\
+          "from #{name}'s self-employment before any expenses?"
+        fill_in question_income, with: member.self_employed_monthly_income
+        question_expenses = "How much are #{name}'s business "\
+          "expenses each month?"
+        fill_in question_expenses, with: member.self_employed_monthly_expenses
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/pregnancy_information_page.rb
+++ b/lib/mi_bridges/driver/pregnancy_information_page.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class PregnancyInformationPage < BasePage
+      TITLE = "Pregnancy Information"
+
+      delegate :members, to: :snap_application
+
+      def setup; end
+
+      def fill_in_required_fields
+        if no_one_pregnant?
+          click_no_one
+        else
+          members.each do |member|
+            check_in_section(
+              "starPregnancyAllPrograms",
+              member.new_mom?,
+              first_name_section(member),
+            )
+          end
+        end
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def click_no_one
+        check_in_section "starPregnancyAllPrograms"
+      end
+
+      def no_one_pregnant?
+        members.none?(&:new_mom?)
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/pregnancy_information_page.rb
+++ b/lib/mi_bridges/driver/pregnancy_information_page.rb
@@ -11,7 +11,7 @@ module MiBridges
 
       def fill_in_required_fields
         if no_one_pregnant?
-          click_no_one
+          check_no_one_in_section "starPregnancyAllPrograms"
         else
           members.each do |member|
             check_in_section(
@@ -28,10 +28,6 @@ module MiBridges
       end
 
       private
-
-      def click_no_one
-        check_in_section "starPregnancyAllPrograms"
-      end
 
       def no_one_pregnant?
         members.none?(&:new_mom?)


### PR DESCRIPTION
Page objects for "Mailing Address", "Pregnancy Information", and
"More about <PERSON>'s Self Employment". A bigger change as a result of
the "Self-Employment" section is that the string we're testing against
in the H1 can now be dynamic - it can reference a member of the
application as per this example.

As a result this commit will check for both equality of the string, and
whether there is a match in the chance we make `TITLE` a regular
expression.