### PR TITLE
Use different email subject/body when client in office

### DIFF
--- a/app/jobs/office_email_application_job.rb
+++ b/app/jobs/office_email_application_job.rb
@@ -4,6 +4,7 @@ class OfficeEmailApplicationJob < ApplicationJob
       ApplicationMailer.office_application_notification(
         file_name: snap_application.pdf.path,
         recipient_email: snap_application.receiving_office_email,
+        office_location: snap_application.office_location,
       ).deliver
 
       "Emailed to #{snap_application.receiving_office_email}"

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -34,7 +34,7 @@ class ApplicationMailer < ActionMailer::Base
     if office_location.present?
       "A new 1171 from someone in the lobby has been submitted!"
     else
-      "A new 1171 from the Digital Assister has been submitted!"
+      "A new 1171 from someone online has been submitted!"
     end
   end
 

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -12,12 +12,37 @@ class ApplicationMailer < ActionMailer::Base
     )
   end
 
-  def office_application_notification(file_name:, recipient_email:)
+  def office_application_notification(
+    file_name:,
+    recipient_email:,
+    office_location: nil
+  )
     attachments["snap_application.pdf"] = File.read(file_name)
+    @office_location = office_location
+
     mail(
       from: %("Michigan Benefits" <hello@#{ENV['EMAIL_DOMAIN']}>),
       to: recipient_email,
-      subject: "A new 1171 from the Digital Assister has been submitted!",
+      subject: subject(office_location),
+      template_name: template_name(office_location),
     )
+  end
+
+  private
+
+  def subject(office_location)
+    if office_location.present?
+      "A new 1171 from someone in the lobby has been submitted!"
+    else
+      "A new 1171 from the Digital Assister has been submitted!"
+    end
+  end
+
+  def template_name(office_location)
+    if office_location.present?
+      "in_office_application_notification"
+    else
+      "office_application_notification"
+    end
   end
 end

--- a/app/views/application_mailer/in_office_application_notification.html.erb
+++ b/app/views/application_mailer/in_office_application_notification.html.erb
@@ -1,10 +1,9 @@
 <p>
-Hello Genesee County staff!
+Hello <%= @office_location.capitalize %> staff!
 </p>
 
 <p>
-Attached you'll find a new 1171, completed just moments ago by a client using
-the Digital Assister.
+Attached you'll find a new 1171, completed just moments ago by a client in your office lobby, using the Digital Assister.
 </p>
 
 <p>

--- a/app/views/application_mailer/office_application_notification.html.erb
+++ b/app/views/application_mailer/office_application_notification.html.erb
@@ -3,14 +3,11 @@ Hello Genesee County staff!
 </p>
 
 <p>
-Attached you'll find a new 1171, completed just moments ago by a client using
-the Digital Assister.
+A new application for FAP was just completed online. Attached you'll find a new 1171, completed using the Digital Assister. This person is not present at your office.
 </p>
 
 <p>
-Thank you as always for your feedback on this new process. Let us know what is
-working, and what can be improved! Reach out with ideas or issues anytime by
-replying to this email.
+Thank you as always for your feedback on this new process. Let us know what is working, and what can be improved! Reach out with ideas or issues anytime by replying to this email.
 </p>
 
 <p>

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ApplicationMailer do
           expect(email.from).to eq(["hello@example.com"])
           expect(email.to).to eq(["user@example.com"])
           expect(email.subject).to eq(
-            "A new 1171 from the Digital Assister has been submitted!",
+            "A new 1171 from someone online has been submitted!",
           )
           expect(email.body.encoded).not_to include(
             "by a client in your office lobby",

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -21,21 +21,55 @@ RSpec.describe ApplicationMailer do
   end
 
   describe ".office_application_notification" do
-    it "sets the correct headers" do
-      with_modified_env EMAIL_DOMAIN: "example.com" do
-        email = ApplicationMailer.office_application_notification(
-          file_name: "#{Rails.root}/spec/fixtures/image.jpg",
-          recipient_email: "user@example.com",
-        )
-        from_header = email.header.select do |header|
-          header.name == "From"
-        end.first.value
+    context "office_location not present" do
+      it "sets the correct headers" do
+        with_modified_env EMAIL_DOMAIN: "example.com" do
+          email = ApplicationMailer.office_application_notification(
+            file_name: "#{Rails.root}/spec/fixtures/image.jpg",
+            recipient_email: "user@example.com",
+          )
+          from_header = email.header.select do |header|
+            header.name == "From"
+          end.first.value
 
-        expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
-        expect(email.from).to eq(["hello@example.com"])
-        expect(email.to).to eq(["user@example.com"])
-        expect(email.subject).
-          to eq("A new 1171 from the Digital Assister has been submitted!")
+          expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
+          expect(email.from).to eq(["hello@example.com"])
+          expect(email.to).to eq(["user@example.com"])
+          expect(email.subject).to eq(
+            "A new 1171 from the Digital Assister has been submitted!",
+          )
+          expect(email.body.encoded).not_to include(
+            "by a client in your office lobby",
+          )
+        end
+      end
+    end
+
+    context "office_location present" do
+      it "sets the correct values" do
+        with_modified_env EMAIL_DOMAIN: "example.com" do
+          email = ApplicationMailer.office_application_notification(
+            file_name: "#{Rails.root}/spec/fixtures/image.jpg",
+            recipient_email: "user@example.com",
+            office_location: "union",
+          )
+          from_header = email.header.select do |header|
+            header.name == "From"
+          end.first.value
+
+          expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
+          expect(email.from).to eq(["hello@example.com"])
+          expect(email.to).to eq(["user@example.com"])
+          expect(email.subject).to eq(
+            "A new 1171 from someone in the lobby has been submitted!",
+          )
+          expect(email.body.encoded).to include(
+            "Union",
+          )
+          expect(email.body.encoded).to include(
+            "by a client in your office lobby",
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
**WHY**: to alert office staff
