### PR TITLE
Calculate hourly wage based on pay interval

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,6 +1,4 @@
 class Member < ApplicationRecord
-  AVERAGE_WEEKS_PER_MONTH = 4.33
-  MONTHS_PER_YEAR = 12
   PAYMENT_INTERVALS = [
     "Hourly",
     "Weekly",
@@ -71,17 +69,10 @@ class Member < ApplicationRecord
   end
 
   def employed_monthly_income
-    return if employed_pay_quantity.nil?
-    if employed_pay_interval == "Hourly"
-      employed_hours_per_week * employed_pay_quantity * AVERAGE_WEEKS_PER_MONTH
-    elsif ["Every Two Weeks", "Twice a Month"].include? employed_pay_interval
-      employed_pay_quantity * (AVERAGE_WEEKS_PER_MONTH / 2)
-    elsif employed_pay_interval == "Weekly"
-      employed_pay_quantity * AVERAGE_WEEKS_PER_MONTH
-    elsif employed_pay_interval == "Monthly"
-      employed_pay_quantity
-    else # "Year"
-      employed_pay_quantity / MONTHS_PER_YEAR
-    end
+    MonthlyIncomeCalculator.new(
+      pay_interval: employed_pay_interval,
+      pay_quantity: employed_pay_quantity,
+      hours_per_week: employed_hours_per_week,
+    ).run
   end
 end

--- a/app/services/hourly_income_calculator.rb
+++ b/app/services/hourly_income_calculator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class HourlyIncomeCalculator
+  AVERAGE_WEEKS_PER_MONTH = 4.33
+  def initialize(pay_quantity: nil, pay_interval: nil, hours_per_week: nil)
+    @pay_quantity = pay_quantity.to_f
+    @pay_interval = pay_interval
+    @hours_per_week = hours_per_week
+  end
+
+  def run
+    if pay_interval == "Hourly"
+      pay_quantity
+    elsif ["Every Two Weeks", "Twice a Month"].include?(pay_interval)
+      pay_quantity / (hours_per_week * 2)
+    elsif pay_interval == "Weekly"
+      pay_quantity / hours_per_week
+    elsif pay_interval == "Monthly"
+      pay_quantity / (hours_per_week * AVERAGE_WEEKS_PER_MONTH)
+    else
+      0
+    end.round(2)
+  end
+
+  private
+
+  attr_reader :hours_per_week, :pay_quantity, :pay_interval
+end

--- a/app/services/monthly_income_calculator.rb
+++ b/app/services/monthly_income_calculator.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class MonthlyIncomeCalculator
+  AVERAGE_WEEKS_PER_MONTH = 4.33
+  MONTHS_PER_YEAR = 12
+
+  def initialize(pay_quantity: nil, pay_interval: nil, hours_per_week: nil)
+    @pay_quantity = pay_quantity
+    @pay_interval = pay_interval
+    @hours_per_week = hours_per_week
+  end
+
+  def run
+    if pay_quantity.nil? || pay_interval.nil?
+      nil
+    else
+      calculate_based_on_pay_interval
+    end
+  end
+
+  private
+
+  attr_reader :hours_per_week, :pay_quantity, :pay_interval
+
+  def calculate_based_on_pay_interval
+    if pay_interval == "Hourly"
+      return if hours_per_week.nil?
+      hours_per_week * pay_quantity * AVERAGE_WEEKS_PER_MONTH
+    elsif ["Every Two Weeks", "Twice a Month"].include?(pay_interval)
+      pay_quantity * (AVERAGE_WEEKS_PER_MONTH / 2)
+    elsif pay_interval == "Weekly"
+      pay_quantity * AVERAGE_WEEKS_PER_MONTH
+    elsif pay_interval == "Monthly"
+      pay_quantity
+    else #  pay_interval == "Yearly"
+      pay_quantity.to_f / MONTHS_PER_YEAR
+    end.round(2)
+  end
+end

--- a/lib/mi_bridges/driver/more_about_job_income_page.rb
+++ b/lib/mi_bridges/driver/more_about_job_income_page.rb
@@ -65,7 +65,7 @@ module MiBridges
       end
 
       def current_member
-        @current_member ||= members.select do |member|
+        @_current_member ||= members.select do |member|
           member.mi_bridges_formatted_name == name
         end.first
       end

--- a/lib/mi_bridges/driver/more_about_job_income_page.rb
+++ b/lib/mi_bridges/driver/more_about_job_income_page.rb
@@ -20,7 +20,7 @@ module MiBridges
           from: "How often does #{name} get paid? This is #{name}'s pay period",
         )
 
