### PR TITLE
Allow clients to select up to 10 jobs

### DIFF
--- a/app/controllers/medicaid/income_job_number_continued_controller.rb
+++ b/app/controllers/medicaid/income_job_number_continued_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class IncomeJobNumberContinuedController < MedicaidStepsController
+    private
+
+    def skip?
+      current_application.new_number_of_jobs < 4
+    end
+  end
+end

--- a/app/controllers/medicaid/income_job_number_controller.rb
+++ b/app/controllers/medicaid/income_job_number_controller.rb
@@ -4,6 +4,22 @@ module Medicaid
   class IncomeJobNumberController < MedicaidStepsController
     private
 
+    def existing_attributes
+      HashWithIndifferentAccess.new(number_of_job_attributes)
+    end
+
+    def number_of_job_attributes
+      { new_number_of_jobs: number_of_jobs }
+    end
+
+    def number_of_jobs
+      if current_application.new_number_of_jobs&. > 4
+        4
+      else
+        current_application.new_number_of_jobs
+      end
+    end
+
     def skip?
       not_employed?
     end

--- a/app/steps/medicaid/income_job_number.rb
+++ b/app/steps/medicaid/income_job_number.rb
@@ -2,6 +2,9 @@
 
 module Medicaid
   class IncomeJobNumber < Step
-    step_attributes(:number_of_jobs)
+    step_attributes(:new_number_of_jobs)
+
+    validates :new_number_of_jobs,
+      presence: { message: "Make sure to answer this question" }
   end
 end

