### PR TITLE
Add personal information for additional household members

### DIFF
--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -83,10 +83,10 @@ module MiBridges
         end
       end
 
-      def fill_in_birthday_fields(member)
-        month = padded(member.birthday.month)
-        day = padded(member.birthday.day)
-        year = member.birthday.year
+      def fill_in_birthday_fields(birthday)
+        month = padded(birthday.month)
+        day = padded(birthday.day)
+        year = birthday.year
 
         fill_in "monthgroupDateOfBirth", with: month
         fill_in "dategroupDateOfBirth", with: day

--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -82,6 +82,24 @@ module MiBridges
           logger.debug("#{description.upcase}: #{text.join(', ')}")
         end
       end
+
+      def fill_in_birthday_fields(member)
+        month = padded(member.birthday.month)
+        day = padded(member.birthday.day)
+        year = member.birthday.year
+
+        fill_in "monthgroupDateOfBirth", with: month
+        fill_in "dategroupDateOfBirth", with: day
+        fill_in "yeargroupDateOfBirth", with: year
+
+        fill_in "monthconfirmGroupDateOfBirth", with: month
+        fill_in "dateconfirmGroupDateOfBirth", with: day
+        fill_in "yearconfirmGroupDateOfBirth", with: year
+      end
+
+      def padded(int)
+        sprintf("%02d", int)
+      end
     end
   end
 end

--- a/lib/mi_bridges/driver/people_listed_page.rb
+++ b/lib/mi_bridges/driver/people_listed_page.rb
@@ -20,7 +20,7 @@ module MiBridges
           fill_in "firstName", with: member.first_name_and_age
           fill_in "lastName", with: member.last_name
           click_id "gender_#{member.sex.first.upcase}"
-          fill_in_birthday_fields
+          fill_in_birthday_fields(member)
           select_yes_person_lives_at_same_address
         else
           fill_in "peopleInYourHome", with: snap_application.members.size
@@ -46,24 +46,6 @@ module MiBridges
           )
           !page.has_content?(member_first_name)
         end
-      end
-
-      def fill_in_birthday_fields
-        month = padded(member.birthday.month)
-        day = padded(member.birthday.day)
-        year = member.birthday.year
-
-        fill_in "monthgroupDateOfBirth", with: month
-        fill_in "dategroupDateOfBirth", with: day
-        fill_in "yeargroupDateOfBirth", with: year
-
-        fill_in "monthconfirmGroupDateOfBirth", with: month
-        fill_in "dateconfirmGroupDateOfBirth", with: day
-        fill_in "yearconfirmGroupDateOfBirth", with: year
-      end
-
-      def padded(int)
-        sprintf("%02d", int)
       end
 
       def select_yes_person_lives_at_same_address

--- a/lib/mi_bridges/driver/people_listed_page.rb
+++ b/lib/mi_bridges/driver/people_listed_page.rb
@@ -41,11 +41,13 @@ module MiBridges
 
       def find_not_yet_added_member
         snap_application.members.detect do |member|
-          member_first_name = Regexp.new(
-            Regexp.escape(member.first_name_and_age),
-          )
+          member_first_name = Regexp.new(escape_parens_in_name(member))
           !page.has_content?(member_first_name)
         end
+      end
+
+      def escape_parens_in_name(member)
+        Regexp.escape(member.first_name_and_age)
       end
 
       def select_yes_person_lives_at_same_address

--- a/lib/mi_bridges/driver/people_listed_page.rb
+++ b/lib/mi_bridges/driver/people_listed_page.rb
@@ -20,7 +20,7 @@ module MiBridges
           fill_in "firstName", with: member.first_name_and_age
           fill_in "lastName", with: member.last_name
           click_id "gender_#{member.sex.first.upcase}"
-          fill_in_birthday_fields(member)
+          fill_in_birthday_fields(member.birthday)
           select_yes_person_lives_at_same_address
         else
           fill_in "peopleInYourHome", with: snap_application.members.size

--- a/lib/mi_bridges/driver/personal_information_page.rb
+++ b/lib/mi_bridges/driver/personal_information_page.rb
@@ -16,7 +16,7 @@ module MiBridges
       def fill_in_required_fields
         fill_in_name
         click_on_gender
-        fill_in_birthday_fields(primary_member)
+        fill_in_birthday_fields(primary_member.birthday)
         select_county
         fill_in_address
         click_same_address_answer

--- a/lib/mi_bridges/driver/personal_information_page.rb
+++ b/lib/mi_bridges/driver/personal_information_page.rb
@@ -16,7 +16,7 @@ module MiBridges
       def fill_in_required_fields
         fill_in_name
         click_on_gender
-        fill_in_birthday_fields
+        fill_in_birthday_fields(primary_member)
         select_county
         fill_in_address
         click_same_address_answer
@@ -37,20 +37,6 @@ module MiBridges
 
       def click_on_gender
         click_id "gender_#{primary_member.sex.first.upcase}"
-      end
-
-      def fill_in_birthday_fields
-        month = padded(primary_member.birthday.month)
-        day = padded(primary_member.birthday.day)
-        year = primary_member.birthday.year
-
-        fill_in "monthgroupDateOfBirth", with: month
-        fill_in "dategroupDateOfBirth", with: day
-        fill_in "yeargroupDateOfBirth", with: year
-
-        fill_in "monthconfirmGroupDateOfBirth", with: month
-        fill_in "dateconfirmGroupDateOfBirth", with: day
-        fill_in "yearconfirmGroupDateOfBirth", with: year
       end
 
       def select_county
@@ -85,10 +71,6 @@ module MiBridges
         fill_in "phone3homePhone", with: phone_number[6..9]
 
         select "Home Phone", from: "bestWayToGetInTouch"
-      end
-
-      def padded(int)
-        sprintf("%02d", int)
       end
 
       def invalid_physical_address?


### PR DESCRIPTION
**WHY**:
If a household has more than 1 member, the "People listed" form needs to
be filled out for each additional member.

For non-primary members, required fields are:
- first name
- last name
- marital status
- gender
- DOB
- whether they live in the same household as the primary member

To test, run the driving code with `bin/drive_dev` using the ID of a Snap Application that has more than one household member.

We are determining which household members have not yet been added by checking to see whose "first_name_and_age" is not already on the page. See:

![screen shot 2017-09-20 at 4 38 30 pm](https://user-images.githubusercontent.com/601515/30673174-11c15ba6-9e26-11e7-8a6e-5b6c838f8b84.png)
