### PR TITLE
Check "homeless" box if address is unstable

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,16 +34,19 @@ minimal_application.update!(
   money_or_accounts_income: false,
   real_estate_income: false,
   vehicle_income: false,
+  unstable_housing: true,
+  mailing_address_same_as_residential_address: true,
 )
 
 Address.where(
   snap_application: minimal_application,
-  street_address: "123 Main St.",
+  street_address: "",
 ).first_or_create(
-  city: "Flint",
+  city: "",
+  zip: "",
   county: "Genesee",
   state: "MI",
-  zip: "48501",
+  mailing: false,
 )
 
 Member.where(

--- a/lib/mi_bridges/driver/personal_information_page.rb
+++ b/lib/mi_bridges/driver/personal_information_page.rb
@@ -44,6 +44,10 @@ module MiBridges
       end
 
       def fill_in_address
+        if snap_application.unstable_housing?
+          click_id "homeless"
+        end
+
         fill_in "Street Address",
           with: residential_address.street_address
         fill_in "City",


### PR DESCRIPTION
**WHY**
* We do not validate residential street / city / zip if unstable address
* MI Bridges has same behavior/
* If someone's address is unstable and we do not mark as homeless,
driving could fail because we may not have street/city/zip

TO TEST:
* re run rake db:seed
* run driver with minimal application
