### PR TITLE
Allow multiple members for Medicaid application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 .rspec
 mkmf.log
 Guardfile
+.idea

--- a/app/controllers/medicaid/intro_household_controller.rb
+++ b/app/controllers/medicaid/intro_household_controller.rb
@@ -4,8 +4,9 @@ module Medicaid
   class IntroHouseholdController < MedicaidStepsController
     def edit
       @step = step_class.new(
-        first_name: current_application.first_name,
-        last_name: current_application.last_name,
+        first_name: current_application.primary_member.first_name,
+        last_name: current_application.primary_member.last_name,
+        non_applicant_members: current_application.non_applicant_members,
       )
     end
   end

--- a/app/controllers/medicaid/intro_household_member_controller.rb
+++ b/app/controllers/medicaid/intro_household_member_controller.rb
@@ -21,15 +21,14 @@ module Medicaid
 
     def member_attributes
       {
-          first_name: member.first_name,
-          last_name: member.last_name,
-          sex: member.sex,
+        first_name: member.first_name,
+        last_name: member.last_name,
+        sex: member.sex,
       }
     end
 
     def member
       @member ||= current_application.members.build
     end
-
   end
 end

--- a/app/controllers/medicaid/intro_household_member_controller.rb
+++ b/app/controllers/medicaid/intro_household_member_controller.rb
@@ -2,5 +2,34 @@
 
 module Medicaid
   class IntroHouseholdMemberController < MedicaidStepsController
+    def update
+      @step = step_class.new(step_params)
+
+      if @step.valid?
+        member.update!(step_params)
+        redirect_to next_path
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def existing_attributes
+      HashWithIndifferentAccess.new(member_attributes)
+    end
+
+    def member_attributes
+      {
+          first_name: member.first_name,
+          last_name: member.last_name,
+          sex: member.sex,
+      }
+    end
+
+    def member
+      @member ||= current_application.members.build
+    end
+
   end
 end

--- a/app/controllers/medicaid/intro_name_controller.rb
+++ b/app/controllers/medicaid/intro_name_controller.rb
@@ -23,13 +23,13 @@ module Medicaid
       {
         first_name: member.first_name,
         last_name: member.last_name,
-        sex: member.sex
+        sex: member.sex,
       }
     end
 
     def member
       current_application.members.first ||
-          current_application.members.new
+        current_application.members.new
     end
   end
 end

--- a/app/controllers/medicaid/intro_name_controller.rb
+++ b/app/controllers/medicaid/intro_name_controller.rb
@@ -2,5 +2,34 @@
 
 module Medicaid
   class IntroNameController < MedicaidStepsController
+    def update
+      @step = step_class.new(step_params)
+
+      if @step.valid?
+        member.update!(step_params)
+        redirect_to(next_path)
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def existing_attributes
+      HashWithIndifferentAccess.new(member_attributes)
+    end
+
+    def member_attributes
+      {
+        first_name: member.first_name,
+        last_name: member.last_name,
+        sex: member.sex
+      }
+    end
+
+    def member
+      current_application.members.first ||
+          current_application.members.new
+    end
   end
 end

--- a/app/dashboards/member_dashboard.rb
+++ b/app/dashboards/member_dashboard.rb
@@ -9,7 +9,7 @@ class MemberDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    snap_application: Field::BelongsTo,
+    snap_application: Field::Polymorphic,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     marital_status: Field::String,

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class MedicaidApplication < ApplicationRecord
+  has_many :members, as: :benefit_application, dependent: :destroy
+
   attribute :ssn
   attr_encrypted(
     :ssn,
@@ -9,5 +11,13 @@ class MedicaidApplication < ApplicationRecord
 
   def self.step_navigation
     Medicaid::StepNavigation
+  end
+
+  def primary_member
+    members.order(:id).first || NullMember.new
+  end
+
+  def non_applicant_members
+    members - [primary_member]
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -9,7 +9,7 @@ class Member < ApplicationRecord
     "Other",
   ].freeze
 
-  belongs_to :snap_application
+  belongs_to :benefit_application, polymorphic: true
 
   validates :employed_pay_interval,
     inclusion: { in: PAYMENT_INTERVALS },
@@ -26,7 +26,7 @@ class Member < ApplicationRecord
   end
 
   def primary_member?
