### PR TITLE
Drive all new Snap Apps

### DIFF
--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -21,6 +21,10 @@ class SuccessController < StandardStepsController
       destination: :office_email,
       snap_application: current_snap_application,
     )
+
+    DriveApplicationJob.perform_later(
+      snap_application: current_snap_application,
+    )
   end
 
   def after_successful_update_hook

--- a/app/jobs/drive_application_job.rb
+++ b/app/jobs/drive_application_job.rb
@@ -1,0 +1,7 @@
+class DriveApplicationJob < ApplicationJob
+  def perform(snap_application:)
+    if snap_application.driver_applications.empty?
+      MiBridges::Driver.new(snap_application: snap_application).run
+    end
+  end
+end

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe SuccessController do
   before do
     session[:snap_application_id] = current_app.id
+    run_double = double(run: true)
+    allow(MiBridges::Driver).to receive(:new).
+      with(snap_application: current_app).
+      and_return(run_double)
   end
 
   describe "#edit" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,7 @@ RSpec.configure do |config|
   config.include FeatureHelper, type: :feature
   config.include SnapApplicationFormHelper, type: :feature
   config.include GenericHelper
+  config.include BackgroundJobs
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/support/background_jobs.rb
+++ b/spec/support/background_jobs.rb
@@ -1,0 +1,8 @@
+module BackgroundJobs
+  def run_background_jobs_immediately
+    delay_jobs = Delayed::Worker.delay_jobs
+    Delayed::Worker.delay_jobs = false
+    yield
+    Delayed::Worker.delay_jobs = delay_jobs
+  end
+end


### PR DESCRIPTION
* When success page is reached, app is driven
* If app was already driven, do not re-drive
* We are not submitting apps on MI Bridges yet, we only get to the
submit page, but this will allow us to test our driving
code with real data so we can feel more confident when we do start
submitting.

Minor:
* Add helper for running background jobs immediately, h/t https://robots.thoughtbot.com/process-jobs-inline-when-running-acceptance-tests