### PR TITLE
Silence deprecation errors re: AR + attr_encrypted

### DIFF
--- a/app/models/driver_application.rb
+++ b/app/models/driver_application.rb
@@ -7,12 +7,10 @@ class DriverApplication < ApplicationRecord
   validates :snap_application, presence: true
   has_many :driver_errors, dependent: :destroy
 
-  attribute %i[
-    password
-    secret_question_1_answer
-    secret_question_2_answer
-    user_id
-  ]
+  attribute :password
+  attribute :secret_question_1_answer
+  attribute :secret_question_2_answer
+  attribute :user_id
 
   attr_encrypted(:user_id, key: ENCRYPTION_KEY)
   attr_encrypted(:password, key: ENCRYPTION_KEY)


### PR DESCRIPTION
When running the test suite we see a LOT of instances of the following:

```
DEPRECATION WARNING: user_id is not an attribute known to Active Record.
This behavior is deprecated and will be removed in the next version of
Rails. If you'd like user_id to be managed by Active Record, add
`attribute :user_id to your class. (called from block (3 levels) in <top
(required)> at ./spec/models/snap_application_spec.rb:235)
```

This is due to the `attribute` class method not liking being given an
array of symbols as a parameter. Passing each attribute to the
`attribute` method fixes this.