### PR TITLE
Check that "From" header in emails have a name

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,17 +1,21 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: "hello@#{ENV['EMAIL_DOMAIN']}"
   layout "mailer"
 
   def snap_application_notification(file_name:, recipient_email:)
     attachments["snap_application.pdf"] = File.read(file_name)
-    mail to: recipient_email, subject: "Your SNAP application"
+    mail(
+      from: %("Michigan Benefits" <hello@#{ENV['EMAIL_DOMAIN']}>),
+      to: recipient_email,
+      subject: "Your SNAP application",
+    )
   end
 
   def office_application_notification(file_name:, recipient_email:)
     attachments["snap_application.pdf"] = File.read(file_name)
     mail(
+      from: %("Michigan Benefits" <hello@#{ENV['EMAIL_DOMAIN']}>),
       to: recipient_email,
       subject: "A new 1171 from the Digital Assister has been submitted!",
     )

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe ApplicationMailer do
+  describe ".snap_application_notification" do
+    it "sets the correct headers" do
+      with_modified_env EMAIL_DOMAIN: "example.com" do
+        email = ApplicationMailer.snap_application_notification(
+          file_name: "#{Rails.root}/spec/fixtures/image.jpg",
+          recipient_email: "user@example.com",
+        )
+        from_header = email.header.select do |header|
+          header.name == "From"
+        end.first.value
+
+        expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
+        expect(email.from).to eq(["hello@example.com"])
+        expect(email.to).to eq(["user@example.com"])
+        expect(email.subject).to eq("Your SNAP application")
+      end
+    end
+  end
+
+  describe ".office_application_notification" do
+    it "sets the correct headers" do
+      with_modified_env EMAIL_DOMAIN: "example.com" do
+        email = ApplicationMailer.office_application_notification(
+          file_name: "#{Rails.root}/spec/fixtures/image.jpg",
+          recipient_email: "user@example.com",
+        )
+        from_header = email.header.select do |header|
+          header.name == "From"
+        end.first.value
+
+        expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
+        expect(email.from).to eq(["hello@example.com"])
+        expect(email.to).to eq(["user@example.com"])
+        expect(email.subject).
+          to eq("A new 1171 from the Digital Assister has been submitted!")
+      end
+    end
+  end
+end


### PR DESCRIPTION
When emails are sent to an office or a client, the "FROM" field in the
email should have a more approachable value instead of just
"hello@somedomain.com".

This commit changes the FROM header and adds some tests to accompany the
resulting emails' headers, asserting their validity.