### PR TITLE
Save error info for all failed driving attempts

### DIFF
--- a/app/models/driver_application.rb
+++ b/app/models/driver_application.rb
@@ -5,6 +5,7 @@ class DriverApplication < ApplicationRecord
 
   belongs_to :snap_application
   validates :snap_application, presence: true
+  has_many :driver_errors, dependent: :destroy
 
   attribute %i[
     password

--- a/app/models/driver_error.rb
+++ b/app/models/driver_error.rb
@@ -1,0 +1,9 @@
+class DriverError < ApplicationRecord
+  belongs_to :driver_application
+
+  validates :driver_application, presence: true
+  validates :error_class, presence: true
+  validates :error_message, presence: true
+  validates :page_class, presence: true
+  validates :page_html, presence: true
+end

--- a/db/migrate/20171002204734_create_driver_errors.rb
+++ b/db/migrate/20171002204734_create_driver_errors.rb
@@ -1,0 +1,13 @@
+class CreateDriverErrors < ActiveRecord::Migration[5.1]
+  def change
+    create_table :driver_errors do |t|
+      t.references :driver_application, null: false, foreign_key: true
+      t.string :error_class, null: false
+      t.string :error_message, null: false
+      t.string :page_class, null: false
+      t.text :page_html, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170926234635) do
+ActiveRecord::Schema.define(version: 20171002204734) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,17 @@ ActiveRecord::Schema.define(version: 20170926234635) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["snap_application_id"], name: "index_driver_applications_on_snap_application_id"
+  end
+
+  create_table "driver_errors", force: :cascade do |t|
+    t.bigint "driver_application_id", null: false
+    t.string "error_class", null: false
+    t.string "error_message", null: false
+    t.string "page_class", null: false
+    t.text "page_html", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["driver_application_id"], name: "index_driver_errors_on_driver_application_id"
   end
 
   create_table "exports", force: :cascade do |t|
@@ -156,4 +167,5 @@ ActiveRecord::Schema.define(version: 20170926234635) do
   end
 
   add_foreign_key "driver_applications", "snap_applications"
+  add_foreign_key "driver_errors", "driver_applications"
 end

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -125,8 +125,6 @@ module MiBridges
       end
 
       run_flow([SubmitPage])
-    rescue StandardError => e
-      debug(e)
     end
 
     def run_flow(flow)
@@ -137,6 +135,7 @@ module MiBridges
           page.fill_in_required_fields
           page.continue
         rescue StandardError => e
+          save_error(e, page)
           debug(e)
         end
       end
@@ -156,6 +155,18 @@ module MiBridges
       else
         Logger::INFO
       end
+    end
+
+    def save_error(e, page)
+      @snap_application.
+        driver_application.
+        driver_errors.
+        create(
+          error_class: e.class.to_s,
+          error_message: e.message,
+          page_class: page.class.to_s,
+          page_html: page.html,
+        )
     end
 
     def debug(e)

--- a/spec/factories/driver_errors.rb
+++ b/spec/factories/driver_errors.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  factory :driver_error do
+    driver_application
+
+    error_class "RuntimeError"
+    error_message "runtime error"
+    page_class "MiBridges::Driver::BasePage"
+    page_html "<html></html>"
+  end
+end

--- a/spec/models/driver_application_spec.rb
+++ b/spec/models/driver_application_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe DriverApplication do
   describe "Associations" do
     it { should belong_to(:snap_application) }
+    it { should have_many(:driver_errors).dependent(:destroy) }
   end
 
   describe "Validations" do

--- a/spec/models/driver_error_spec.rb
+++ b/spec/models/driver_error_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe DriverError, type: :model do
+  describe "associations" do
+    it { should belong_to(:driver_application) }
+  end
+
+  describe "validations" do
+    it { should validate_presence_of(:driver_application) }
+    it { should validate_presence_of(:error_class) }
+    it { should validate_presence_of(:error_message) }
+    it { should validate_presence_of(:page_class) }
+    it { should validate_presence_of(:page_html) }
+  end
+end


### PR DESCRIPTION
When driving errors out, we should get some visibility into _why_ things
failed. The information we have available upon exceptions being caught
are the exceptions themselves, the message property in the exception,
the current page object we are attempting to run, and the contents of
the page we are on currently.