### PR TITLE
Fix steps page and display medicaid steps

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -6,6 +6,16 @@ class StepsController < ApplicationController
   before_action :ensure_application_present, only: %i(edit index)
   before_action :maybe_skip, only: :edit
 
+  def ensure_application_present
+    return if current_application
+
+    redirect_to root_path
+  end
+
+  def current_application
+    snap_application || medicaid_application
+  end
+
   def edit
     @step = step_class.new(existing_attributes.slice(*step_attrs))
 
@@ -37,6 +47,17 @@ class StepsController < ApplicationController
   def next_path(params = {})
     next_step = step_navigation.next
     decoded_step_path(step: next_step, params: params) if next_step
+  end
+
+  # This is an intentional noop
+  def step_navigation; end
+
+  def snap_application
+    SnapApplication.find_by(id: session[:snap_application_id])
+  end
+
+  def medicaid_application
+    MedicaidApplication.find_by(id: session[:medicaid_application_id])
   end
 
   private
@@ -78,7 +99,7 @@ class StepsController < ApplicationController
   end
 
   def previous_path(params = nil)
-    previous_step = step_navigation.previous
+    previous_step = step_navigation&.previous
     if previous_step
       decoded_step_path(step: previous_step, params: params)
     else

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -6,4 +6,8 @@ class MedicaidApplication < ApplicationRecord
     :ssn,
     key: Rails.application.secrets.secret_key_for_ssn_encryption,
   )
+
+  def self.step_navigation
+    Medicaid::StepNavigation
+  end
 end

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -54,6 +54,10 @@ class SnapApplication < ApplicationRecord
     where.not(id: Export.emailed_client.succeeded.application_ids)
   end)
 
+  def self.step_navigation
+    StepNavigation
+  end
+
   def exportable?
     signature.present?
   end

--- a/app/views/steps/index.html.erb
+++ b/app/views/steps/index.html.erb
@@ -1,9 +1,10 @@
 <% content_for :header_title, 'Navigation' %>
 <div class="slab">
-  <% StepNavigation.sections.each do |section, steps| %>
+  <% current_application.class.step_navigation.sections.each do |section, steps| %>
     <h3>
       <%= section %>
     </h3>
+
     <% steps.each do |step| %>
       <div>
         <%= link_to step.to_param.titleize,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,10 +38,9 @@ Rails.application.routes.draw do
 
   resource :skip_send_application, only: [:create]
 
-  # Medicaid
-  resources :steps, only: %i[index] do
+  resources :steps, only: %i[index show] do
     collection do
-      Medicaid::StepNavigation.steps_and_substeps.each do |controller_class|
+      StepNavigation.steps_and_substeps.each do |controller_class|
         { get: :edit, put: :update }.each do |method, action|
           match "/#{controller_class.to_param}",
             action: action,
@@ -49,13 +48,8 @@ Rails.application.routes.draw do
             via: method
         end
       end
-    end
-  end
 
-  # FAP
-  resources :steps, only: %i[show index] do
-    collection do
-      StepNavigation.steps_and_substeps.each do |controller_class|
+      Medicaid::StepNavigation.steps_and_substeps.each do |controller_class|
         { get: :edit, put: :update }.each do |method, action|
           match "/#{controller_class.to_param}",
             action: action,

--- a/spec/controllers/steps_controller_spec.rb
+++ b/spec/controllers/steps_controller_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe StepsController do
+  context "when no applications have been started" do
+    it "redirects to the homepage" do
+      get :index
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  context "when a snap application has been started" do
+    it "renders the index page" do
+      current_app = create(:snap_application)
+      session[:snap_application_id] = current_app.id
+
+      get :index
+
+      expect(response).to render_template(:index)
+    end
+  end
+
+  context "when a medicaid application has been started" do
+    it "renders the index page" do
+      current_app = create(:medicaid_application)
+      session[:medicaid_application_id] = current_app.id
+
+      get :index
+
+      expect(response).to render_template(:index)
+    end
+  end
+end


### PR DESCRIPTION
The steps page had run into some issues sometime in the recent past and
was 500'ing out. This commit fixes that issue, as well as:

1. Adds the medicaid steps to the steps index
2. Displays either/or/both the snap and medicaid steps only if there's
   a respective id present in the session.
3. If there is no id present, user is redirected to the homepage
4. Add a controller spec to ensure this continues to be functional
5. Join the two application sections in the routes