-    snap_application.primary_member.id == id
+    benefit_application.primary_member.id == id
   end
 
   def monthly_income

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -28,7 +28,7 @@ class SnapApplication < ApplicationRecord
   has_many :driver_applications, dependent: :destroy
   has_many :driver_errors, through: :driver_applications
   has_many :exports, dependent: :destroy
-  has_many :members, dependent: :destroy
+  has_many :members, as: :benefit_application, dependent: :destroy
 
   scope :signed, -> { where.not(signed_at: nil) }
   scope :unsigned, -> { where(signed_at: nil) }

--- a/app/steps/medicaid/intro_household.rb
+++ b/app/steps/medicaid/intro_household.rb
@@ -5,6 +5,7 @@ module Medicaid
     step_attributes(
       :first_name,
       :last_name,
+      :non_applicant_members,
     )
   end
 end

--- a/app/steps/medicaid/intro_household_member.rb
+++ b/app/steps/medicaid/intro_household_member.rb
@@ -2,5 +2,10 @@
 
 module Medicaid
   class IntroHouseholdMember < Step
+    step_attributes(
+      :first_name,
+      :last_name,
+      :sex,
+    )
   end
 end

--- a/app/steps/medicaid/intro_name.rb
+++ b/app/steps/medicaid/intro_name.rb
@@ -5,7 +5,7 @@ module Medicaid
     step_attributes(
       :first_name,
       :last_name,
-      :gender,
+      :sex,
     )
 
     validates :first_name,
@@ -14,7 +14,7 @@ module Medicaid
     validates :last_name,
       presence: { message: "Make sure to provide a last name" }
 
