### PR TITLE
Record when apps (and its errors) are driven

### DIFF
--- a/db/migrate/20171005165616_add_driven_at_to_driver_errors.rb
+++ b/db/migrate/20171005165616_add_driven_at_to_driver_errors.rb
@@ -1,0 +1,19 @@
+class AddDrivenAtToDriverErrors < ActiveRecord::Migration[5.1]
+  def up
+    add_column :driver_applications, :driven_at, :datetime
+    add_column :driver_errors, :driven_at, :datetime
+
+    execute <<~SQL
+      UPDATE driver_applications SET driven_at=now();
+      UPDATE driver_errors SET driven_at=now();
+    SQL
+
+    change_column_null :driver_applications, :driven_at, false
+    change_column_null :driver_errors, :driven_at, false
+  end
+
+  def down
+    remove_column :driver_applications, :driven_at
+    remove_column :driver_errors, :driven_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171005000507) do
+ActiveRecord::Schema.define(version: 20171005165616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 20171005000507) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "tracking_number"
+    t.datetime "driven_at", null: false
     t.index ["snap_application_id"], name: "index_driver_applications_on_snap_application_id"
   end
 
@@ -67,6 +68,7 @@ ActiveRecord::Schema.define(version: 20171005000507) do
     t.text "page_html", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "driven_at", null: false
     t.index ["driver_application_id"], name: "index_driver_errors_on_driver_application_id"
   end
 

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -170,6 +170,7 @@ module MiBridges
           error_message: e.message,
           page_class: page.class.to_s,
           page_html: page.html,
+          driven_at: latest_drive_attempt.driven_at,
         )
     end
 

--- a/lib/mi_bridges/driver/create_account_page.rb
+++ b/lib/mi_bridges/driver/create_account_page.rb
@@ -50,6 +50,7 @@ module MiBridges
           password: generate_password,
           secret_question_1_answer: generate_secret_question_1_answer,
           secret_question_2_answer: generate_secret_question_2_answer,
+          driven_at: DateTime.current,
         )
       end
 

--- a/lib/mi_bridges/driver/home_log_in_page.rb
+++ b/lib/mi_bridges/driver/home_log_in_page.rb
@@ -6,6 +6,7 @@ module MiBridges
       delegate :latest_drive_attempt, to: :snap_application
 
       def setup
+        latest_drive_attempt.update(driven_at: DateTime.current)
         visit "https://www.mibridges.michigan.gov/access/"
       end
 

--- a/spec/factories/driver_application.rb
+++ b/spec/factories/driver_application.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     password "password"
     secret_question_1_answer "Answer 1"
     secret_question_2_answer "Answer 2"
+    driven_at DateTime.current
 
     snap_application
   end

--- a/spec/factories/driver_errors.rb
+++ b/spec/factories/driver_errors.rb
@@ -4,6 +4,7 @@ FactoryGirl.define do
     error_message "runtime error"
     page_class "MiBridges::Driver::BasePage"
     page_html "<html></html>"
+    driven_at DateTime.current
 
     driver_application
   end


### PR DESCRIPTION
When we create and drive an application we are saving the information about
the drive to a `driver_applications` record. When these drives occur we
should be recording the date and time WHEN the drive is occurring. In
addition, the associated errors should have the same time set to them so
that errors can be grouped by the time they were all run by its parent
`DriverApplication` object.