### PR TITLE
Add MiBridges module to fix autoloading

### DIFF
--- a/lib/mi_bridges.rb
+++ b/lib/mi_bridges.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+module MiBridges
+end

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -160,6 +160,8 @@ module MiBridges
     end
 
     def save_error(e, page)
+      return if latest_drive_attempt.nil?
+
       latest_drive_attempt.
         driver_errors.
         create(


### PR DESCRIPTION
Rails' auto-loading might be having a hard time pulling in all of the
driving code because the MiBridges module, which we namespace all our
driving code inside of, is not defined in its own file.

Also:

* In `save_error`, if latest_drive_attempt is null we should not try to
  tap into it.