### PR TITLE
Remove fax rake task

### DIFF
--- a/app/models/export_factory.rb
+++ b/app/models/export_factory.rb
@@ -9,18 +9,6 @@ class ExportFactory
     new.create!(params)
   end
 
-  def self.export_unfaxed_snap_applications
-    SnapApplication.
-      faxable.
-      untouched_since(DELAY_THRESHOLD.minutes.ago).
-      find_each do |snap_application|
-        create(
-          destination: :fax,
-          snap_application: snap_application,
-        )
-      end
-  end
-
   def create(params)
     enqueue(Export.create(params))
   end

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -30,7 +30,6 @@ class SnapApplication < ApplicationRecord
   has_many :exports, dependent: :destroy
   has_many :members, dependent: :destroy
 
-  scope :faxable, -> { signed.unfaxed }
   scope :signed, -> { where.not(signed_at: nil) }
   scope :unsigned, -> { where(signed_at: nil) }
   scope :untouched_since, ->(threshold) { where("updated_at < ?", threshold) }

--- a/lib/tasks/queue_faxes.rake
+++ b/lib/tasks/queue_faxes.rake
@@ -1,4 +1,0 @@
-desc "Queues faxes for signed, unfaxed applicants"
-task queue_faxes: :environment do
-  ExportFactory.export_unfaxed_snap_applications
-end


### PR DESCRIPTION
Reason for Change
=================
* We are now emailing applications to MDHHS instead of faxing them.
* We would also like to keep our valuable fax machinery intact, just in case.

Changes
=======
* Remove the rake task which sends unfaxed applications.
* The Heroku scheduler task had already been shut off - this is just to make sure.

Minor
=======
* Rename the spec to match the method name.