### PR TITLE
Only export apps when they're sufficiently done

### DIFF
--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -12,6 +12,8 @@ class SuccessController < SnapStepsController
   private
 
   def before_rendering_edit_hook
+    return if !current_application.exportable?
+
     ExportFactory.create(
       destination: :sms,
       snap_application: current_application,

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -54,6 +54,10 @@ class SnapApplication < ApplicationRecord
     where.not(id: Export.emailed_client.succeeded.application_ids)
   end)
 
+  def exportable?
+    signature.present?
+  end
+
   def drive_status
     if driver_applications.any? && latest_drive_attempt.driver_errors.empty?
       :drive_success

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -42,6 +42,21 @@ RSpec.describe SuccessController do
       end
     end
 
+    context "application is not exportable" do
+      it "does not run the export factory, or application driver" do
+        run_background_jobs_immediately do
+          allow(ExportFactory).to receive(:create)
+          allow(DriveApplicationJob).to receive(:perform_later)
+          current_app.update(signature: nil)
+
+          get :edit
+
+          expect(ExportFactory).not_to have_received(:create)
+          expect(DriveApplicationJob).not_to have_received(:perform_later)
+        end
+      end
+    end
+
     context "sms consent present" do
       it "sends the submitted_message sms" do
         run_background_jobs_immediately do

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -38,6 +38,22 @@ RSpec.describe SnapApplication do
     end
   end
 
+  describe "#exportable?" do
+    it "is true if a signature exists" do
+      app = build(:snap_application, signature: "John Doe")
+
+      expect(app).to be_exportable
+    end
+
+    it "is false if signature does not exist" do
+      app1 = build(:snap_application, signature: "")
+      app2 = build(:snap_application, signature: nil)
+
+      expect(app1).not_to be_exportable
+      expect(app2).not_to be_exportable
+    end
+  end
+
   describe "#pdf" do
     it "delegates to the Dhs1171Pdf class" do
       app = build(:snap_application)


### PR DESCRIPTION
If there is no signature on a snap application then they should *not* be
sent to the offices in MI. This can occasionally happen if someone is
skipping steps or bouncing around the application and not filling
everything out sufficiently.

This commit introduces a guard clause in the final success controller
that will bail out of the Export/Driving work if the application is not
"done" enough. For now this checks for only the signature being present.
In the future it stands to reason that there will be further conditions
that define whether or not an application is "done".