### PR TITLE
Small refactor of IntroLocationController

### DIFF
--- a/app/controllers/medicaid/intro_location_controller.rb
+++ b/app/controllers/medicaid/intro_location_controller.rb
@@ -7,13 +7,5 @@ module Medicaid
     def ensure_application_present
       true
     end
-
-    def existing_attributes
-      {}
-    end
-
-    def step_class
-      Medicaid::IntroLocation
-    end
   end
 end

--- a/app/controllers/standard_steps_controller.rb
+++ b/app/controllers/standard_steps_controller.rb
@@ -28,6 +28,6 @@ class StandardStepsController < StepsController
   def before_rendering_edit_hook; end
 
   def existing_attributes
-    HashWithIndifferentAccess.new(current_snap_application.attributes)
+    HashWithIndifferentAccess.new(current_snap_application&.attributes)
   end
 end


### PR DESCRIPTION
Let `existing_attributes` and `step_class` defer to their super classes.
Existing attributes can have the nil object problem fixed with the
lonely `&` operator. This well return nil and get wrapped by the
HashWithIndifferentAccess ... returning an empty hash

```ruby
HashWithIndifferentAccess.new(nil) => {}
```

`step_class` successfully infers the correct, namespaced, class from the
controller path as it is -- not sure why it didn't work for us in
development mode earlier.