### PR TITLE
Add script for re-driving applications from Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem "neat", "~> 1.8" # to keep in sync with getcalfresh
 gem "pdf-forms"
 gem "pg", "~> 0.18"
 gem "prawn"
+gem "pry-rails"
 gem "puma"
 gem "rails", "~> 5.1"
 gem "responders"
@@ -59,7 +60,6 @@ group :development, :test do
   gem "listen"
   gem "mailcatcher", "~> 0.2"
   gem "pry-byebug"
-  gem "pry-rails"
   gem "rspec-rails"
   gem "rspec_junit_formatter"
   gem "rubocop-rspec", require: false

--- a/bin/re_drive_prod
+++ b/bin/re_drive_prod
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+read -p "What is the ID of the SNAP Application you want to re-drive? " -r
+SNAP_APPLICATION_ID=$REPLY
+echo
+
+read -p "What is the name of the Heroku remote you'd like to access?
+(staging/production) " -r
+echo
+
+echo "Backing up $REPLY database, just in case..."
+heroku pg:backups:capture --remote $REPLY
+
+DB_URL="$(heroku config:get DATABASE_URL -r $REPLY)"
+export DATABASE_URL=$DB_URL
+
+export DEBUG_DRIVE="true"
+./bin/rails runner "app = SnapApplication.find($SNAP_APPLICATION_ID);
+ MiBridges::Driver.new(snap_application: app).re_run"

--- a/bin/re_drive_prod
+++ b/bin/re_drive_prod
@@ -7,12 +7,40 @@ echo
 read -p "What is the name of the Heroku remote you'd like to access? (staging/production) "
 echo
 
-echo "Backing up $REPLY database, just in case..."
-heroku pg:backups:capture --remote $REPLY
+HEROKU_REMOTE=$REPLY
 
-DB_URL="$(heroku config:get DATABASE_URL -r $REPLY)"
+read -p "WARNING: you are about to access the $HEROKU_REMOTE database directly.
+Are you sure you want to proceed? (y/n) " -n 1 -r
+echo
+
+if [[ $REPLY =~ ^[Yy]$ ]];then
+  echo "OK, proceeding with accessing $HEROKU_REMOTE database..."
+else
+  echo "OK, bye bye!"
+  exit 1
+fi
+echo
+
+read -p "Have you set up the development environment to use DATABASE_URL in the
+database.yml file? (y/n) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]];then
+  echo "OK, proceeding with accessing $HEROKU_REMOTE database..."
+else
+  echo "Please update database.yml and re-run this script"
+  exit 1
+fi
+echo
+
+echo "Backing up $HEROKU_REMOTE database, just in case..."
+heroku pg:backups:capture --remote $HEROKU_REMOTE
+
+DB_URL="$(heroku config:get DATABASE_URL -r $HEROKU_REMOTE)"
+ENCRYPTION_KEY="$(heroku config:get SECRET_KEY_FOR_DRIVER_APPLICATION -r $HEROKU_REMOTE)"
+
+export DEBUG_DRIVE=true
 export DATABASE_URL=$DB_URL
+export SECRET_KEY_FOR_DRIVER_APPLICATION=$ENCRYPTION_KEY
 
-export DEBUG_DRIVE="true"
-./bin/rails runner "app = SnapApplication.find($SNAP_APPLICATION_ID);
+./bin/rails runner "app = SnapApplication.find $SNAP_APPLICATION_ID;
  MiBridges::Driver.new(snap_application: app).re_run"

--- a/bin/re_drive_prod
+++ b/bin/re_drive_prod
@@ -1,11 +1,10 @@
 #!/bin/bash
 
-read -p "What is the ID of the SNAP Application you want to re-drive? " -r
+read -p "What is the ID of the SNAP Application you want to re-drive? "
 SNAP_APPLICATION_ID=$REPLY
 echo
 
-read -p "What is the name of the Heroku remote you'd like to access?
-(staging/production) " -r
+read -p "What is the name of the Heroku remote you'd like to access? (staging/production) "
 echo
 
 echo "Backing up $REPLY database, just in case..."

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,83 +1,15 @@
-# PostgreSQL. Versions 9.1 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On OS X with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On OS X with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem 'pg'
-#
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see rails configuration guide
-  # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 development:
   <<: *default
-  database: michigan_prototype_development
+  database: <%= ENV["DATABASE_URL"] || 'michigan_prototype_development' %>
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user that initialized the database.
-  #username: michigan_prototype
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: michigan_prototype_test
-
-# As with config/secrets.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password as a unix environment variable when you boot
-# the app. Read http://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full rundown on how to provide these environment variables in a
-# production deployment.
-#
-# On Heroku and other platform providers, you may have a full connection URL
-# available as an environment variable. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# You can use this database configuration with:
-#
-#   production:
-#     url: <%= ENV['DATABASE_URL'] %>
-#
 
 production:
   adapter: postgresql

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,12 +5,11 @@ default: &default
 
 development:
   <<: *default
-  database: <%= ENV["DATABASE_URL"] || 'michigan_prototype_development' %>
-
+  database: michigan_prototype_development
 test:
   <<: *default
   database: michigan_prototype_test
 
 production:
   adapter: postgresql
-  url: <%= ENV['DATABASE_URL'] %>
+  url: <%= ENV["DATABASE_URL"] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -7,7 +7,7 @@ Rails.application.configure do
 
   config.cache_classes = true
   config.eager_load = true
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local = false
   config.action_controller.perform_caching = true
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
**WHY**:
- if a drive fails, this is the simplest way to debug

**HOW**:
- run `bin/re_drive_prod`
- script prompts you for the id of a Snap App and which env you're
  targeting
- note that this only works for Snap Apps that have *already* been driven once (logs in with existing driver account in MI Bridges, which will fail if there is no existing account)
- try it out yourself with ID 236 and staging env!
