### PR TITLE
Do not display back arrow on final submission page

### DIFF
--- a/app/controllers/medicaid/confirmation_controller.rb
+++ b/app/controllers/medicaid/confirmation_controller.rb
@@ -2,5 +2,8 @@
 
 module Medicaid
   class ConfirmationController < MedicaidStepsController
+    def previous_path(*_args)
+      nil
+    end
   end
 end

--- a/app/views/medicaid/confirmation/edit.html.erb
+++ b/app/views/medicaid/confirmation/edit.html.erb
@@ -1,3 +1,4 @@
+<% content_for :back_path, nil %>
 <% content_for :header_title, "Confirmation" %>
 
 <div class="form-card">


### PR DESCRIPTION
Overriding both the back_path var AND the previous_path method to both
return nil will result in the back arrow not showing up.