### PR TITLE
Add "More about <user>'s income'" page

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -7,6 +7,7 @@ class Member < ApplicationRecord
     "Every Two Weeks",
     "Twice a Month",
     "Monthly",
+    "Yearly",
     "Other",
   ].freeze
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,7 +1,20 @@
 class Member < ApplicationRecord
   AVERAGE_WEEKS_PER_MONTH = 4.33
   MONTHS_PER_YEAR = 12
+  PAYMENT_INTERVALS = [
+    "Hourly",
+    "Weekly",
+    "Every Two Weeks",
+    "Twice a Month",
+    "Monthly",
+    "Other",
+  ].freeze
+
   belongs_to :snap_application
+
+  validates :employed_pay_interval,
+    inclusion: { in: PAYMENT_INTERVALS },
+    allow_nil: true
 
   attribute :ssn
   attr_encrypted(
@@ -60,8 +73,8 @@ class Member < ApplicationRecord
     return if employed_pay_quantity.nil?
     if employed_pay_interval == "Hourly"
       employed_hours_per_week * employed_pay_quantity * AVERAGE_WEEKS_PER_MONTH
-    elsif employed_pay_interval == "Daily"
-      employed_pay_quantity * (AVERAGE_WEEKS_PER_MONTH * 5)
+    elsif ["Every Two Weeks", "Twice a Month"].include? employed_pay_interval
+      employed_pay_quantity * (AVERAGE_WEEKS_PER_MONTH / 2)
     elsif employed_pay_interval == "Weekly"
       employed_pay_quantity * AVERAGE_WEEKS_PER_MONTH
     elsif employed_pay_interval == "Monthly"

--- a/app/views/income_details_per_member/edit.html.erb
+++ b/app/views/income_details_per_member/edit.html.erb
@@ -28,7 +28,7 @@
                   optional: true %>
                 <%= ff.mb_select :employed_pay_interval,
                   "How often are you paid that amount?",
-                  ["Hourly", "Daily", "Weekly", "2 weeks", "Monthly", "Yearly"],
+                  Member::PAYMENT_INTERVALS,
                   { layout: "inline", optional: true } %>
                 <% else # self employed %>
                   <%= ff.mb_input_field :self_employed_profession,

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -30,6 +30,7 @@ module MiBridges
       HousingUtilityBillsPage,
       HousingUtilityBillsSummaryPage,
       JobIncomeInformationPage,
+      JobIncomeMoreAboutPage,
       JobIncomeSummaryPage,
       LiquidAssetsPage,
       LiquidAssetsSummaryPage,
@@ -130,7 +131,7 @@ module MiBridges
       # rubocop:disable Debugger
       binding.pry if ENV["DEBUG_DRIVE"]
       # rubocop:enable Debugger
-      throw e
+      raise e
     end
 
     attr_reader :snap_application, :logger
@@ -140,9 +141,15 @@ module MiBridges
     end
 
     def find_page_klass
-      APPLY_FLOW.detect do |page|
+      klass = APPLY_FLOW.detect do |page|
         page_title == page::TITLE ||
           page_title.match?(page::TITLE)
+      end
+
+      if klass.nil?
+        fail MiBridges::Errors::PageNotFoundError.new(page_title)
+      else
+        klass
       end
     end
 

--- a/lib/mi_bridges/driver/job_income_more_about_page.rb
+++ b/lib/mi_bridges/driver/job_income_more_about_page.rb
@@ -10,9 +10,15 @@ module MiBridges
       def setup; end
 
       def fill_in_required_fields
-        fill_in "Name of Employer", with: current_member.employed_employer_name
-        select current_member.employed_pay_interval,
-          from: "How often does #{name} get paid? This is #{name}'s pay period"
+        fill_in(
+          "Name of Employer",
+          with: current_member.employed_employer_name,
+        )
+
+        select(
+          current_member.employed_pay_interval,
+          from: "How often does #{name} get paid? This is #{name}'s pay period",
+        )
 
         if hourly?
           fill_in_hourly
@@ -32,15 +38,22 @@ module MiBridges
       end
 
       def fill_in_hourly
-        fill_in "If #{name} gets paid by the hour, ",
-          with: current_member.employed_pay_quantity
-        fill_in "Please tell us how many hours #{name} works",
-          with: current_member.employed_hours_per_week
+        fill_in(
+          "If #{name} gets paid by the hour, ",
+          with: current_member.employed_pay_quantity,
+        )
+
+        fill_in(
+          "Please tell us how many hours #{name} works",
+          with: current_member.employed_hours_per_week,
+        )
       end
 
       def fill_in_salary
-        fill_in "If #{name} earns a salary instead",
-          with: current_member.employed_pay_quantity
+        fill_in(
+          "If #{name} earns a salary instead",
+          with: current_member.employed_pay_quantity,
+        )
       end
 
       def current_member

--- a/lib/mi_bridges/driver/job_income_more_about_page.rb
+++ b/lib/mi_bridges/driver/job_income_more_about_page.rb
@@ -12,8 +12,7 @@ module MiBridges
       def fill_in_required_fields
         fill_in "Name of Employer", with: current_member.employed_employer_name
         select current_member.employed_pay_interval,
-          from: "How often does Complete (40) get paid? "\
-                "This is Complete (40)'s pay period"
+          from: "How often does #{name} get paid? This is #{name}'s pay period"
 
         if hourly?
           fill_in_hourly
@@ -28,28 +27,33 @@ module MiBridges
 
       private
 
-      def current_member
-        title = find("h1").text
-        name = title.scan(/More About (.*)'s Job/).flatten.first
-        members.select do |member|
-          member.mi_bridges_formatted_name == name
-        end.first
-      end
-
       def hourly?
         current_member.employed_pay_interval == "Hourly"
       end
 
       def fill_in_hourly
-        fill_in "If Complete (40) gets paid by the hour, ",
+        fill_in "If #{name} gets paid by the hour, ",
           with: current_member.employed_pay_quantity
-        fill_in "Please tell us how many hours Complete (40) works each week",
+        fill_in "Please tell us how many hours #{name} works",
           with: current_member.employed_hours_per_week
       end
 
       def fill_in_salary
-        fill_in "If Complete (40) earns a salary instead",
+        fill_in "If #{name} earns a salary instead",
           with: current_member.employed_pay_quantity
+      end
+
+      def current_member
+        members.select do |member|
+          member.mi_bridges_formatted_name == name
+        end.first
+      end
+
+      def name
+        @_name ||= begin
+                     title = find("h1").text
+                     title.scan(/More About (.*)'s Job/).flatten.first
+                   end
       end
     end
   end

--- a/lib/mi_bridges/driver/job_income_more_about_page.rb
+++ b/lib/mi_bridges/driver/job_income_more_about_page.rb
@@ -34,7 +34,7 @@ module MiBridges
       private
 
       def hourly?
-        current_member.employed_pay_interval == "Hourly"
+        current_member.employed_pay_interval != "Yearly"
       end
 
       def fill_in_hourly

--- a/lib/mi_bridges/driver/job_income_more_about_page.rb
+++ b/lib/mi_bridges/driver/job_income_more_about_page.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module MiBridges
+  class Driver
+    class JobIncomeMoreAboutPage < BasePage
+      TITLE = /More About .*'s Job/
+
+      delegate :members, to: :snap_application
+
+      def setup; end
+
+      def fill_in_required_fields
+        fill_in "Name of Employer", with: current_member.employed_employer_name
+        select current_member.employed_pay_interval,
+          from: "How often does Complete (40) get paid? "\
+                "This is Complete (40)'s pay period"
+
+        if hourly?
+          fill_in_hourly
+        else
+          fill_in_salary
+        end
+      end
+
+      def continue
+        click_on "Next"
+      end
+
+      private
+
+      def current_member
+        title = find("h1").text
+        name = title.scan(/More About (.*)'s Job/).flatten.first
+        members.select do |member|
+          member.mi_bridges_formatted_name == name
+        end.first
+      end
+
+      def hourly?
+        current_member.employed_pay_interval == "Hourly"
+      end
+
+      def fill_in_hourly
+        fill_in "If Complete (40) gets paid by the hour, ",
+          with: current_member.employed_pay_quantity
+        fill_in "Please tell us how many hours Complete (40) works each week",
+          with: current_member.employed_hours_per_week
+      end
+
+      def fill_in_salary
+        fill_in "If Complete (40) earns a salary instead",
+          with: current_member.employed_pay_quantity
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/other_types_of_income_page.rb
+++ b/lib/mi_bridges/driver/other_types_of_income_page.rb
@@ -5,6 +5,12 @@ module MiBridges
     class OtherTypesOfIncomePage < BasePage
       TITLE = "Other Types of Income"
 
+      delegate(
+        :additional_income,
+        :primary_member,
+        to: :snap_application,
+      )
+
       def setup; end
 
       def fill_in_required_fields

--- a/lib/mi_bridges/errors.rb
+++ b/lib/mi_bridges/errors.rb
@@ -1,0 +1,13 @@
+module MiBridges
+  class Error < StandardError; end
+
+  module Errors
+    class PageNotFoundError < MiBridges::Error
+      attr_reader :message
+
+      def initialize(message)
+        @message = message
+      end
+    end
+  end
+end

--- a/spec/features/snap_application_with_maximum_info_spec.rb
+++ b/spec/features/snap_application_with_maximum_info_spec.rb
@@ -102,7 +102,7 @@ feature "SNAP application with maximum info" do
       fill_in "Employer name", with: "Company ABC Inc."
       fill_in "Usual hours per week", with: 25
       fill_in "Pay (before tax)", with: 100
-      select "Daily", from: "How often are you paid that amount?"
+      select "Weekly", from: "How often are you paid that amount?"
 
       fill_in "Type of work", with: "Chef"
       fill_in "Average monthly pay (before tax)", with: 300


### PR DESCRIPTION
In addition, add more information about when we hit the specific error
when a page's title is not found in our registry of page objects.

Why? Because it will tell us exactly what the page title is that is
being searched for, therefore allowing us to add a page that adheres to
the pattern.