### PR TITLE
Add good and strong migrations gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "capybara"
 gem "delayed_job_active_record"
 gem "delayed_job_web"
 gem "faraday"
+gem "good_migrations"
 gem "high_voltage"
 gem "jquery-rails"
 gem "mimemagic"
@@ -32,6 +33,7 @@ gem "selenium-webdriver", "3.4.3"
 gem "sfax",
   git: "https://github.com/codeforamerica/sfax",
   ref: "da88847faaf5ab51255e4d7e47d76493d05113b1"
+gem "strong_migrations"
 gem "token_phrase"
 gem "twilio-ruby"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,9 @@ GEM
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
+    good_migrations (0.0.2)
+      activerecord (>= 3.1)
+      railties (>= 3.1)
     haml (5.0.3)
       temple (>= 0.8.0)
       tilt
@@ -354,6 +357,8 @@ GEM
     sqlite3 (1.3.13)
     sqlite3-ruby (1.3.3)
       sqlite3 (>= 1.3.3)
+    strong_migrations (0.1.9)
+      activerecord (>= 3.2.0)
     temple (0.8.0)
     thin (1.6.2)
       daemons (>= 1.0.9)
@@ -407,6 +412,7 @@ DEPENDENCIES
   dotenv-rails
   factory_girl_rails
   faraday
+  good_migrations
   high_voltage
   jquery-rails
   launchy
@@ -436,6 +442,7 @@ DEPENDENCIES
   sfax!
   shoulda-matchers (~> 3.1)
   simplecov
+  strong_migrations
   timecop
   token_phrase
   twilio-ruby

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,5 @@ end
 task default: %w(spec rubocop bundler:audit)
 
 Rails.application.load_tasks
+
+task "db:schema:dump": "strong_migrations:alphabetize_columns"

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,5 @@
+StrongMigrations.start_after = 20171005165616
+StrongMigrations.auto_analyze = true
+
+ActiveRecord::Base.dump_schema_after_migration =
+  Rails.env.development? && `git status db/migrate/ --porcelain`.present?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,143 +16,123 @@ ActiveRecord::Schema.define(version: 20171005165616) do
   enable_extension "plpgsql"
 
   create_table "addresses", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "street_address", null: false
     t.string "city", null: false
     t.string "county", null: false
-    t.string "state", null: false
-    t.string "zip", null: false
+    t.datetime "created_at", null: false
     t.boolean "mailing", default: true, null: false
     t.bigint "snap_application_id"
+    t.string "state", null: false
+    t.string "street_address", null: false
+    t.datetime "updated_at", null: false
+    t.string "zip", null: false
     t.index ["snap_application_id"], name: "index_addresses_on_snap_application_id"
   end
 
   create_table "delayed_jobs", force: :cascade do |t|
-    t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
+    t.datetime "created_at"
+    t.datetime "failed_at"
     t.text "handler", null: false
     t.text "last_error"
-    t.datetime "run_at"
     t.datetime "locked_at"
-    t.datetime "failed_at"
     t.string "locked_by"
+    t.integer "priority", default: 0, null: false
     t.string "queue"
-    t.datetime "created_at"
+    t.datetime "run_at"
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "driver_applications", force: :cascade do |t|
-    t.bigint "snap_application_id", null: false
-    t.string "encrypted_user_id", null: false
-    t.string "encrypted_user_id_iv", null: false
+    t.datetime "created_at", null: false
+    t.datetime "driven_at", null: false
     t.string "encrypted_password", null: false
     t.string "encrypted_password_iv", null: false
     t.string "encrypted_secret_question_1_answer", null: false
     t.string "encrypted_secret_question_1_answer_iv", null: false
     t.string "encrypted_secret_question_2_answer", null: false
     t.string "encrypted_secret_question_2_answer_iv", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string "encrypted_user_id", null: false
+    t.string "encrypted_user_id_iv", null: false
+    t.bigint "snap_application_id", null: false
     t.string "tracking_number"
-    t.datetime "driven_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["snap_application_id"], name: "index_driver_applications_on_snap_application_id"
   end
 
   create_table "driver_errors", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "driven_at", null: false
     t.bigint "driver_application_id", null: false
     t.string "error_class", null: false
     t.string "error_message", null: false
     t.string "page_class", null: false
     t.text "page_html", null: false
-    t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "driven_at", null: false
     t.index ["driver_application_id"], name: "index_driver_errors_on_driver_application_id"
   end
 
   create_table "exports", force: :cascade do |t|
-    t.bigint "snap_application_id"
-    t.string "destination"
-    t.string "metadata"
-    t.boolean "force", default: false
-    t.string "status", default: "new"
     t.datetime "completed_at"
     t.datetime "created_at", null: false
+    t.string "destination"
+    t.boolean "force", default: false
+    t.string "metadata"
+    t.bigint "snap_application_id"
+    t.string "status", default: "new"
     t.datetime "updated_at", null: false
     t.index ["snap_application_id"], name: "index_exports_on_snap_application_id"
   end
 
   create_table "members", force: :cascade do |t|
+    t.datetime "birthday"
+    t.boolean "buy_food_with", default: true
+    t.boolean "citizen"
     t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "marital_status"
-    t.string "sex"
-    t.bigint "snap_application_id"
+    t.boolean "disabled"
+    t.string "employed_employer_name"
+    t.integer "employed_hours_per_week"
+    t.string "employed_pay_interval"
+    t.integer "employed_pay_quantity"
+    t.string "employment_status"
     t.string "encrypted_ssn"
     t.string "encrypted_ssn_iv"
     t.string "first_name"
+    t.boolean "in_college"
     t.string "last_name"
