### PR TITLE
Add yes/no form partials & assoc fields to steps

### DIFF
--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -1,20 +1,4 @@
 class MbFormBuilder < ActionView::Helpers::FormBuilder
-  def mb_boolean_buttons(method)
-    <<-HTML.html_safe
-        #{hidden_field(method, class: 'boolean-answer')}
-
-        <button
-          type="submit"
-          class="button button--nav button--full-width"
-          data-no> No </button>
-
-        <button
-          type="submit"
-          class="button button--nav button--cta button--full-width"
-          data-yes> Yes </button>
-    HTML
-  end
-
   def mb_input_field(
     method,
     label_text,

--- a/app/steps/medicaid/contact.rb
+++ b/app/steps/medicaid/contact.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class Contact < Step
+    step_attributes(:mail_sent_to_residential)
   end
 end

--- a/app/steps/medicaid/contact_homeless.rb
+++ b/app/steps/medicaid/contact_homeless.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class ContactHomeless < Step
+    step_attributes(:homeless)
   end
 end

--- a/app/steps/medicaid/contact_other_address.rb
+++ b/app/steps/medicaid/contact_other_address.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class ContactOtherAddress < Step
+    step_attributes(:reliable_mail_address)
   end
 end

--- a/app/steps/medicaid/contact_ss_dob.rb
+++ b/app/steps/medicaid/contact_ss_dob.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class ContactSsDob < Step
+    step_attributes(:submit_ssn)
   end
 end

--- a/app/steps/medicaid/expenses_alimony.rb
+++ b/app/steps/medicaid/expenses_alimony.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class ExpensesAlimony < Step
+    step_attributes(:pay_child_support_alimony_arrears)
   end
 end

--- a/app/steps/medicaid/expenses_student_loan.rb
+++ b/app/steps/medicaid/expenses_student_loan.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class ExpensesStudentLoan < Step
+    step_attributes(:pay_student_loan_interest)
   end
 end

--- a/app/steps/medicaid/health_disability.rb
+++ b/app/steps/medicaid/health_disability.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class HealthDisability < Step
+    step_attributes(:disabled)
   end
 end

--- a/app/steps/medicaid/health_pregnancy.rb
+++ b/app/steps/medicaid/health_pregnancy.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class HealthPregnancy < Step
+    step_attributes(:new_mom)
   end
 end

--- a/app/steps/medicaid/income_job.rb
+++ b/app/steps/medicaid/income_job.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class IncomeJob < Step
+    step_attributes(:employed)
   end
 end

--- a/app/steps/medicaid/income_other_income.rb
+++ b/app/steps/medicaid/income_other_income.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class IncomeOtherIncome < Step
+    step_attributes(:income_not_from_job)
   end
 end

--- a/app/steps/medicaid/insurance_current.rb
+++ b/app/steps/medicaid/insurance_current.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class InsuranceCurrent < Step
+    step_attributes(:self_employed)
   end
 end

--- a/app/steps/medicaid/insurance_current_type.rb
+++ b/app/steps/medicaid/insurance_current_type.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class InsuranceCurrentType < Step
+    step_attributes(:insured)
   end
 end

--- a/app/steps/medicaid/insurance_medical_expenses.rb
+++ b/app/steps/medicaid/insurance_medical_expenses.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class InsuranceMedicalExpenses < Step
+    step_attributes(:need_medical_expense_help_3_months)
   end
 end

--- a/app/steps/medicaid/intro_caretaker.rb
+++ b/app/steps/medicaid/intro_caretaker.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class IntroCaretaker < Step
+    step_attributes(:caretaker_or_parent)
   end
 end

--- a/app/steps/medicaid/intro_citizen.rb
+++ b/app/steps/medicaid/intro_citizen.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class IntroCitizen < Step
+    step_attributes(:everyone_a_citizen)
   end
 end

--- a/app/steps/medicaid/intro_college.rb
+++ b/app/steps/medicaid/intro_college.rb
@@ -2,5 +2,6 @@
 
 module Medicaid
   class IntroCollege < Step
+    step_attributes(:college_student)
   end
 end

--- a/app/steps/medicaid/intro_location.rb
+++ b/app/steps/medicaid/intro_location.rb
@@ -2,8 +2,6 @@
 
 module Medicaid
   class IntroLocation < Step
-    step_attributes(
-      :michigan_resident,
-    )
+    step_attributes(:michigan_resident)
   end
 end

--- a/app/views/medicaid/contact/edit.html.erb
+++ b/app/views/medicaid/contact/edit.html.erb
@@ -9,22 +9,14 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Do you receive mail at your residential address?</div>
+    <div class="form-card__title">
+      Do you receive mail at your residential address?
+    </div>
   </header>
 
-  <div class="form-card__content">
-
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/contact_other_address" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/contact_home_address" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form',
+    step: @step,
+   field: :mail_sent_to_residential %>
 </div>
 
 <!-- https://trello.com/c/QwrCdRgF/29-do-you-receive-mail-at-your-residential-address -->

--- a/app/views/medicaid/contact_homeless/edit.html.erb
+++ b/app/views/medicaid/contact_homeless/edit.html.erb
@@ -12,19 +12,7 @@
     <div class="form-card__title">Are you currently homeless?</div>
   </header>
 
-  <div class="form-card__content">
-
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/contact_current_address" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/contact_phone" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form', step: @step, field: :homeless %>
 </div>
 
 <!-- https://trello.com/c/QwrCdRgF/29-do-you-receive-mail-at-your-residential-address -->

--- a/app/views/medicaid/contact_other_address/edit.html.erb
+++ b/app/views/medicaid/contact_other_address/edit.html.erb
@@ -9,22 +9,12 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Is there somewhere we can reliably send you mail?</div>
+    <div class="form-card__title">
+      Is there somewhere we can reliably send you mail?
+    </div>
   </header>
 
-  <div class="form-card__content">
-
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/contact_homeless" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/contact_current_address" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form', step: @step, field: :reliable_mail_address %>
 </div>
 
 <!-- https://trello.com/c/QwrCdRgF/29-do-you-receive-mail-at-your-residential-address -->

--- a/app/views/medicaid/contact_ss_dob/edit.html.erb
+++ b/app/views/medicaid/contact_ss_dob/edit.html.erb
@@ -9,27 +9,25 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Provide your Social Security Number and Date of Birth if you're ready</div>
+    <div class="form-card__title">
+      Provide your Social Security Number and Date of Birth if you're ready
+    </div>
+
     <p class="text--help text--centered">
-      This information isn't required at this time. But if you submit it now, the application process will go faster. Would you like to submit it now?
+      This information isn't required at this time. But if you submit it now,
+      the application process will go faster. Would you like to submit it now?
     </p>
   </header>
 
   <div class="form-card__content">
-    <p class='text--secure'><i class='illustration illustration--safety'></i>Social security numbers help ensure you receive the correct benefits. MDHHS maintains strict security guidelines to protect the identities of our residents.</p>
+    <p class='text--secure'>
+      <i class='illustration illustration--safety'></i>Social security numbers
+      help ensure you receive the correct benefits. MDHHS maintains strict
+      security guidelines to protect the identities of our residents.
+    </p>
   </div>
 
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/confirmation" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/contact_social_security" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form', step: @step, field: :submit_ssn %>
 </div>
 
 <!-- https://trello.com/c/tlOPbhom/38-provide-your-social-security-number-and-date-of-birth-if-youre-ready -->

--- a/app/views/medicaid/expenses_alimony/edit.html.erb
+++ b/app/views/medicaid/expenses_alimony/edit.html.erb
@@ -9,21 +9,14 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Do you pay child support, alimony or arrears?</div>
+    <div class="form-card__title">
+      Do you pay child support, alimony or arrears?
+    </div>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/amounts_overview" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/amounts_overview" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form',
+    step: @step,
+    field: :pay_child_support_alimony_arrears %>
 </div>
 
 <!-- Single-member copy: https://trello.com/c/VoxppHxk/47-do-you-pay-child-support-alimony-or-arrears -->

--- a/app/views/medicaid/expenses_student_loan/edit.html.erb
+++ b/app/views/medicaid/expenses_student_loan/edit.html.erb
@@ -12,18 +12,9 @@
     <div class="form-card__title">Do you pay student loan interest?</div>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/expenses_alimony" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/expenses_alimony" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form',
+    step: @step,
+    field: :pay_student_loan_interest %>
 </div>
 
 <!-- Single-member copy: https://trello.com/c/SK9TLk1I/46-do-you-pay-student-loan-interest -->

--- a/app/views/medicaid/health_disability/edit.html.erb
+++ b/app/views/medicaid/health_disability/edit.html.erb
@@ -9,24 +9,19 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Do you have a disabilty?</div>
+    <div class="form-card__title">
+      Do you have a disabilty?
+    </div>
+
     <p class="text--help text--centered">
-      This can include living in a nursing home or other medical facility or a physical, mental, or emotional health condition that limits activity.
+      This can include living in a nursing home or other medical facility or a
+      physical, mental, or emotional health condition that limits activity.
     </p>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/health_pregnancy" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/health_pregnancy" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form',
+    step: @step,
+    field: :disabled %>
 </div>
 
 <!-- Single-member content: https://trello.com/c/Xv2RISCN/43-do-you-have-a-disability -->

--- a/app/views/medicaid/health_pregnancy/edit.html.erb
+++ b/app/views/medicaid/health_pregnancy/edit.html.erb
@@ -15,18 +15,9 @@
     </p>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/tax_filing" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/tax_filing" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form',
+    step: @step,
+    field: :new_mom %>
 </div>
 
 <!-- Single-member content: https://trello.com/c/SnW4pvXU/44-have-you-been-pregnant-recently -->

--- a/app/views/medicaid/income_job/edit.html.erb
+++ b/app/views/medicaid/income_job/edit.html.erb
@@ -15,18 +15,7 @@
     </p>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/income_self_employment" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/income_job_number" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form', step: @step, field: :employed %>
 </div>
 
 <!-- Single-member copy: https://trello.com/c/XUtAnqtN/48-do-you-currently-have-a-job -->

--- a/app/views/medicaid/income_other_income/edit.html.erb
+++ b/app/views/medicaid/income_other_income/edit.html.erb
@@ -15,18 +15,7 @@
     </p>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/expenses_student_loan" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/income_other_income_type" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form', step: @step, field: :income_not_from_job %>
 </div>
 
 <!-- https://trello.com/c/tXO2ckrd/50-do-you-get-income-thats-not-from-a-job -->

--- a/app/views/medicaid/income_self_employment/edit.html.erb
+++ b/app/views/medicaid/income_self_employment/edit.html.erb
@@ -15,18 +15,7 @@
     </p>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/income_other_income" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/income_other_income" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form', step: @step, field: :self_employed %>
 </div>
 
 <!-- https://trello.com/c/5htwB4p3/49-are-you-self-employed -->

--- a/app/views/medicaid/insurance_current/edit.html.erb
+++ b/app/views/medicaid/insurance_current/edit.html.erb
@@ -9,24 +9,17 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Are you currently enrolled in a health insurance plan?</div>
+    <div class="form-card__title">
+      Are you currently enrolled in a health insurance plan?
+    </div>
+
     <p class="text--help text--centered">
-      You may be eligible for dual enrollment, which can help cover additional medical expenses.
+      You may be eligible for dual enrollment, which can help cover additional
+      medical expenses.
     </p>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/insurance_medical_expenses" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/insurance_current_type" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form', step: @step, field: :insured %>
 </div>
 
 <!-- https://trello.com/c/wkRhS6tp/10-are-you-currently-enrolled-in-a-health-insurance-plan -->

--- a/app/views/medicaid/insurance_medical_expenses/edit.html.erb
+++ b/app/views/medicaid/insurance_medical_expenses/edit.html.erb
@@ -11,21 +11,14 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Do you need help paying for medical expenses from the last 3 months?</div>
+    <div class="form-card__title">
+      Do you need help paying for medical expenses from the last 3 months?
+    </div>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/health_disability" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/health_disability" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form',
+    step: @step,
+    field: :need_medical_expense_help_3_months %>
 </div>
 
 <!-- https://trello.com/c/Zt3tRe3w/42-do-you-need-help-paying-for-medical-expenses-from-the-last-3-months -->

--- a/app/views/medicaid/intro_caretaker/edit.html.erb
+++ b/app/views/medicaid/intro_caretaker/edit.html.erb
@@ -9,19 +9,12 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Is anyone a caretaker or parent of other people in the household?</div>
+    <div class="form-card__title">
+      Is anyone a caretaker or parent of other people in the household?
+    </div>
   </header>
 
-  <!-- Replace with partial -->
-  <footer class="form-card__buttons">
-    <a href="#" class="button button--nav button--full-width">
-      No
-    </a>
-
-    <a href="/pages/medicaid/intro_caretaker_member" class="button button--nav button--cta button--full-width">
-      Yes
-    </a>
-  </footer>
+  <%= render 'shared/yes_no_form', step: @step, field: :caretaker_or_parent %>
 </div>
 
 <!-- Single-member content: https://trello.com/c/bNj8pyx5/54-what-type-of-health-insurance-plan-are-you-currently-enrolled-in -->

--- a/app/views/medicaid/intro_citizen/edit.html.erb
+++ b/app/views/medicaid/intro_citizen/edit.html.erb
@@ -12,22 +12,12 @@
     <div class="form-card__title">Are you currently a US Citizen?</div>
     <p class="text--help text--centered">
       You don't always have to be a citizen to receive benefits. If you are not
-      a citizen, you'll be asked to provide paperwork about your immigration status.
+      a citizen, you'll be asked to provide paperwork about your immigration
+      status.
     </p>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/insurance_current" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/insurance_current" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form', step: @step, field: :everyone_a_citizen %>
 </div>
 
 <!-- https://trello.com/c/NTimWZGd/82-are-you-currently-a-us-citizen -->

--- a/app/views/medicaid/intro_college/edit.html.erb
+++ b/app/views/medicaid/intro_college/edit.html.erb
@@ -12,18 +12,7 @@
     <div class="form-card__title">Are you currently a college student?</div>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/intro_citizen" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/intro_citizen" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form', step: @step, field: :college_student %>
 </div>
 
 <!-- Single-member content: https://trello.com/c/NYa5qEAJ/45-are-you-currently-a-college-student -->

--- a/app/views/medicaid/intro_location/edit.html.erb
+++ b/app/views/medicaid/intro_location/edit.html.erb
@@ -20,17 +20,5 @@
     </p>
   </header>
 
-  <%= form_for @step,
-    as: :step,
-    builder: MbFormBuilder,
-    url: current_path,
-    method: :put do |f| %>
-
-    <div class="form-card__content">
-      <footer class="form-card__buttons">
-        <%= f.mb_boolean_buttons :michigan_resident %>
-      </footer>
-    </div>
-
-  <% end %>
+  <%= render 'shared/yes_no_form', step: @step, field: :michigan_resident %>
 </div>

--- a/app/views/medicaid/tax_filing/edit.html.erb
+++ b/app/views/medicaid/tax_filing/edit.html.erb
@@ -9,24 +9,18 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Do you plan on filing a federal tax return next year?</div>
+    <div class="form-card__title">
+      Do you plan on filing a federal tax return next year?
+    </div>
+
     <p class="text--help text--centered">
       Some households don't file based on their income.
     </p>
   </header>
 
-  <div class="form-card__content">
-    <!-- Replace with partial -->
-    <footer class="form-card__buttons">
-      <a href="/pages/medicaid/income_job" class="button button--nav button--full-width">
-        No
-      </a>
-
-      <a href="/pages/medicaid/income_job" class="button button--nav button--cta button--full-width">
-        Yes
-      </a>
-    </footer>
-  </div>
+  <%= render 'shared/yes_no_form',
+    step: @step,
+    field: :filing_federal_taxes_next_year %>
 </div>
 
 <!-- Single-member content: https://trello.com/c/RgMQyNhk/72-do-you-plan-on-filing-a-federal-tax-return-next-year -->

--- a/app/views/shared/_yes_no_form.html.erb
+++ b/app/views/shared/_yes_no_form.html.erb
@@ -1,0 +1,23 @@
+<%= form_for step,
+  as: :step,
+  builder: MbFormBuilder,
+  url: current_path,
+  method: :put do |f| %>
+
+  <div class="form-card__content">
+    <footer class="form-card__buttons">
+      <%= f.hidden_field(field, class: 'boolean-answer') %>
+
+      <button
+        type="submit"
+        class="button button--nav button--full-width"
+        data-no> No </button>
+
+      <button
+        type="submit"
+        class="button button--nav button--cta button--full-width"
+        data-yes> Yes </button>
+    </footer>
+  </div>
+
+<% end %>


### PR DESCRIPTION
The views that ask for a yes or no answer can all display those forms
through one shared partial. These views have all been updated to pull in
that (new) partial.

The fields for each of those steps have also all been added to the
related step classes.

Last but not least, after looking at things, it probably makes more
sense to surface any HTML to the views, that CAN be displayed in the
view. The form builder method is just an obfuscation at this point if we
can handle this in the partial.