### PR TITLE
Rename "test" office and add URL to email signature

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,20 +2,20 @@
 # We use a different name because RAILS_ENV is overloaded and is technically the
 # same across each release stage.
 
-APP_RELEASE_STAGE=development
-
-ADMIN_USER="admin"
 ADMIN_PASSWORD="password"
-PORT=3000
+ADMIN_USER="admin"
+APP_RELEASE_STAGE=development
 FORM_RECIPIENT=test@example.com
-MAILER_FROM=from@example.com
+PORT=3000
 TWILIO_ACCOUNT_SID=bbbb1111
 TWILIO_AUTH_TOKEN=aaaa0000
 TWILIO_PHONE_NUMBER=8007771234
 
 # Mailgun
-EMAIL_DOMAIN=
+EMAIL_DOMAIN="michiganbenefits.org"
 HOSTNAME_FOR_URLS=
+HOSTNAME_FOR_URLS="localhost:3000"
+MAILER_FROM=from@example.com
 MAILGUN_SMTP_LOGIN=
 MAILGUN_SMTP_PASSWORD=
 MAILGUN_SMTP_PORT=587

--- a/app/views/application_mailer/office_application_notification.html.erb
+++ b/app/views/application_mailer/office_application_notification.html.erb
@@ -17,5 +17,5 @@
   <br>
   Alan Williams (Code for America) & Lena Selzer (Civilla)
   <br>
-  https://www.michiganbenefits.org/
+  <%= root_url %>
 </p>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   # Customize default host
   config.action_mailer.default_url_options = {
     host: ENV["HOSTNAME_FOR_URLS"],
-    protocol: "http",
+    protocol: "https",
   }
 
   config.action_mailer.smtp_settings = SMTP_SETTINGS

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,4 +15,8 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
   config.active_support.deprecation = :stderr
   config.assets.debug = true
+
+  config.action_mailer.default_url_options = {
+    host: "example.com",
+  }
 end

--- a/config/offices.yml
+++ b/config/offices.yml
@@ -4,7 +4,7 @@ defaults: &defaults
   # zip code is not in our mapping
   fallback_office: "clio"
   covered_zip_codes:
-    "12345": "staging_sfax"
+    "12345": "test_office"
     # Clio Zip Codes
     "48415": "clio"
     "48417": "clio"
@@ -45,9 +45,8 @@ defaults: &defaults
 development:
   <<: *defaults
   offices:
-    staging_sfax: # Technically this is to our sfax production fax;
-                  # because you can't fax yourself
-      fax_number: "+18448487565"
+    test_office:
+      fax_number: "+16173963015"
       email: "staging@example.com"
     union:
       fax_number: "+16173963015"
@@ -58,9 +57,8 @@ development:
 staging:
   <<: *defaults
   offices:
-    staging_sfax: # Technically this is to our sfax production fax;
-                  # because you can't fax yourself
-      fax_number: "+18448487565"
+    test_office:
+      fax_number: "+18448487565" # sends to sfax production
       email: "hello@michiganbenefits.org"
     union:
       fax_number: "+16173963015"
@@ -71,9 +69,9 @@ staging:
 production:
   <<: *defaults
   offices:
-    staging_sfax:
-      fax_number: "+18888433549"
-      email: "gcfengineering+heroku@codeforamerica.org"
+    test_office:
+      fax_number: "+18888433549" # sends to sfax staging
+      email: "hello@michiganbenefits.org"
     union:
       fax_number: "+18107607372"
       email: "MDHHS-Genesee-UnionSt-DigitalAssisterApp@michigan.gov"

--- a/spec/models/office_recipient_spec.rb
+++ b/spec/models/office_recipient_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe OfficeRecipient do
       )
 
       expect(fax_recipient.office).to eq(
-        "email" => "gcfengineering+heroku@codeforamerica.org",
-        "name" => "Staging Sfax",
+        "email" => "hello@michiganbenefits.org",
+        "name" => "Test Office",
         "fax_number" => staging_fax_number,
       )
     end


### PR DESCRIPTION
**WHY**:
- "staging_sfax" made more sense when this file represented fax numbers,
but now it represents offices. When we set the zip to 12345, we want to
send an email/fax to the "test" office. Se we renamed it "test office" !
- the production URL used to be hardcoded into the email signature. Now
it's dynamic.

email footer:

<img width="1257" alt="screen shot 2017-09-28 at 4 28 40 pm" src="https://user-images.githubusercontent.com/601515/30994858-5b8a9b76-a46b-11e7-8a4f-b5962655c6ab.png">