-    t.datetime "birthday"
-    t.boolean "buy_food_with", default: true
+    t.boolean "living_elsewhere"
+    t.string "marital_status"
+    t.boolean "new_mom"
     t.string "relationship"
     t.boolean "requesting_food_assistance", default: true
-    t.string "employment_status"
-    t.string "employed_employer_name"
-    t.integer "employed_hours_per_week"
-    t.integer "employed_pay_quantity"
-    t.string "employed_pay_interval"
-    t.string "self_employed_profession"
-    t.integer "self_employed_monthly_income"
     t.string "self_employed_monthly_expenses"
-    t.boolean "citizen"
-    t.boolean "disabled"
-    t.boolean "new_mom"
-    t.boolean "in_college"
-    t.boolean "living_elsewhere"
+    t.integer "self_employed_monthly_income"
+    t.string "self_employed_profession"
+    t.string "sex"
+    t.bigint "snap_application_id"
+    t.datetime "updated_at", null: false
     t.index ["snap_application_id"], name: "index_members_on_snap_application_id"
   end
 
   create_table "snap_applications", force: :cascade do |t|
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "signature"
-    t.datetime "signed_at"
-    t.string "email"
-    t.string "documents", default: [], array: true
-    t.string "phone_number"
-    t.boolean "sms_consented"
-    t.boolean "consent_to_terms"
-    t.boolean "mailing_address_same_as_residential_address", default: true
-    t.boolean "unstable_housing", default: false
-    t.boolean "everyone_a_citizen"
+    t.text "additional_income", default: [], array: true
+    t.text "additional_information"
     t.boolean "anyone_disabled"
-    t.boolean "anyone_new_mom"
     t.boolean "anyone_in_college"
     t.boolean "anyone_living_elsewhere"
+    t.boolean "anyone_new_mom"
+    t.string "care_expenses", default: [], array: true
+    t.boolean "consent_to_terms"
+    t.boolean "court_ordered"
+    t.string "court_ordered_expenses", default: [], array: true
+    t.datetime "created_at", null: false
+    t.boolean "dependent_care"
+    t.string "documents", default: [], array: true
+    t.string "email"
+    t.boolean "everyone_a_citizen"
+    t.string "financial_accounts", default: [], array: true
     t.boolean "income_change"
     t.text "income_change_explanation"
-    t.integer "rent_expense"
-    t.integer "property_tax_expense"
-    t.integer "insurance_expense"
-    t.boolean "utility_heat"
-    t.boolean "utility_cooling"
-    t.boolean "utility_electrity"
-    t.boolean "utility_water_sewer"
-    t.boolean "utility_trash"
-    t.boolean "utility_phone"
-    t.boolean "utility_other"
-    t.boolean "dependent_care"
-    t.boolean "medical"
-    t.boolean "court_ordered"
-    t.integer "monthly_care_expenses"
-    t.integer "monthly_medical_expenses"
-    t.integer "monthly_court_ordered_expenses"
-    t.string "care_expenses", default: [], array: true
-    t.string "medical_expenses", default: [], array: true
-    t.string "court_ordered_expenses", default: [], array: true
-    t.text "additional_income", default: [], array: true
     t.integer "income_child_support"
     t.integer "income_other"
     t.integer "income_pension"
@@ -160,13 +140,33 @@ ActiveRecord::Schema.define(version: 20171005165616) do
     t.integer "income_ssi_or_disability"
     t.integer "income_unemployment_insurance"
     t.integer "income_workers_compensation"
+    t.integer "insurance_expense"
+    t.boolean "mailing_address_same_as_residential_address", default: true
+    t.boolean "medical"
+    t.string "medical_expenses", default: [], array: true
     t.boolean "money_or_accounts_income"
-    t.boolean "real_estate_income"
-    t.boolean "vehicle_income"
-    t.string "financial_accounts", default: [], array: true
-    t.integer "total_money"
-    t.text "additional_information"
+    t.integer "monthly_care_expenses"
+    t.integer "monthly_court_ordered_expenses"
+    t.integer "monthly_medical_expenses"
     t.string "office_location"
+    t.string "phone_number"
+    t.integer "property_tax_expense"
+    t.boolean "real_estate_income"
+    t.integer "rent_expense"
+    t.string "signature"
+    t.datetime "signed_at"
+    t.boolean "sms_consented"
+    t.integer "total_money"
+    t.boolean "unstable_housing", default: false
+    t.datetime "updated_at", null: false
+    t.boolean "utility_cooling"
+    t.boolean "utility_electrity"
+    t.boolean "utility_heat"
+    t.boolean "utility_other"
+    t.boolean "utility_phone"
+    t.boolean "utility_trash"
+    t.boolean "utility_water_sewer"
+    t.boolean "vehicle_income"
   end
 
   add_foreign_key "driver_applications", "snap_applications"


### PR DESCRIPTION
There are two reasons why I'm suggesting we add these gems.

1. We're running into odd issues with the schema file being generated
and causing diff issues when something like overcommit is run. This has
prevented several people from rebasing a branch and can be mitigated if
the schema has a more predictable diff, and is generated only when it's
necessary. `strong_migrations` helps us with that. See:

  * https://github.com/ankane/strong_migrations#schema-sanity
  * https://github.com/ankane/strong_migrations#faster-migrations

2. We're continuing to generate and run many new migrations - therefore
the constraints inherant with these gems will help us move more
carefully, and in some places with more speed. Constraints are good.

In this commit I've added initialization configuration as suggested by
the README in the strong_migrations project, and have generated a brand
new schema dump.

See here for more information:

https://github.com/ankane/strong_migrations