### PR TITLE
Prevent infinite looping over the same page

### DIFF
--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -3,6 +3,8 @@
 module MiBridges
   class Driver
     class BasePage
+      INSTANTIATION_LIMIT = 5
+
       include Capybara::DSL
 
       @@run_counts = {}
@@ -13,7 +15,7 @@ module MiBridges
         @snap_application = snap_application
 
         @@run_counts[self.class.to_s] ||= 0
-        if @@run_counts[self.class.to_s] >= 5
+        if @@run_counts[self.class.to_s] >= INSTANTIATION_LIMIT
           raise MiBridges::Errors::TooManyAttempts.new(self.class.to_s)
         else
           @@run_counts[self.class.to_s] += 1

--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -83,7 +83,7 @@ module MiBridges
       end
 
       def skip_instance_limitation?
-        self.class.methods(false).include? :skip_instance_limitation
+        self.class.instance_methods(false).include?(:skip_instance_limitation)
       end
 
       def check_instance_limitation

--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -13,8 +13,8 @@ module MiBridges
         @logger = logger
         log("filling out page")
         @snap_application = snap_application
-        return if skip_instance_limitation?
-        check_instance_limitation
+        return if skip_infinite_loop_check?
+        check_for_infinite_looping
       end
 
       def fill_in(*args)
@@ -82,11 +82,11 @@ module MiBridges
         end
       end
 
-      def skip_instance_limitation?
-        self.class.instance_methods(false).include?(:skip_instance_limitation)
+      def skip_infinite_loop_check?
+        self.class.instance_methods(false).include?(:skip_infinite_loop_check)
       end
 
-      def check_instance_limitation
+      def check_for_infinite_looping
         @@run_counts[self.class.to_s] ||= 0
         if @@run_counts[self.class.to_s] >= INSTANTIATION_LIMIT
           raise MiBridges::Errors::TooManyAttempts.new(self.class.to_s)

--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -5,10 +5,19 @@ module MiBridges
     class BasePage
       include Capybara::DSL
 
+      @@run_counts = {}
+
       def initialize(snap_application, logger: nil)
         @logger = logger
         log("filling out page")
         @snap_application = snap_application
+
+        @@run_counts[self.class.to_s] ||= 0
+        if @@run_counts[self.class.to_s] >= 5
+          raise MiBridges::Errors::TooManyAttempts.new(self.class.to_s)
+        else
+          @@run_counts[self.class.to_s] += 1
+        end
       end
 
       def fill_in(*args)

--- a/lib/mi_bridges/driver/personal_information_page.rb
+++ b/lib/mi_bridges/driver/personal_information_page.rb
@@ -11,7 +11,7 @@ module MiBridges
         to: :snap_application,
       )
 
-      def skip_instance_limitation; end
+      def skip_infinite_loop_check; end
 
       def setup; end
 

--- a/lib/mi_bridges/driver/personal_information_page.rb
+++ b/lib/mi_bridges/driver/personal_information_page.rb
@@ -11,7 +11,7 @@ module MiBridges
         to: :snap_application,
       )
 
-      def self.skip_instance_limitation; end
+      def skip_instance_limitation; end
 
       def setup; end
 

--- a/lib/mi_bridges/driver/personal_information_page.rb
+++ b/lib/mi_bridges/driver/personal_information_page.rb
@@ -11,6 +11,8 @@ module MiBridges
         to: :snap_application,
       )
 
+      def self.skip_instance_limitation; end
+
       def setup; end
 
       def fill_in_required_fields

--- a/lib/mi_bridges/driver/relationship_information_page.rb
+++ b/lib/mi_bridges/driver/relationship_information_page.rb
@@ -5,6 +5,8 @@ module MiBridges
     class RelationshipInformationPage < BasePage
       TITLE = "Relationship Information"
 
+      def skip_infinite_loop_check; end
+
       def setup
         @first_member = find_first_member
         @second_members = find_second_members

--- a/lib/mi_bridges/errors.rb
+++ b/lib/mi_bridges/errors.rb
@@ -1,13 +1,15 @@
 module MiBridges
-  class Error < StandardError; end
+  class Error < StandardError
+    attr_reader :message
+
+    def initialize(message)
+      @message = message
+    end
+  end
 
   module Errors
-    class PageNotFoundError < MiBridges::Error
-      attr_reader :message
+    class PageNotFoundError < MiBridges::Error; end
 
-      def initialize(message)
-        @message = message
-      end
-    end
+    class TooManyAttempts < MiBridges::Error; end
   end
 end

--- a/spec/lib/mi_bridges/driver/pages_spec.rb
+++ b/spec/lib/mi_bridges/driver/pages_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Driver pages" do
       module MiBridges
         class Driver
           class SkipInstanceCheckPage < BasePage
