### PR TITLE
Remove `Naming/BinaryOperatorParameter` cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -271,11 +271,6 @@ Style/OneLineConditional:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#ternary-operator'
   Enabled: false
 
-Naming/BinaryOperatorParameter:
-  Description: 'When defining binary operators, name the argument other.'
-  StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#other-arg'
-  Enabled: false
-
 Metrics/ParameterLists:
   Description: 'Avoid parameter lists longer than three or four parameters.'
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#too-many-params'


### PR DESCRIPTION
```sh
Warning: unrecognized cop Naming/BinaryOperatorParameter found in .rubocop.yml
```