### PR TITLE
Improve first name formatting for MI Bridges

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -43,8 +43,8 @@ class Member < ApplicationRecord
     birthday.strftime("%m/%d/%Y")
   end
 
-  def first_name_and_age
-    "#{first_name} (age #{age})"
+  def mi_bridges_formatted_name
+    "#{first_name.first(10)} (#{age})"
   end
 
   private

--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -74,7 +74,7 @@ module MiBridges
       end
 
       def first_name_section(member)
-        member.first_name_and_age.gsub(/[^0-9A-Za-z]/, "")
+        member.mi_bridges_formatted_name.gsub(/[^0-9A-Za-z]/, "")
       end
 
       def log(description, *text)

--- a/lib/mi_bridges/driver/household_member_questions_page.rb
+++ b/lib/mi_bridges/driver/household_member_questions_page.rb
@@ -31,7 +31,7 @@ module MiBridges
         check_in_section(
           "starBlindnessorDisability",
           condition: anyone_disabled?,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 
@@ -51,7 +51,7 @@ module MiBridges
         check_in_section(
           "starSSIBenefit",
           condition: anyone_disabled?,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 

--- a/lib/mi_bridges/driver/housing_utility_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_utility_bills_page.rb
@@ -26,7 +26,7 @@ module MiBridges
         check_in_section(
           "starHousingBills",
           condition: true,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 
@@ -34,7 +34,7 @@ module MiBridges
         check_in_section(
           "starUtilityBills",
           condition: true,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 

--- a/lib/mi_bridges/driver/job_income_information_page.rb
+++ b/lib/mi_bridges/driver/job_income_information_page.rb
@@ -26,7 +26,7 @@ module MiBridges
         check_in_section(
           "starCurrentorRecentJob",
           condition: employment_status == "employed",
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 
@@ -34,7 +34,7 @@ module MiBridges
         check_in_section(
           "starSelfEmployment",
           condition: employment_status == "self_employed",
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 

--- a/lib/mi_bridges/driver/liquid_assets_page.rb
+++ b/lib/mi_bridges/driver/liquid_assets_page.rb
@@ -31,7 +31,7 @@ module MiBridges
         check_in_section(
           "starCashonHand",
           condition: total_money?,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 
@@ -39,7 +39,7 @@ module MiBridges
         check_in_section(
           "starSavingsAccount",
           condition: financial_accounts.include?("savings_account"),
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 
@@ -47,7 +47,7 @@ module MiBridges
         check_in_section(
           "starCheckingAccount",
           condition: financial_accounts.include?("checking_account"),
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 

--- a/lib/mi_bridges/driver/money_other_sources_page.rb
+++ b/lib/mi_bridges/driver/money_other_sources_page.rb
@@ -35,7 +35,7 @@ module MiBridges
         check_in_section(
           "starOtherIncome",
           condition: income_other?,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 
@@ -43,7 +43,7 @@ module MiBridges
         check_in_section(
           "starSupplementalSecurityIncomeSSI",
           condition: income_ssi_or_disability?,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 

--- a/lib/mi_bridges/driver/more_about_self_employment_page.rb
+++ b/lib/mi_bridges/driver/more_about_self_employment_page.rb
@@ -23,7 +23,7 @@ module MiBridges
       private
 
       def fill_in_all_programs_for(member)
-        name = member.first_name_and_age
+        name = member.mi_bridges_formatted_name
         question_type = "What type of self-employment does #{name} have?"
         select "Other", from: question_type
         question_other = "If self-employment type is Other, "\
@@ -32,7 +32,7 @@ module MiBridges
       end
 
       def fill_in_fap_program_benefits_for(member)
-        name = member.first_name_and_age
+        name = member.mi_bridges_formatted_name
         question_income = "What is the gross monthly income amount "\
           "from #{name}'s self-employment before any expenses?"
         fill_in question_income, with: member.self_employed_monthly_income

--- a/lib/mi_bridges/driver/other_assets_page.rb
+++ b/lib/mi_bridges/driver/other_assets_page.rb
@@ -34,7 +34,7 @@ module MiBridges
         check_in_section(
           "starVehicles",
           condition: vehicle_income?,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 
@@ -42,7 +42,7 @@ module MiBridges
         check_in_section(
           "starRealEstate",
           condition: real_estate_income?,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 
@@ -54,7 +54,7 @@ module MiBridges
         check_in_section(
           "starLifeInsurance",
           condition: financial_accounts.include?("life_insurance"),
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 

--- a/lib/mi_bridges/driver/people_listed_page.rb
+++ b/lib/mi_bridges/driver/people_listed_page.rb
@@ -17,7 +17,7 @@ module MiBridges
         select member.marital_status.titleize, from: "maritalStatus"
 
         if for_next_household_member?
-          fill_in "firstName", with: member.first_name_and_age
+          fill_in "firstName", with: member.mi_bridges_formatted_name
           fill_in "lastName", with: member.last_name
           click_id "gender_#{member.sex.first.upcase}"
           fill_in_birthday_fields(member.birthday)
@@ -47,7 +47,7 @@ module MiBridges
       end
 
       def escape_parens_in_name(member)
-        Regexp.escape(member.first_name_and_age)
+        Regexp.escape(member.mi_bridges_formatted_name)
       end
 
       def select_yes_person_lives_at_same_address

--- a/lib/mi_bridges/driver/personal_information_page.rb
+++ b/lib/mi_bridges/driver/personal_information_page.rb
@@ -31,7 +31,7 @@ module MiBridges
       private
 
       def fill_in_name
-        fill_in "First Name", with: primary_member.first_name_and_age
+        fill_in "First Name", with: primary_member.mi_bridges_formatted_name
         fill_in "Last Name", with: primary_member.last_name
       end
 

--- a/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
+++ b/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
@@ -30,7 +30,7 @@ module MiBridges
         check_in_section(
           "starChildSpousalSupportPayments",
           condition: court_ordered?,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 
@@ -38,7 +38,7 @@ module MiBridges
         check_in_section(
           "starMedicalBills",
           condition: monthly_medical_expenses?,
-          for_label: primary_member.first_name_and_age,
+          for_label: primary_member.mi_bridges_formatted_name,
         )
       end
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -39,17 +39,34 @@ RSpec.describe Member do
       end
     end
 
-    describe "#first_name_and_age" do
-      it "returns first name and age" do
-        time = Time.utc(2008, 9, 1, 10, 5, 0)
-        Timecop.freeze(time) do
-          member = build(
-            :member,
-            first_name: "Lala",
-            birthday: DateTime.parse("June 20, 1990"),
-          )
+    describe "#mi_bridges_formatted_name" do
+      context "name is over 10 chars" do
+        it "cuts name off at 10 chars" do
+          time = Time.utc(2008, 9, 1, 10, 5, 0)
+          Timecop.freeze(time) do
+            member = build(
+              :member,
+              first_name: "JacquelineR",
+              birthday: DateTime.parse("June 20, 1990"),
+            )
 
-          expect(member.first_name_and_age).to eq "Lala (age 18)"
+            expect(member.mi_bridges_formatted_name).to eq "Jacqueline (18)"
+          end
+        end
+      end
+
+      context "name is shorter than 10 chars" do
+        it "returns full first name and age" do
+          time = Time.utc(2008, 9, 1, 10, 5, 0)
+          Timecop.freeze(time) do
+            member = build(
+              :member,
+              first_name: "Lala",
+              birthday: DateTime.parse("June 20, 1990"),
+            )
+
+            expect(member.mi_bridges_formatted_name).to eq "Lala (18)"
+          end
         end
       end
     end


### PR DESCRIPTION
**WHY**:
- MI Bridges has a 15 char limit
- Shorten name differentiator by removing "age" from parens
- Only include first 10 chars of name so that age never cut off
