### PR TITLE
Add medicaid_application model & integrate with the form object

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,31 +10,32 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require jquery
-//= require jquery_ujs
-//= require handlebars
-//= require_tree .
-var textWell = (function() {
+// = require jquery
+// = require jquery_ujs
+// = require handlebars
+// = require_tree .
+
+var textWell = (function () {
   return {
-    init: function() {
-      $(document).on('click', '.textwell .textwell__expander', function() {
+    init: function () {
+      $(document).on('click', '.textwell .textwell__expander', function () {
         $(this).parent('.textwell').addClass('textwell--expanded')
       })
     }
   }
-})();
+})()
 
-var radioSelector = (function() {
+var radioSelector = (function () {
   var rs = {
-    init: function() {
-      $('.radio-button').each(function(index, button){
-        if($(this).find('input').is(':checked')) {
-          $(this).addClass('is-selected');
+    init: function () {
+      $('.radio-button').each(function (index, button) {
+        if ($(this).find('input').is(':checked')) {
+          $(this).addClass('is-selected')
         }
 
-        $(this).find('input').click(function(e) {
-          $(this).parent().siblings().removeClass('is-selected');
-          $(this).parent().addClass('is-selected');
+        $(this).find('input').click(function (e) {
+          $(this).parent().siblings().removeClass('is-selected')
+          $(this).parent().addClass('is-selected')
         })
       })
     }
@@ -42,22 +43,21 @@ var radioSelector = (function() {
   return {
     init: rs.init
   }
-})();
+})()
 
-var checkboxSelector = (function() {
+var checkboxSelector = (function () {
   var cs = {
-    init: function() {
-      $('.checkbox').each(function(index, button){
-        if($(this).find('input').is(':checked')) {
-          $(this).addClass('is-selected');
+    init: function () {
+      $('.checkbox').each(function (index, button) {
+        if ($(this).find('input').is(':checked')) {
+          $(this).addClass('is-selected')
         }
 
-        $(this).find('input').click(function(e) {
-          if($(this).is(':checked')) {
-            $(this).parent().addClass('is-selected');
-          }
-          else {
-            $(this).parent().removeClass('is-selected');
+        $(this).find('input').click(function (e) {
+          if ($(this).is(':checked')) {
+            $(this).parent().addClass('is-selected')
+          }else {
+            $(this).parent().removeClass('is-selected')
           }
         })
       })
@@ -66,10 +66,28 @@ var checkboxSelector = (function() {
   return {
     init: cs.init
   }
-})();
+})()
 
-$(document).ready(function() {
-  radioSelector.init();
-  checkboxSelector.init();
-  textWell.init();
-});
+var yesNoButtons = (function () {
+  var yn = {
+    init: function () {
+      $('[data-no]').on('click', function () {
+        $('input.boolean-answer').val('0')
+      })
+
+      $('[data-yes]').on('click', function () {
+        $('input.boolean-answer').val('1')
+      })
+    }
+  }
+  return {
+    init: yn.init
+  }
+})()
+
+$(document).ready(function () {
+  radioSelector.init()
+  checkboxSelector.init()
+  textWell.init()
+  yesNoButtons.init()
+})

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -35,7 +35,7 @@ class StepsController < ApplicationController
   end
 
   def current_path(params = nil)
-    step_path(self.class, params)
+    step_path(self.class, params).gsub("%2F", "/")
   end
 
   def maybe_skip

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -1,4 +1,20 @@
 class MbFormBuilder < ActionView::Helpers::FormBuilder
+  def mb_boolean_buttons(method)
+    <<-HTML.html_safe
+        #{hidden_field(method, class: 'boolean-answer')}
+
+        <button
+          type="submit"
+          class="button button--nav button--full-width"
+          data-no> No </button>
+
+        <button
+          type="submit"
+          class="button button--nav button--cta button--full-width"
+          data-yes> Yes </button>
+    HTML
+  end
+
   def mb_input_field(
     method,
     label_text,

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class MedicaidApplication < ApplicationRecord
+end

--- a/app/steps/medicaid/intro_location.rb
+++ b/app/steps/medicaid/intro_location.rb
@@ -2,5 +2,8 @@
 
 module Medicaid
   class IntroLocation < Step
+    step_attributes(
+      :michigan_resident,
+    )
   end
 end

--- a/app/views/medicaid/intro_location/edit.html.erb
+++ b/app/views/medicaid/intro_location/edit.html.erb
@@ -9,24 +9,28 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Before we get started, do you currently reside in Michigan?</div>
+    <div class="form-card__title">
+      Before we get started, do you currently reside in Michigan?
+    </div>
+
     <p class="text--help text--centered">
-      If not, we'll help point you in the right direction. However, this application for health coverage is specifically for current residents of Michigan.
+      If not, we'll help point you in the right direction. However, this
+      application for health coverage is specifically for current residents of
+      Michigan.
     </p>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/intro_location_help" class="button button--nav button--full-width">
-        No
-      </a>
+  <%= form_for @step,
+    as: :step,
+    builder: MbFormBuilder,
+    url: current_path,
+    method: :put do |f| %>
 
-      <a href="/pages/medicaid/intro_name" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+    <div class="form-card__content">
+      <footer class="form-card__buttons">
+        <%= f.mb_boolean_buttons :michigan_resident %>
+      </footer>
+    </div>
+
+  <% end %>
 </div>
-
-<!-- https://trello.com/c/gUz9VB91/28-before-we-start-do-you-currently-reside-in-michigan -->

--- a/db/migrate/20171011140150_create_medicaid_applications.rb
+++ b/db/migrate/20171011140150_create_medicaid_applications.rb
@@ -1,0 +1,9 @@
+class CreateMedicaidApplications < ActiveRecord::Migration[5.1]
+  def change
+    create_table :medicaid_applications do |t|
+      t.boolean :michigan_resident, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171005165616) do
+ActiveRecord::Schema.define(version: 20171011140150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,12 @@ ActiveRecord::Schema.define(version: 20171005165616) do
     t.string "status", default: "new"
     t.datetime "updated_at", null: false
     t.index ["snap_application_id"], name: "index_exports_on_snap_application_id"
+  end
+
+  create_table "medicaid_applications", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "michigan_resident", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "members", force: :cascade do |t|

--- a/spec/factories/medicaid_applications.rb
+++ b/spec/factories/medicaid_applications.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :medicaid_application do
+    michigan_resident true
+  end
+end


### PR DESCRIPTION
   Medicaid information must be stored, of course, so this commit
    introduces that first migration and model to get things started.

   In addition, an update to the form builder here allows us to abstract
   the common pattern of the "yes" and "no" buttons on the Medicaid side of
   the application. Clicking one or the other will pass the boolean value
   to the update action, as well as allowing us to determine which page is
   the next page for either option.