--- a/app/steps/medicaid/income_job_number_continued.rb
+++ b/app/steps/medicaid/income_job_number_continued.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class IncomeJobNumberContinued < Step
+    step_attributes(:new_number_of_jobs)
+  end
+end

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -28,6 +28,7 @@ module Medicaid
       "Income" => [
         Medicaid::IncomeJobController,
         Medicaid::IncomeJobNumberController,
+        Medicaid::IncomeJobNumberContinuedController,
         Medicaid::IncomeSelfEmploymentController,
         Medicaid::IncomeOtherIncomeController,
         Medicaid::IncomeOtherIncomeTypeController,

--- a/app/views/medicaid/income_job_number_continued/edit.html.erb
+++ b/app/views/medicaid/income_job_number_continued/edit.html.erb
@@ -11,10 +11,13 @@
       <%= f.mb_radio_set :new_number_of_jobs,
         '',
         [
-          { value: "1", label: "1 job" },
-          { value: "2", label: "2 jobs" },
-          { value: "3", label: "3 jobs" },
-          { value: "4", label: "4 or more jobs" },
+          { value: "4", label: "4 jobs" },
+          { value: "5", label: "5 jobs" },
+          { value: "6", label: "6 jobs" },
+          { value: "7", label: "7 jobs" },
+          { value: "8", label: "8 jobs" },
+          { value: "9", label: "9 jobs" },
+          { value: "10", label: "10 jobs" },
         ] %>
 
       <%= render "medicaid/next_step" %>

--- a/db/migrate/20171018174809_number_of_jobs_to_integer.rb
+++ b/db/migrate/20171018174809_number_of_jobs_to_integer.rb
@@ -7,9 +7,11 @@ class NumberOfJobsToInteger < ActiveRecord::Migration[5.1]
         UPDATE medicaid_applications
         SET new_number_of_jobs=1
         WHERE number_of_jobs='1 job';
+
         UPDATE medicaid_applications
         SET new_number_of_jobs=2
         WHERE number_of_jobs='2 jobs';
+
         UPDATE medicaid_applications
         SET new_number_of_jobs=3
         WHERE number_of_jobs='3 or more jobs';

--- a/db/migrate/20171018174809_number_of_jobs_to_integer.rb
+++ b/db/migrate/20171018174809_number_of_jobs_to_integer.rb
@@ -1,0 +1,23 @@
+class NumberOfJobsToInteger < ActiveRecord::Migration[5.1]
+  def up
+    add_column :medicaid_applications, :new_number_of_jobs, :integer
+
+    safety_assured do
+      execute <<~SQL
+        UPDATE medicaid_applications
+        SET new_number_of_jobs=1
+        WHERE number_of_jobs='1 job';
+        UPDATE medicaid_applications
+        SET new_number_of_jobs=2
+        WHERE number_of_jobs='2 jobs';
+        UPDATE medicaid_applications
+        SET new_number_of_jobs=3
+        WHERE number_of_jobs='3 or more jobs';
+      SQL
+    end
+  end
+
+  def down
+    remove_column :medicaid_applications, :new_number_of_jobs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171017191829) do
+ActiveRecord::Schema.define(version: 20171018174809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,7 @@ ActiveRecord::Schema.define(version: 20171017191829) do
     t.boolean "michigan_resident", null: false
     t.boolean "need_medical_expense_help_3_months"
     t.boolean "new_mom"
+    t.integer "new_number_of_jobs"
     t.string "number_of_jobs"
     t.boolean "pay_child_support_alimony_arrears"
     t.boolean "pay_student_loan_interest"

--- a/spec/controllers/income_expenses_job_number_controller_spec.rb
+++ b/spec/controllers/income_expenses_job_number_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Medicaid::IncomeJobNumberController do
         get :edit
 
         expect(response).to redirect_to(
-          "/steps/medicaid/income-self-employment",
+          "/steps/medicaid/income-job-number-continued",
         )
       end
     end

--- a/spec/controllers/medicaid/income_job_number_continued_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_continued_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IncomeJobNumberContinuedController do
+  describe "#next_path" do
+    it "is the self employment page path" do
+      expect(subject.next_path).to eq "/steps/medicaid/income-self-employment"
+    end
+  end
+
+  describe "#edit" do
+    context "client is has 4+ jobs" do
+      it "renders edit " do
+        medicaid_application =
+          create(
+            :medicaid_application,
+            new_number_of_jobs: 4,
+          )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context "client has fewer than 4 jobs" do
+      it "redirects to the next page" do
+        medicaid_application =
+          create(
+            :medicaid_application,
+            new_number_of_jobs: 3,
+          )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/income_job_number_controller_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_controller_spec.rb
@@ -1,13 +1,33 @@
 require "rails_helper"
 
-RSpec.describe Medicaid::IncomeJobNumberController, type: :controller do
+RSpec.describe Medicaid::IncomeJobNumberController do
+  let(:step) { assigns(:step) }
+
   describe "#next_path" do
     it "is the self employment page path" do
-      expect(subject.next_path).to eq "/steps/medicaid/income-self-employment"
+      expect(subject.next_path).to eq(
+        "/steps/medicaid/income-job-number-continued",
+      )
     end
   end
 
   describe "#edit" do
+    context "client has 4 or more jobs" do
+      it "sets the job number to 4" do
+        medicaid_application = create(
+          :medicaid_application,
+          employed: true,
+          new_number_of_jobs: 5,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+        expect(step.new_number_of_jobs).to eq(4)
+      end
+    end
+
     context "client is employed" do
       it "renders edit " do
         medicaid_application =

--- a/spec/controllers/medicaid/income_job_number_controller_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_controller_spec.rb
@@ -1,8 +1,6 @@
 require "rails_helper"
 
 RSpec.describe Medicaid::IncomeJobNumberController do
-  let(:step) { assigns(:step) }
-
   describe "#next_path" do
     it "is the self employment page path" do
       expect(subject.next_path).to eq(
@@ -22,6 +20,7 @@ RSpec.describe Medicaid::IncomeJobNumberController do
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
+        step = assigns(:step)
 
         expect(response).to render_template(:edit)
         expect(step.new_number_of_jobs).to eq(4)


### PR DESCRIPTION
* This PR adds a "new_job_number" column, which is an integer rather
than a string. The old job number column will be removed in a follow up
PR and `new_job_number` renamed to `job_number`.

* Next up is adding income inputs for each job.

* Open question:

* How do we feel about defaulting the number to 4 on the "continued" page?

<img width="792" alt="screen shot 2017-10-18 at 11 31 29 am" src="https://user-images.githubusercontent.com/601515/31735845-e8756660-b3f7-11e7-885b-c42b4e0e2b89.png">


<img width="772" alt="screen shot 2017-10-18 at 11 09 40 am" src="https://user-images.githubusercontent.com/601515/31735783-c9c9a5b4-b3f7-11e7-8bd9-33c6f915ae34.png">
