### PR TITLE
Improvements to release script

### DIFF
--- a/bin/release-diff
+++ b/bin/release-diff
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
 
-staging_sha=$(heroku releases -r staging | head -n 2 | tail -n 1 | cut -d " " -f 4)
-prod_sha=$(heroku releases -r production | head -n 2 | tail -n 1 | cut -d " " -f 4)
+staging_sha=$(heroku releases -r staging | grep "Deploy" | head -n 1 | tail -n 1 | cut -d " " -f 4)
+prod_sha=$(heroku releases -r production | grep "Deploy" | head -n 1 | tail -n 1 | cut -d " " -f 4)
 open "https://github.com/codeforamerica/michigan-benefits/compare/$prod_sha...$staging_sha"

--- a/config/offices.yml
+++ b/config/offices.yml
@@ -55,6 +55,19 @@ development:
     clio:
       fax_number: "+16173963015"
       email: "clio@example.com"
+staging:
+  <<: *defaults
+  offices:
+    staging_sfax: # Technically this is to our sfax production fax;
+                  # because you can't fax yourself
+      fax_number: "+18448487565"
+      email: "hello@michiganbenefits.org"
+    union:
+      fax_number: "+16173963015"
+      email: "union@example.com"
+    clio:
+      fax_number: "+16173963015"
+      email: "clio@example.com"
 production:
   <<: *defaults
   offices:


### PR DESCRIPTION
* Grep for "deploy" in heroku releases (if the last change to heroku was
updating an ENV var, the `bin/release-diff` command opens up an invalid
URL because there is not a commit SHA in the latest heroku "release"
* Set up "staging" app release stage for faxes and emails.
* Send staging test emails to hello@michiganbenefits.org, which goes to
front so we all have access to it / can view it.

Screenshot of invalid diff (before "GREP"):
![screen shot 2017-09-22 at 9 31 16 am](https://user-images.githubusercontent.com/601515/30755800-dedb07f2-9f7c-11e7-9a3a-84b8fb3830ad.png)