-        if hourly?
+        if not_salaried?
           fill_in_hourly
         else
           fill_in_salary
@@ -33,20 +33,28 @@ module MiBridges
 
       private
 
-      def hourly?
+      def not_salaried?
         current_member.employed_pay_interval != "Yearly"
       end
 
       def fill_in_hourly
         fill_in(
           "If #{name} gets paid by the hour, ",
-          with: current_member.employed_pay_quantity,
+          with: hourly_wage,
         )
 
         fill_in(
           "Please tell us how many hours #{name} works",
           with: current_member.employed_hours_per_week,
         )
+      end
+
+      def hourly_wage
+        HourlyIncomeCalculator.new(
+          pay_quantity: current_member.employed_pay_quantity,
+          pay_interval: current_member.employed_pay_interval,
+          hours_per_week: current_member.employed_hours_per_week,
+        ).run
       end
 
       def fill_in_salary
@@ -57,7 +65,7 @@ module MiBridges
       end
 
       def current_member
-        members.select do |member|
+        @current_member ||= members.select do |member|
           member.mi_bridges_formatted_name == name
         end.first
       end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Member do
     end
 
     context "employed" do
-      it "returns monthly income" do
+      it "calls MonthlyIncomeCalculator to find monthly income" do
         member = build(
           :member,
           employment_status: "employed",

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -31,11 +31,16 @@ RSpec.describe Member do
           employed_pay_interval: "Hourly",
           employed_hours_per_week: 10,
         )
+        calc_double = double(run: true)
+        allow(MonthlyIncomeCalculator).to receive(:new).with(
+          pay_interval: "Hourly",
+          pay_quantity: 10,
+          hours_per_week: 10,
+        ).and_return(calc_double)
 
-        weekly_pay_times_average_weeks_per_month = 433.0
-        expect(member.monthly_income).to eq(
-          weekly_pay_times_average_weeks_per_month,
-        )
+        member.monthly_income
+
+        expect(calc_double).to have_received(:run)
       end
     end
 

--- a/spec/services/hourly_income_calculcator_spec.rb
+++ b/spec/services/hourly_income_calculcator_spec.rb
@@ -1,0 +1,92 @@
+require "rails_helper"
+
+RSpec.describe HourlyIncomeCalculator do
+  describe "#run" do
+    context "pay quantity is nil" do
+      it "returns zero" do
+        amount = HourlyIncomeCalculator.new(
+          pay_quantity: nil,
+          hours_per_week: nil,
+          pay_interval: nil,
+        ).run
+
+        expect(amount).to eq 0
+      end
+    end
+
+    context "pay interval is hourly" do
+      it "returns the pay quantity" do
+        pay_quantity = 1
+        hours_per_week = 100
+
+        amount = HourlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: hours_per_week,
+          pay_interval: "Hourly",
+        ).run
+
+        expect(amount).to eq 1
+      end
+    end
+
+    context "pay interval is every two weeks" do
+      it "divides the quantity by hours per week times 2" do
+        pay_quantity = 200
+        hours_per_week = 100
+
+        amount = HourlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: hours_per_week,
+          pay_interval: "Every Two Weeks",
+        ).run
+
+        expect(amount).to eq 1
+      end
+    end
+
+    context "pay interval is twice a month" do
+      it "divides the quantity by hours per week times 2" do
+        pay_quantity = 200
+        hours_per_week = 100
+
+        amount = HourlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: hours_per_week,
+          pay_interval: "Twice a Month",
+        ).run
+
+        expect(amount).to eq 1
+      end
+    end
+
+    context "pay interval is weekly" do
+      it "divides the quantity by hours per week" do
+        pay_quantity = 100
+        hours_per_week = 100
+
+        amount = HourlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: hours_per_week,
+          pay_interval: "Weekly",
+        ).run
+
+        expect(amount).to eq 1
+      end
+    end
+
+    context "pay interval is monthly" do
+      it "returns quantity divided by hours/week times average weeks/month" do
+        pay_quantity = 100
+        hours_per_week = 10
+
+        amount = HourlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: hours_per_week,
+          pay_interval: "Monthly",
+        ).run
+
+        expect(amount).to eq 2.31
+      end
+    end
+  end
+end

