### PR TITLE
Add default response for Child support question

### DIFF
--- a/lib/mi_bridges/driver/money_other_sources_page.rb
+++ b/lib/mi_bridges/driver/money_other_sources_page.rb
@@ -7,6 +7,7 @@ module MiBridges
 
       delegate(
         :income_other?,
+        :income_child_support?,
         :income_ssi_or_disability?,
         :primary_member,
         to: :snap_application,
@@ -16,6 +17,7 @@ module MiBridges
 
       def fill_in_required_fields
         check_retirement_survivors_disability_insurance
+        check_child_support_income
         check_other_income
         check_supplemental_security_income
         check_room_and_meals
@@ -37,6 +39,10 @@ module MiBridges
           condition: income_other?,
           for_label: primary_member.mi_bridges_formatted_name,
         )
+      end
+
+      def check_child_support_income
+        check_no_one_in_section "starChildSupport"
       end
 
       def check_supplemental_security_income


### PR DESCRIPTION
**WHY**: I didn't catch this before because MI Bridges only shows this
question if there is someone under 18 in the household.

The tricky thing about this is that we know if *anyone* receives child
support income in a household, but MI Bridges wants to know which child.

After you select a name, it follows up with a queston about the amount
of child support income for each name selected.i

Options are:
- always say "no one" (easiest - already done via this PR)
- always select first child (second easiest)
- collect more granular child support data in MI Benefits so we can fill
this out accurately (hardest)

In order to know which is best, it would be good to get context on the
importance of this question for the county workers.

question:

![screen shot 2017-09-26 at 10 57 38 am](https://user-images.githubusercontent.com/601515/30876757-6845aa42-a2ac-11e7-88ae-b92bf9f95dfe.png)

screen you see if you check a box next to a name:
![screen shot 2017-09-26 at 11 14 08 am](https://user-images.githubusercontent.com/601515/30876753-642b58b2-a2ac-11e7-9168-507a94c73061.png)
