### PR TITLE
Add test coverage for controllers re: skip logic

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -34,6 +34,11 @@ class StepsController < ApplicationController
     NullStep
   end
 
+  def next_path(params = {})
+    next_step = step_navigation.next
+    decoded_step_path(step: next_step, params: params) if next_step
+  end
+
   private
 
   delegate :step_class, to: :class
@@ -83,11 +88,6 @@ class StepsController < ApplicationController
 
   def going_backwards?
     params["rel"] == "back"
-  end
-
-  def next_path(params = {})
-    next_step = step_navigation.next
-    decoded_step_path(step: next_step, params: params) if next_step
   end
 
   def skip_path(params = nil)

--- a/spec/controllers/medicaid/amounts_expenses_controller_spec.rb
+++ b/spec/controllers/medicaid/amounts_expenses_controller_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::AmountsExpensesController, type: :controller do
+  describe "#next_path" do
+    it "is the medicaid contact path" do
+      expect(subject.next_path).to eq "/steps/medicaid/contact"
+    end
+  end
+
+  describe "#edit" do
+    context "client with no student loans or child support" do
+      it "redirects to next step" do
+        medicaid_application =
+          create(
+            :medicaid_application,
+            pay_student_loan_interest: false,
+            pay_child_support_alimony_arrears: false,
+          )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "client with a student loan" do
+      it "renders edit" do
+        medicaid_application =
+          create(
+            :medicaid_application,
+            pay_student_loan_interest: true,
+            pay_child_support_alimony_arrears: false,
+          )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context "client with child support costs" do
+      it "renders edit" do
+        medicaid_application =
+          create(
+            :medicaid_application,
+            pay_student_loan_interest: false,
+            pay_child_support_alimony_arrears: true,
+          )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/contact_home_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_home_address_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::ContactHomeAddressController, type: :controller do
+  describe "#next_path" do
+    it "is the contact address (other) page path" do
+      expect(subject.next_path).to eq "/steps/medicaid/contact-other-address"
+    end
+  end
+
+  describe "#edit" do
+    context "client has mail sent to residential address" do
+      it "renders the edit page" do
+        medicaid_application =
+          create(
+            :medicaid_application,
+            mail_sent_to_residential: true,
+          )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+
+      context "client does not have mail sent to residential address" do
+        it "redirects to the next page" do
+          medicaid_application =
+            create(
+              :medicaid_application,
+              mail_sent_to_residential: false,
+            )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to redirect_to(subject.next_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/contact_homeless_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_homeless_controller_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::ContactHomelessController, type: :controller do
+  describe "#next_path" do
+    it "is the 'no mailing address' page path" do
+      expect(subject.next_path).
+        to eq "/steps/medicaid/contact-residential-no-mail-address"
+    end
+  end
+
+  describe "#edit" do
+    context "client has no reliable mailing address" do
+      it "renders the edit template" do
+        medicaid_application = create(
+          :medicaid_application,
+          mail_sent_to_residential: false,
+          reliable_mail_address: false,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context "mail is sent to residential address" do
+      it "redirects to next page" do
+        medicaid_application = create(
+          :medicaid_application,
+          mail_sent_to_residential: true,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "mail is sent to a reliable mailing address" do
+      it "redirects to the next page" do
+        medicaid_application = create(
+          :medicaid_application,
+          reliable_mail_address: true,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/contact_mailing_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_mailing_address_controller_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::ContactMailingAddressController, type: :controller do
+  describe "#next_path" do
+    it "is the homeless client contact page path" do
+      expect(subject.next_path).
+        to eq "/steps/medicaid/contact-homeless"
+    end
+  end
+
+  describe "#edit" do
+    context "client has no reliable mailing address" do
+      it "renders the edit template" do
+        medicaid_application = create(
+          :medicaid_application,
+          reliable_mail_address: false,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "mail is sent to residential address" do
+      it "redirects to next page" do
+        medicaid_application = create(
+          :medicaid_application,
+          mail_sent_to_residential: true,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "mail not sent to residential, has no reliable address" do
+      it "renders the edit page" do
+        medicaid_application = create(
+          :medicaid_application,
+          reliable_mail_address: true,
+          mail_sent_to_residential: false,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/contact_other_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_other_address_controller_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::ContactOtherAddressController, type: :controller do
+  describe "#next_path" do
+    it "is the contact mailing address page path" do
+      expect(subject.next_path).to eq "/steps/medicaid/contact-mailing-address"
+    end
+  end
+
+  describe "#edit" do
+    context "mail is sent to residential address" do
+      it "redirects to next page" do
+        medicaid_application = create(
+          :medicaid_application,
+          mail_sent_to_residential: true,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "mail not sent to residential address" do
+      it "renders the edit page" do
+        medicaid_application = create(
+          :medicaid_application,
+          mail_sent_to_residential: false,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/contact_residential_no_mail_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_residential_no_mail_address_controller_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::ContactResidentialNoMailAddressController do
+  describe "#next_path" do
+    it "is the phone contact info page path" do
+      expect(subject.next_path).to eq "/steps/medicaid/contact-phone"
+    end
+  end
+
+  describe "#edit" do
+    context "no reliable or residential mailing address, and not homeless" do
+      it "redirects to next page" do
+        medicaid_application = create(
+          :medicaid_application,
+          mail_sent_to_residential: false,
+          reliable_mail_address: false,
+          homeless: false,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context "mail is sent to residential address" do
+      it "redirects to next page" do
+        medicaid_application = create(
+          :medicaid_application,
+          mail_sent_to_residential: true,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "mail sent to reliable address" do
+      it "redirects to the next page" do
+        medicaid_application = create(
+          :medicaid_application,
+          reliable_mail_address: true,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "client is homeless" do
+      it "redirects to the next page" do
+        medicaid_application = create(
+          :medicaid_application,
+          homeless: true,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/income_job_number_controller_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IncomeJobNumberController, type: :controller do
+  describe "#next_path" do
+    it "is the self employment page path" do
+      expect(subject.next_path).to eq "/steps/medicaid/income-self-employment"
+    end
+  end
+
+  describe "#edit" do
+    context "client is employed" do
+      it "renders edit " do
+        medicaid_application =
+          create(
+            :medicaid_application,
+            employed: true,
+          )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context "client is unemployed" do
+      it "redirects to the next page" do
+        medicaid_application =
+          create(
+            :medicaid_application,
+            employed: false,
+          )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds some tests to back the recently created medicaid flow
controllers. The logic around skipping to the next page needs some
robust test coverage to ensure the logic does not break in the future.

Also move the `next_path` method to the public method space so we can
call it from the specs to test that they are skipping to the correct
"next" path.