### PR TITLE
Add relationship details for all household members

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -172,5 +172,24 @@ Member.where(
   self_employed_monthly_expenses: "400",
 )
 
+Member.where(
+  snap_application: complete_application,
+  first_name: "Random",
+  last_name: "Roommate",
+).first_or_create(
+  marital_status: "Never married",
+  sex: "female",
+  encrypted_ssn: "VhzEa7Hee+IXOdIBwjhPL0vB/OTqR4fe1TIi\n",
+  encrypted_ssn_iv: "F7Gz/ujIHfhZuhoY\n",
+  birthday: 50.years.ago,
+  buy_food_with: true,
+  relationship: "Roommate",
+  requesting_food_assistance: true,
+  employment_status: "self_employed",
+  self_employed_profession: "Marketing",
+  self_employed_monthly_income: 800,
+  self_employed_monthly_expenses: "400",
+)
+
 puts "More complete application created (or found) " \
   "with id: #{complete_application.id}"

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -45,6 +45,7 @@ module MiBridges
       PersonalInformationPage,
       PregnancyInformationPage,
       ProgramBenefitsPage,
+      RelationshipInformationPage,
       SchoolDetailsPage,
       StartPage,
       SubmitPage,

--- a/lib/mi_bridges/driver/relationship_information_page.rb
+++ b/lib/mi_bridges/driver/relationship_information_page.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class RelationshipInformationPage < BasePage
+      TITLE = "Relationship Information"
+
+      def setup
+        @first_member = find_first_member
+        @second_members = find_second_members
+      end
+
+      def fill_in_required_fields
+        second_members.each do |member|
+          fill_in_relationship(member)
+          buy_food_with(member)
+        end
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      attr_reader :first_member, :second_members
+
+      def fill_in_relationship(member)
+        selector = find(:xpath, relationship_xpath(member))
+        selector.select(mi_bridges_relationship(member))
+      end
+
+      def relationship_xpath(member)
+        second = member.mi_bridges_formatted_name
+        "//*[@title=\"* #{first_member_name}\'s Relationship to #{second}\"]"
+      end
+
+      def buy_food_with(member)
+        buy_food_with_section =
+          find("fieldset", text: buy_food_with_label(member))
+
+        within buy_food_with_section do
+          find(:xpath, ".//*[@title='#{buy_food_with_option(member)}']").click
+        end
+      end
+
+      def buy_food_with_label(member)
+        second = member.mi_bridges_formatted_name
+        "Does #{first_member_name} usually buy and fix food with #{second}?"
+      end
+
+      def buy_food_with_option(member)
+        if member.buy_food_with?
+          "Yes"
+        else
+          "No"
+        end
+      end
+
+      def first_member_name
+        first_member.mi_bridges_formatted_name
+      end
+
+      def find_first_member
+        name = page.first(:xpath, first_member_name_label).text
+        find_household_member_by_name(name)
+      end
+
+      def first_member_name_label
+        '//*[@id="helpContent"]/div/div[2]/div/div[1]/div[1]/div/div/div/label'
+      end
+
+      def find_second_members
+        labels = page.all(:xpath, second_member_name_label)
+        labels.map do |label|
+          find_household_member_by_name(label.text)
+        end
+      end
+
+      def second_member_name_label
+        '//*[@id="helpContent"]/div/div[2]/div/div[1]/div[4]/div/div/div/label'
+      end
+
+      def find_household_member_by_name(name)
+        snap_application.members.detect do |member|
+          member.mi_bridges_formatted_name == name
+        end
+      end
+
+      def mi_bridges_relationship(member)
+        if first_member == snap_application.primary_member
+          map_member_relationship_to_mi_bridges(member)
+        else
+          "is Related to another way to"
+        end
+      end
+
+      def map_member_relationship_to_mi_bridges(member)
+        relationship = member.relationship || "Other"
+        sex = first_member.sex
+        mapping = send("#{sex}_relationship_mapping".to_sym).
+          merge(other_relationship_mapping)
+        mapping[relationship]
+      end
+
+      def female_relationship_mapping
+        {
+          "Child" => "is the Mother of",
+          "Parent" => "is the Daughter of",
+          "Sibling" => "is the Sister of",
+          "Spouse" => "is the Wife of",
+        }
+      end
+
+      def male_relationship_mapping
+        {
+          "Child" => "is the Father of",
+          "Parent" => "is the Son of",
+          "Sibling" => "is the Brother of",
+          "Spouse" => "is the Husband of",
+        }
+      end
+
+      def other_relationship_mapping
+        {
+          "Roommate" => "is Related to another way to",
+          "Other" => "is Related to another way to",
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
* This was a doozy!
* The way MI Bridges handles this is that it starts with a page for the
primary member and asks how that person is related to every other
household member.
* The next page asks how the second household member is related to every
other member who is not the primary member
* The third page asks how the third household member is related to ever
member who is not the first or second member
* Etc etc

I tested this locally using a household with 4 members so I have pretty
high confidence that it will work for a household of any size.

NOTE that there are a few weird things here:
1. The relationship mapping is flipped. In our app, we ask 'What is their relationship to you?',
but MI Bridges asks the relationship of the first person to the second.
So if I am the primary member, I would report my child as "Child", but
in MI Bridges I would enter in "Mother" because it asks how Primary
relates to Secondary.
2. Relationship is not a validated field, so we fall back to "Other"
3. We only collect relationship info for primary to other members, so
for any relationship info page that is not the first one, we select "is Related to another way to"
as the relationship.
4. Used a lot of crazy XPATH stuff here because each section is defined
by an id that uses the position of a household member, which felt
brittle.

Example output for non-primary member:
![screen shot 2017-09-21 at 3 36 50 pm](https://user-images.githubusercontent.com/601515/30722274-37a4062e-9ee5-11e7-8831-237f72f6584e.png)

Example for primary member (where we actually have relationship data and don't just fall back to other)
![screen shot 2017-09-21 at 2 28 30 pm](https://user-images.githubusercontent.com/601515/30722280-417f8024-9ee5-11e7-9164-cf08e86309ec.png)