-    validates :gender, inclusion: {
+    validates :sex, inclusion: {
       in: %w(male female),
       message: "Make sure to answer this question",
     }

--- a/app/views/medicaid/intro_household/edit.html.erb
+++ b/app/views/medicaid/intro_household/edit.html.erb
@@ -18,11 +18,21 @@
           <i class="button__icon--left icon-check icon-check--color"></i>
           <%= "#{@step.first_name} #{@step.last_name}" %>  (That's you!)
         </p>
+        <% @step.non_applicant_members.each do |member| %>
+            <div>
+              <p>
+                <i class="button__icon--left icon-check icon-check--color"></i>
+                <%= "#{member.first_name.titleize} #{member.last_name.titleize}" %>
+              </p>
+            </div>
+        <% end %>
 
-        <a href="/pages/medicaid/intro_household_member" class="button button-full-width button-bold">
+        <%= link_to(
+          decoded_step_path(step: Medicaid::IntroHouseholdMemberController),
+          class: 'button button-full-width button-bold') do %>
           <i class="button__icon--left icon-add"></i>
           Add a member
-        </a>
+        <% end %>
 
       </div>
     </div>

--- a/app/views/medicaid/intro_household_member/edit.html.erb
+++ b/app/views/medicaid/intro_household_member/edit.html.erb
@@ -6,27 +6,18 @@
   </header>
 
   <div class="form-card__content">
-    <label class="form-question" for="example_text">What is their first name?</label>
-    <input type="text" class="text-input" name="example_text">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+      <%= f.mb_input_field :first_name,
+        "What is their first name?",
+        autofocus: true %>
+      <%= f.mb_input_field :last_name, "What is their last name?" %>
+      <%= f.mb_radio_set :sex,
+        'What is their gender?',
+        [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
+        notes: ["As it appears on official government documents"],
+        layout: "inline" %>
 
-    <label class="form-question" for="example_text">What is their last name?</label>
-    <input type="text" class="text-input"  name="example_text">
-
-    <label class="form-question" for="example_text">What is their gender? (As it appears on official government documents)</label>
-    <label for="example_radio" class="radio-button">
-      <input type="radio" name="example_radio" id="example_radio">
-      Female
-    </label>
-
-    <label for="example_radio" class="radio-button">
-      <input type="radio" name="example_radio" id="example_radio">
-      Male
-    </label>
+      <%= render "medicaid/next_step" %>
+    <% end %>
   </div>
-
-  <footer class="form-card__button_right">
-    <a href="/pages/medicaid/intro_household" class="button button--nav  button--cta button--full-width">
-      Next
-    </a>
-  </footer>
 </div>

--- a/app/views/medicaid/intro_name/edit.html.erb
+++ b/app/views/medicaid/intro_name/edit.html.erb
@@ -11,7 +11,7 @@
         "What is your first name?",
         autofocus: true %>
       <%= f.mb_input_field :last_name, "What is your last name?" %>
-      <%= f.mb_radio_set :gender,
+      <%= f.mb_radio_set :sex,
         'What is your gender?',
         [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
         notes: ["As it appears on official government documents"],

--- a/db/migrate/20171017191829_extract_members_from_medicaid_app.rb
+++ b/db/migrate/20171017191829_extract_members_from_medicaid_app.rb
@@ -3,21 +3,21 @@ class ExtractMembersFromMedicaidApp < ActiveRecord::Migration[5.1]
     add_column :members, :benefit_application_id, :bigint
     add_column :members, :benefit_application_type, :string
 
-    safety_assured {
+    safety_assured do
       execute <<~SQL
         UPDATE members SET benefit_application_id=snap_application_id;
         UPDATE members SET benefit_application_type='SnapApplication';
       SQL
-    }
+    end
 
     change_column_null :members, :benefit_application_id, false
     change_column_null :members, :benefit_application_type, false
-    safety_assured {
+    safety_assured do
       remove_column :members, :snap_application_id
 
       execute <<~SQL
         INSERT INTO members
-        (first_name,last_name,sex,benefit_application_id,benefit_application_type,created_at,updated_at) 
+        (first_name,last_name,sex,benefit_application_id,benefit_application_type,created_at,updated_at)
         SELECT first_name, last_name, gender, id, 'MedicaidApplication', now(), now()
         FROM medicaid_applications;
       SQL
@@ -25,7 +25,7 @@ class ExtractMembersFromMedicaidApp < ActiveRecord::Migration[5.1]
       remove_column :medicaid_applications, :first_name
       remove_column :medicaid_applications, :last_name
       remove_column :medicaid_applications, :gender
-    }
+    end
   end
 
   def down
@@ -33,7 +33,7 @@ class ExtractMembersFromMedicaidApp < ActiveRecord::Migration[5.1]
     add_column :medicaid_applications, :last_name, :string
     add_column :medicaid_applications, :gender, :string
 
-    safety_assured {
+    safety_assured do
       execute <<~SQL
         UPDATE medicaid_applications
         SET first_name=members.first_name, last_name=members.last_name, gender=members.sex
@@ -44,17 +44,17 @@ class ExtractMembersFromMedicaidApp < ActiveRecord::Migration[5.1]
         DELETE FROM members
         WHERE benefit_application_type='MedicaidApplication';
       SQL
-    }
+    end
 
     add_column :members, :snap_application_id, :bigint
 
-    safety_assured {
+    safety_assured do
       execute <<~SQL
         UPDATE members SET snap_application_id=benefit_application_id;
       SQL
 
       remove_column :members, :benefit_application_id
       remove_column :members, :benefit_application_type
-    }
+    end
   end
 end

--- a/db/migrate/20171017191829_extract_members_from_medicaid_app.rb
+++ b/db/migrate/20171017191829_extract_members_from_medicaid_app.rb
@@ -1,0 +1,60 @@
+class ExtractMembersFromMedicaidApp < ActiveRecord::Migration[5.1]
+  def up
+    add_column :members, :benefit_application_id, :bigint
+    add_column :members, :benefit_application_type, :string
+
+    safety_assured {
+      execute <<~SQL
+        UPDATE members SET benefit_application_id=snap_application_id;
+        UPDATE members SET benefit_application_type='SnapApplication';
+      SQL
+    }
+
+    change_column_null :members, :benefit_application_id, false
+    change_column_null :members, :benefit_application_type, false
+    safety_assured {
+      remove_column :members, :snap_application_id
+
+      execute <<~SQL
+        INSERT INTO members
+        (first_name,last_name,sex,benefit_application_id,benefit_application_type,created_at,updated_at) 
+        SELECT first_name, last_name, gender, id, 'MedicaidApplication', now(), now()
+        FROM medicaid_applications;
+      SQL
+
+      remove_column :medicaid_applications, :first_name
+      remove_column :medicaid_applications, :last_name
+      remove_column :medicaid_applications, :gender
+    }
+  end
+
+  def down
+    add_column :medicaid_applications, :first_name, :string
+    add_column :medicaid_applications, :last_name, :string
+    add_column :medicaid_applications, :gender, :string
+
+    safety_assured {
+      execute <<~SQL
+        UPDATE medicaid_applications
+        SET first_name=members.first_name, last_name=members.last_name, gender=members.sex
+        FROM members
+        WHERE members.benefit_application_type='MedicaidApplication'
+        AND members.benefit_application_id=medicaid_applications.id;
+
+        DELETE FROM members
+        WHERE benefit_application_type='MedicaidApplication';
+      SQL
+    }
+
+    add_column :members, :snap_application_id, :bigint
+
+    safety_assured {
+      execute <<~SQL
+        UPDATE members SET snap_application_id=benefit_application_id;
+      SQL
+
+      remove_column :members, :benefit_application_id
+      remove_column :members, :benefit_application_type
+    }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171016213538) do
+ActiveRecord::Schema.define(version: 20171017191829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -99,8 +99,6 @@ ActiveRecord::Schema.define(version: 20171016213538) do
     t.string "encrypted_ssn"
     t.string "encrypted_ssn_iv"
     t.boolean "filing_federal_taxes_next_year"
-    t.string "first_name"
-    t.string "gender"
     t.boolean "homeless"
     t.boolean "income_alimony"
     t.boolean "income_not_from_job"
@@ -110,7 +108,6 @@ ActiveRecord::Schema.define(version: 20171016213538) do
     t.boolean "income_unemployment"
     t.string "insurance_type"
     t.boolean "insured"
-    t.string "last_name"
     t.boolean "mail_sent_to_residential"
     t.string "mailing_city"
     t.string "mailing_street_address"
@@ -137,6 +134,8 @@ ActiveRecord::Schema.define(version: 20171016213538) do
   end
 
   create_table "members", force: :cascade do |t|
+    t.bigint "benefit_application_id", null: false
+    t.string "benefit_application_type", null: false
     t.datetime "birthday"
     t.boolean "buy_food_with", default: true
     t.boolean "citizen"
@@ -161,9 +160,7 @@ ActiveRecord::Schema.define(version: 20171016213538) do
     t.integer "self_employed_monthly_income"
     t.string "self_employed_profession"
     t.string "sex"
-    t.bigint "snap_application_id"
     t.datetime "updated_at", null: false
-    t.index ["snap_application_id"], name: "index_members_on_snap_application_id"
   end
 
   create_table "snap_applications", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -260,21 +260,21 @@ puts "More complete application created (or found) " \
 puts "Creating a minimal medicaid application..."
 
 medicaid_application = MedicaidApplication.find_or_initialize_by(
-    email: "medicaid.application@example.com",
+  email: "medicaid.application@example.com",
 )
 
 medicaid_application.update!(
-    michigan_resident: true,
+  michigan_resident: true,
 )
 
 medicaid_primary = Member.find_or_initialize_by(
-    benefit_application: medicaid_application,
-    first_name: "Medicaid",
-    last_name: "TestPerson",
+  benefit_application: medicaid_application,
+  first_name: "Medicaid",
+  last_name: "TestPerson",
 )
 
 medicaid_primary.update!(
-    sex: "female",
+  sex: "female",
 )
 
 puts "Minimal medicaid application created (or found) " \

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -52,7 +52,7 @@ minimal_mailing.update!(
 )
 
 minimal_primary = Member.find_or_initialize_by(
-  snap_application: minimal_application,
+  benefit_application: minimal_application,
   first_name: "Test",
   last_name: "Client",
 )
@@ -158,7 +158,7 @@ complete_residential.update!(
 )
 
 complete_primary = Member.find_or_initialize_by(
-  snap_application: complete_application,
+  benefit_application: complete_application,
   first_name: "Complete",
   last_name: "Testapp",
 )
@@ -166,7 +166,7 @@ complete_primary = Member.find_or_initialize_by(
 complete_primary.update!(
   marital_status: "Married",
   sex: "male",
-  snap_application_id: 2,
+  benefit_application_id: 2,
   encrypted_ssn: "lWqpXtZV/j8XV8+Ci/0H6ZFYt5MXwp+TJA==\n",
   encrypted_ssn_iv: "Y9G6b8hj2mmDi4Uv\n",
   birthday: 40.years.ago,
@@ -181,7 +181,7 @@ complete_primary.update!(
 )
 
 complete_second_member = Member.find_or_initialize_by(
-  snap_application: complete_application,
+  benefit_application: complete_application,
   first_name: "Jane",
   last_name: "Doe",
 )
@@ -202,7 +202,7 @@ complete_second_member.update!(
 )
 
 complete_third_member = Member.find_or_initialize_by(
-  snap_application: complete_application,
+  benefit_application: complete_application,
   first_name: "Random",
   last_name: "Roommate",
 )
@@ -256,3 +256,26 @@ complete_application.
 
 puts "More complete application created (or found) " \
   "with id: #{complete_application.id}"
+
+puts "Creating a minimal medicaid application..."
+
+medicaid_application = MedicaidApplication.find_or_initialize_by(
+    email: "medicaid.application@example.com",
+)
+
+medicaid_application.update!(
+    michigan_resident: true,
+)
+
+medicaid_primary = Member.find_or_initialize_by(
+    benefit_application: medicaid_application,
+    first_name: "Medicaid",
+    last_name: "TestPerson",
+)
+
+medicaid_primary.update!(
+    sex: "female",
+)
+
+puts "Minimal medicaid application created (or found) " \
+  "with id: #{medicaid_application.id}"

--- a/lib/mi_bridges/driver/services/submit_relationship.rb
+++ b/lib/mi_bridges/driver/services/submit_relationship.rb
@@ -31,7 +31,7 @@ module MiBridges
         end
 
         def mi_bridges_relationship
-          if first_member == first_member.snap_application.primary_member
+          if first_member == first_member.benefit_application.primary_member
             map_member_relationship_to_mi_bridges
           else
             "is Related to another way to"

--- a/spec/factories/member.rb
+++ b/spec/factories/member.rb
@@ -6,5 +6,6 @@ FactoryGirl.define do
     marital_status "Widowed"
     ssn "123 12 1234"
     birthday { DateTime.parse("August 18, 1990") }
+    benefit_application { create(:snap_application) }
   end
 end

--- a/spec/factories/snap_applications.rb
+++ b/spec/factories/snap_applications.rb
@@ -7,7 +7,7 @@ FactoryGirl.define do
 
     trait :with_member do
       after :create do |app|
-        create(:member, snap_application: app)
+        create(:member, benefit_application: app)
       end
     end
 

--- a/spec/features/medicaid_spec.rb
+++ b/spec/features/medicaid_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.feature "Medicaid app" do
+  scenario "with multiple members", :js do
+    visit dual_index_path
+    within(".slab--hero") do
+      click_on "Apply for Medicaid"
+    end
+
+    on_page "Introduction" do
+      click_on "Yes"
+    end
+
+    on_page "Introduction" do
+      fill_in "What is your first name?", with: "Jessie"
+      fill_in "What is your last name?", with: "Tester"
+      select_radio(question: "What is your gender?", answer: "Female")
+      click_on "Next"
+    end
+
+    on_page "Introduction" do
+      click_on "Add a member"
+    end
+
+    on_page "Introduction" do
+      fill_in "What is their first name?", with: "Christa"
+      fill_in "What is their last name?", with: "Tester"
+      select_radio(question: "What is their gender?", answer: "Female")
+      click_on "Next"
+    end
+
+    expect(page).to have_content("Jessie Tester")
+    expect(page).to have_content("Christa Tester")
+  end
+end

--- a/spec/jobs/fax_application_job_spec.rb
+++ b/spec/jobs/fax_application_job_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe FaxApplicationJob do
     end
 
     it "does not send a fax if application has already been sent" do
-      snap_application = FactoryGirl.create(:snap_application,
+      snap_application = create(:snap_application,
         :with_member, :faxed)
       export = Export.create(snap_application: snap_application,
                              destination: :fax)

--- a/spec/steps/medicaid/intro_name_spec.rb
+++ b/spec/steps/medicaid/intro_name_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Medicaid::IntroName do
       step = Medicaid::IntroName.new(
         first_name: nil,
         last_name: "Boo",
-        gender: "male",
+        sex: "male",
       )
 
       expect(step).to be_invalid
@@ -16,17 +16,17 @@ RSpec.describe Medicaid::IntroName do
       step = Medicaid::IntroName.new(
         first_name: "Boo",
         last_name: nil,
-        gender: "male",
+        sex: "male",
       )
 
       expect(step).to be_invalid
     end
 
-    it "validates presence of gender" do
+    it "validates presence of sex" do
       step = Medicaid::IntroName.new(
         first_name: "Lala",
         last_name: "Boo",
-        gender: nil,
+        sex: nil,
       )
 
       expect(step).to be_invalid


### PR DESCRIPTION
For single member flow, it made sense to save some user details on the application.
Now with multiple members, it made sense to move that information from the application and into the member class. To do this, we made applications (Snap and Medicaid) a polymorphic association on the Member class.

To test, create a Medicaid application and confirm you can add multiple members.