-            def skip_instance_limitation; end
+            def skip_infinite_loop_check; end
           end
         end
       end

--- a/spec/lib/mi_bridges/driver/pages_spec.rb
+++ b/spec/lib/mi_bridges/driver/pages_spec.rb
@@ -17,4 +17,28 @@ RSpec.describe "Driver pages" do
       end
     end
   end
+
+  context "when instantiating a page too many times" do
+    it "raises an exception" do
+      snap_application = double
+
+      expect do
+        6.times { MiBridges::Driver::BasePage.new(snap_application) }
+      end.to raise_error(
+        MiBridges::Errors::TooManyAttempts,
+        "MiBridges::Driver::BasePage",
+      )
+    end
+
+    it "passes the name of the child class name to the error" do
+      snap_application = double
+
+      expect do
+        6.times { MiBridges::Driver::HomePage.new(snap_application) }
+      end.to raise_error(
+        MiBridges::Errors::TooManyAttempts,
+        "MiBridges::Driver::HomePage",
+      )
+    end
+  end
 end

--- a/spec/lib/mi_bridges/driver/pages_spec.rb
+++ b/spec/lib/mi_bridges/driver/pages_spec.rb
@@ -42,5 +42,16 @@ RSpec.describe "Driver pages" do
         "MiBridges::Driver::HomePage",
       )
     end
+
+    it "ignores the limit on pages that are instantiated many times" do
+      snap_application = double
+      limit = MiBridges::Driver::BasePage::INSTANTIATION_LIMIT + 1
+
+      expect do
+        limit.times do
+          MiBridges::Driver::PersonalInformationPage.new(snap_application)
+        end
+      end.not_to raise_error
+    end
   end
 end

--- a/spec/lib/mi_bridges/driver/pages_spec.rb
+++ b/spec/lib/mi_bridges/driver/pages_spec.rb
@@ -21,9 +21,10 @@ RSpec.describe "Driver pages" do
   context "when instantiating a page too many times" do
     it "raises an exception" do
       snap_application = double
+      limit = MiBridges::Driver::BasePage::INSTANTIATION_LIMIT + 1
 
       expect do
-        6.times { MiBridges::Driver::BasePage.new(snap_application) }
+        limit.times { MiBridges::Driver::BasePage.new(snap_application) }
       end.to raise_error(
         MiBridges::Errors::TooManyAttempts,
         "MiBridges::Driver::BasePage",
@@ -32,9 +33,10 @@ RSpec.describe "Driver pages" do
 
     it "passes the name of the child class name to the error" do
       snap_application = double
+      limit = MiBridges::Driver::BasePage::INSTANTIATION_LIMIT + 1
 
       expect do
-        6.times { MiBridges::Driver::HomePage.new(snap_application) }
+        limit.times { MiBridges::Driver::HomePage.new(snap_application) }
       end.to raise_error(
         MiBridges::Errors::TooManyAttempts,
         "MiBridges::Driver::HomePage",

--- a/spec/lib/mi_bridges/driver/pages_spec.rb
+++ b/spec/lib/mi_bridges/driver/pages_spec.rb
@@ -35,11 +35,19 @@ RSpec.describe "Driver pages" do
       snap_application = double
       limit = MiBridges::Driver::BasePage::INSTANTIATION_LIMIT + 1
 
+      module MiBridges
+        class Driver
+          class InstanceCheckPage < BasePage; end
+        end
+      end
+
       expect do
-        limit.times { MiBridges::Driver::HomePage.new(snap_application) }
+        limit.times do
+          MiBridges::Driver::InstanceCheckPage.new(snap_application)
+        end
       end.to raise_error(
         MiBridges::Errors::TooManyAttempts,
-        "MiBridges::Driver::HomePage",
+        "MiBridges::Driver::InstanceCheckPage",
       )
     end
 
@@ -47,9 +55,17 @@ RSpec.describe "Driver pages" do
       snap_application = double
       limit = MiBridges::Driver::BasePage::INSTANTIATION_LIMIT + 1
 
+      module MiBridges
+        class Driver
+          class SkipInstanceCheckPage < BasePage
+            def skip_instance_limitation; end
+          end
+        end
+      end
+
       expect do
         limit.times do
-          MiBridges::Driver::PersonalInformationPage.new(snap_application)
+          MiBridges::Driver::SkipInstanceCheckPage.new(snap_application)
         end
       end.not_to raise_error
     end


### PR DESCRIPTION
Occasionally, some pages will be submitted and redirect back to
themselves, which will be filled in the same way, and result in an
infinite loop of:

1. Detect
2. Submit
3. Fail
4. Re-render same page
5. GOTO 1

This commit will keep a count of number of times a particular child
class page object is instantiated, and will raise an exception with that
class's name so that we can tell _which_ page is getting looped over.