### PR TITLE
Log info about email to both export & logger

### DIFF
--- a/app/jobs/office_email_application_job.rb
+++ b/app/jobs/office_email_application_job.rb
@@ -1,13 +1,14 @@
 class OfficeEmailApplicationJob < ApplicationJob
   def perform(export:)
-    export.execute do |snap_application|
+    export.execute do |snap_application, logger|
       ApplicationMailer.office_application_notification(
         file_name: snap_application.pdf.path,
         recipient_email: snap_application.receiving_office_email,
         office_location: snap_application.office_location,
       ).deliver
 
-      "Emailed to #{snap_application.receiving_office_email}"
+      logger.info("Emailed to #{snap_application.receiving_office_email} "\
+                  "for Snap Client #{snap_application.id}")
     end
   end
 end


### PR DESCRIPTION
Reason for Change
===================

When an export is executed, the block we pass to it can accept a logger
object which, when written/outputted to, will save to the export object
AND log to stdout.

Our email job has not been doing this so this commit changes it to do so
with not only the receiving office, but the id of the client who is
submitting it.