### PR TITLE
Display exports for snap apps in admin/dashboard

### DIFF
--- a/app/controllers/admin/exports_controller.rb
+++ b/app/controllers/admin/exports_controller.rb
@@ -1,0 +1,4 @@
+module Admin
+  class ExportsController < Admin::ApplicationController
+  end
+end

--- a/app/dashboards/export_dashboard.rb
+++ b/app/dashboards/export_dashboard.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "administrate/base_dashboard"
+
+class ExportDashboard < Administrate::BaseDashboard
+  ATTRIBUTE_TYPES = {
+    snap_application: Field::BelongsTo,
+    id: Field::Number,
+    destination: Field::String,
+    metadata: Field::String,
+    force: Field::Boolean,
+    status: Field::String,
+    completed_at: Field::DateTime,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+  }.freeze
+
+  COLLECTION_ATTRIBUTES = %i[
+    completed_at
+    destination
+    metadata
+    snap_application
+  ].freeze
+
+  SHOW_PAGE_ATTRIBUTES = %i[
+    id
+    snap_application
+    destination
+    metadata
+    force
+    status
+    completed_at
+    created_at
+    updated_at
+  ].freeze
+end

--- a/app/dashboards/member_dashboard.rb
+++ b/app/dashboards/member_dashboard.rb
@@ -43,8 +43,8 @@ class MemberDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     first_name
     last_name
-    snap_application
     created_at
+    snap_application
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES

--- a/app/dashboards/snap_application_dashboard.rb
+++ b/app/dashboards/snap_application_dashboard.rb
@@ -60,6 +60,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     zip: Field::String,
     members: Field::HasMany,
     driver_errors: Field::HasMany,
+    exports: Field::HasMany,
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[
@@ -78,6 +79,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
   SHOW_PAGE_ATTRIBUTES = %i[
     id
     members
+    exports
     driver_errors
     created_at
     updated_at

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
       post "resend_email", on: :member
       get "pdf", on: :member
     end
+    resources :exports, only: %i[index show]
     resources :members
     resources :driver_errors, only: %i[index show]
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -222,5 +222,37 @@ complete_third_member.update!(
   self_employed_monthly_expenses: "400",
 )
 
+complete_application.
+  exports.
+  where(destination: :fax).
+  first_or_initialize(
+    metadata: "Faxed to Michigan Benefits (+15551112345)",
+    force: false,
+    status: :succeeded,
+    completed_at: Time.current,
+  ).save
+
+complete_application.
+  exports.
+  where(destination: :client_email).
+  first_or_initialize(
+    metadata: "I, [2017-10-10T14:29:39.397443 #4]  INFO -- : [ActiveJob] "\
+      "[ClientEmailApplicationJob] [1c8d2c86-34f3-48ea-96be-88cf2fee9786] "\
+      "Emailed to #{complete_application.email}\n",
+    force: false,
+    status: :succeeded,
+    completed_at: Time.current,
+  ).save
+
+complete_application.
+  exports.
+  where(destination: :office_email).
+  first_or_initialize(
+    metadata: "",
+    force: false,
+    status: :succeeded,
+    completed_at: Time.current,
+  ).save
+
 puts "More complete application created (or found) " \
   "with id: #{complete_application.id}"


### PR DESCRIPTION
In order to get more visibility as to *where* and *when* applications are sent
to the offices in MI we can display the exports in the admin in the context of
their parent snap application.

This commit adds the resource to the admin and adjusts the seed task to create
some fake data for local testing and demo'ing.