--- a/spec/services/monthly_income_calculator_spec.rb
+++ b/spec/services/monthly_income_calculator_spec.rb
@@ -1,0 +1,128 @@
+require "rails_helper"
+
+RSpec.describe MonthlyIncomeCalculator do
+  describe "#run" do
+    context "pay interval is nil" do
+      it "returns nil" do
+        amount = MonthlyIncomeCalculator.new(
+          pay_quantity: 100,
+          hours_per_week: nil,
+          pay_interval: nil,
+        ).run
+
+        expect(amount).to eq nil
+      end
+    end
+
+    context "pay quantity is nil" do
+      it "returns nil" do
+        amount = MonthlyIncomeCalculator.new(
+          pay_quantity: nil,
+          hours_per_week: nil,
+          pay_interval: "Yearly",
+        ).run
+
+        expect(amount).to eq nil
+      end
+    end
+
+    context "pay interval is hourly" do
+      context "hours per week is nil" do
+        it "returns nil" do
+          pay_quantity = 1
+
+          amount = MonthlyIncomeCalculator.new(
+            pay_quantity: pay_quantity,
+            hours_per_week: nil,
+            pay_interval: "Hourly",
+          ).run
+
+          expect(amount).to eq nil
+        end
+      end
+
+      it "multiplies pay quantity by hours/week and average weeks per month" do
+        pay_quantity = 1
+        hours_per_week = 100
+
+        amount = MonthlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: hours_per_week,
+          pay_interval: "Hourly",
+        ).run
+
+        expect(amount).to eq 433.0
+      end
+    end
+
+    context "pay interval is every two weeks" do
+      it "returns pay quantity times average weeks per month times 2" do
+        pay_quantity = 100
+
+        amount = MonthlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: 0,
+          pay_interval: "Every Two Weeks",
+        ).run
+
+        expect(amount).to eq 216.5
+      end
+    end
+
+    context "pay interval is twice a month" do
+      it "returns pay quantity times average weeks per month times 2" do
+        pay_quantity = 100
+
+        amount = MonthlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: 0,
+          pay_interval: "Twice a Month",
+        ).run
+
+        expect(amount).to eq 216.5
+      end
+    end
+
+    context "pay interval is weekly" do
+      it "returns pay quantity times average weeks per month" do
+        pay_quantity = 100
+
+        amount = MonthlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: 0,
+          pay_interval: "Weekly",
+        ).run
+
+        expect(amount).to eq 433.0
+      end
+    end
+
+    context "pay interval is monthly" do
+      it "returns pay quantity" do
+        pay_quantity = 100
+
+        amount = MonthlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: 0,
+          pay_interval: "Monthly",
+        ).run
+
+        expect(amount).to eq 100
+      end
+    end
+
+    context "pay interval is yearly" do
+      it "returns pay quantity divided by months per year" do
+        pay_quantity = 18
+
+        amount = MonthlyIncomeCalculator.new(
+          pay_quantity: pay_quantity,
+          hours_per_week: 0,
+          pay_interval: "Yearly",
+        ).run
+
+        expect(amount).to eq 1.5
+      end
+    end
+  end
+end


### PR DESCRIPTION
**WHY**:
- we known pay quantity "per interval". Before, we were filling in the
hourly rate as whatever the pay quantity was, which is only accurate if
the interval happens to be hourly. For all other intervals, slightly
more complex calculations are required.
- took this opp to move the monthly income calculator into its own class
as well.
