### PR TITLE
Ensure id is passed as argument to `drive_demo`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,6 +384,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-darwin-15
 
 DEPENDENCIES
   activemodel_type_symbol

--- a/bin/drive_demo
+++ b/bin/drive_demo
@@ -1,5 +1,11 @@
 #!/bin/bash
 
-export DRIVER_SPEED="slow"
-./bin/rails runner "app = SnapApplication.find($1);
-app.driver_applications.destroy_all; MiBridges::Driver.new(snap_application: SnapApplication.find($1)).run"
+if [ -z "$1" ];then
+  echo "ERROR"
+  echo "You did not pass a SnapApplication ID as an argument."
+  echo "(For example './bin/drive_demo 207')"
+else
+  export DRIVER_SPEED="slow"
+  ./bin/rails runner "app = SnapApplication.find($1);
+  app.driver_applications.destroy_all; MiBridges::Driver.new(snap_application: SnapApplication.find($1)).run"
+fi


### PR DESCRIPTION
Like the script in `bin/drive_dev` the `drive_demo` script should enforce that
an id has been passed to the script as an argument