### PR TITLE
No alert after completing Medicaid application

### DIFF
--- a/app/assets/javascripts/form_exit.js.erb
+++ b/app/assets/javascripts/form_exit.js.erb
@@ -10,7 +10,8 @@
         '/privacy',
         '/steps',
         '/terms',
-        'skip_'
+        'skip_',
+        '/dual-index'
       ]
       for(var j=0; j<whiteList.length; j++){
         if(links[i].href.indexOf(whiteList[j]) >= 0){


### PR DESCRIPTION
Add the "dual-index" path to the white-list of paths that will not cause
the "you are exiting the app" message to pop up.