### PR TITLE
Add chrome and chromedriver buildpacks to app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -48,10 +48,10 @@
       "generator": "secret"
     },
     "SECRET_KEY_FOR_DRIVER_APPLICATION": {
-      "generator": "secret"
+      "required": true
     },
     "SECRET_KEY_FOR_SSN_ENCRYPTION": {
-      "generator": "secret"
+      "required": true
     },
     "SHUBOX_JS_ID": {
       "required": true

--- a/app.json
+++ b/app.json
@@ -75,6 +75,12 @@
     },
     {
       "url": "https://github.com/ello/heroku-buildpack-imagemagick"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-chromedriver"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-google-chrome"
     }
   ]
 }

--- a/app.json
+++ b/app.json
@@ -71,7 +71,7 @@
   ],
   "buildpacks": [
     {
-      "url": "https://github.com/fxtentacle/heroku-pdftk-buildpack.git"
+      "url": "https://github.com/jayroh/heroku-pdftk-buildpack"
     },
     {
       "url": "heroku/ruby"

--- a/app.json
+++ b/app.json
@@ -55,6 +55,9 @@
     },
     "SHUBOX_JS_ID": {
       "required": true
+    },
+    "WEB_DRIVER": {
+      "required": true
     }
   },
   "formation": {

--- a/app/steps/household_add_member.rb
+++ b/app/steps/household_add_member.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./concerns/social_security_number.rb"
-
 class HouseholdAddMember < Step
   include MultiparameterAttributeAssignment
   extend AutoStripAttributes

--- a/app/steps/personal_detail.rb
+++ b/app/steps/personal_detail.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative "./concerns/social_security_number.rb"
-
 class PersonalDetail < Step
   extend AutoStripAttributes
   include SocialSecurityNumber

--- a/lib/capybara/drivers/headless_chrome.rb
+++ b/lib/capybara/drivers/headless_chrome.rb
@@ -12,7 +12,7 @@ Capybara.register_driver :headless_chrome do |app|
   capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
     profile: profile,
     chromeOptions: {
-      args: %w[headless disable-gpu],
+      args: %w[headless disable-gpu no-sandbox],
       binary: FindChrome.binary,
     },
   )

--- a/lib/find_chrome.rb
+++ b/lib/find_chrome.rb
@@ -14,6 +14,7 @@ class FindChrome
   CHROMEDRIVER_PATHS = [
     "/usr/local/bin/chromedriver",
     "/usr/lib/chromium-browser/chromedriver",
+    "/app/.chromedriver/bin/chromedriver",
     ENV["CHROMEDRIVER_PATH"],
     find_executable("chromedriver"),
   ].compact.freeze

--- a/lib/find_chrome.rb
+++ b/lib/find_chrome.rb
@@ -6,6 +6,7 @@ class FindChrome
   CHROME_PATHS = [
     "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
     "/opt/google/chrome/chrome",
+    ENV["GOOGLE_CHROME_BIN"],
     ENV["CHROME_PATH"],
     find_executable("chrome"),
   ].compact.freeze


### PR DESCRIPTION
There are a number of dependencies needed to get things driving properly. This PR gets everything set up so that things work.

1. Add chrome and chromedriver buildpacks
2. Use the ENV provided by the Chrome buildpack for the chrome binary
3. Fix issue where we require a concern twice. It breaks due to the callback run upon requiring the file
4. Set `WED_DRIVER` ENV so that the driver doesn't try to run it with the full chrome browser experience
5. Use a fork of the PDFTK buildpack due to a bug that causes conflicts with the other buildpacks
6. Add `no-sandbox` to the list of options provided to the headless chrome driver configuration. Otherwise it crashes
7. Update app.json to inherit attr_encrypted secrets instead of generating them