### PR TITLE
Convert all timestamps in admin dashboard to EST.

### DIFF
--- a/app/views/fields/date_time/_index.html.erb
+++ b/app/views/fields/date_time/_index.html.erb
@@ -1,0 +1,24 @@
+<%#
+# DateTime Index Partial
+
+This partial renders a datetime attribute,
+to be displayed on a resource's index page.
+
+By default, the attribute is rendered
+as a localized date & time string.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::DateTime][1].
+  A wrapper around the DateTime value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/DateTime
+%>
+
+<% if field.data %>
+  <%= field.datetime.
+      in_time_zone("Eastern Time (US & Canada)")&.
+      to_date
+  %>
+<% end %>

--- a/app/views/fields/date_time/_show.html.erb
+++ b/app/views/fields/date_time/_show.html.erb
@@ -1,0 +1,23 @@
+<%#
+# DateTime Show Partial
+
+This partial renders a datetime attribute,
+to be displayed on a resource's show page.
+
+By default, the attribute is rendered
+as a localized date & time string.
+
+## Local variables:
+
+- `field`:
+  An instance of [Administrate::Field::DateTime][1].
+  A wrapper around the DateTime value pulled from the database.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/DateTime
+%>
+
+<% if field.data %>
+  <%= field.datetime.
+    in_time_zone("Eastern Time (US & Canada)")&.
+    strftime("%m/%d/%Y at %I:%M%p %Z") %>
+<% end %>

--- a/spec/controllers/medicaid/amounts_income_controller_spec.rb
+++ b/spec/controllers/medicaid/amounts_income_controller_spec.rb
@@ -45,8 +45,10 @@ RSpec.describe Medicaid::AmountsIncomeController do
         )
         session[:medicaid_application_id] = medicaid_application.id
 
-        post :update, params: {
-          step: { employed_monthly_income: ["111", "222"] },
+        post :update, {
+          params: {
+            step: { employed_monthly_income: ["111", "222"] },
+          },
         }
 
         medicaid_application.reload

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -36,8 +36,8 @@ RSpec.feature "Submit application with minimal information" do
     expect(emails.count).to eq 1
   end
 
-  scenario "application detail timestamps are converted to Eastern timezone", javascript: true do
-    date = DateTime.new(2017,4,5,1,30)
+  scenario "dashboard timestamps are converted to EST", javascript: true do
+    date = DateTime.new(2017, 4, 5, 1, 30)
 
     application = create(:snap_application,
            created_at: date,

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -35,4 +35,23 @@ RSpec.feature "Submit application with minimal information" do
     expect(faxes.count).to eq 1
     expect(emails.count).to eq 1
   end
+
+  scenario "application detail timestamps are converted to Eastern timezone", javascript: true do
+    date = DateTime.new(2017,4,5,6,30)
+
+    application = create(:snap_application,
+           created_at: date,
+           updated_at: date + 1.hour,
+           email: "person@example.com",
+           signed_at: date + 2.hours)
+
+    visit admin_root_path
+    click_link_or_button "person@example.com"
+
+    expect(page).to have_content("Snap Application ##{application.id}")
+
+    expect(page).to have_content("Created At 04/05/2017 at 02:30AM EDT")
+    expect(page).to have_content("Updated At 04/05/2017 at 03:30AM EDT")
+    expect(page).to have_content("Signed At 04/05/2017 at 04:30AM EDT")
+  end
 end

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "Submit application with minimal information" do
   end
 
   scenario "application detail timestamps are converted to Eastern timezone", javascript: true do
-    date = DateTime.new(2017,4,5,6,30)
+    date = DateTime.new(2017,4,5,1,30)
 
     application = create(:snap_application,
            created_at: date,
@@ -46,12 +46,15 @@ RSpec.feature "Submit application with minimal information" do
            signed_at: date + 2.hours)
 
     visit admin_root_path
+
+    expect(page).to have_content("2017-04-04") # Signed at date
+
     click_link_or_button "person@example.com"
 
     expect(page).to have_content("Snap Application ##{application.id}")
 
-    expect(page).to have_content("Created At 04/05/2017 at 02:30AM EDT")
-    expect(page).to have_content("Updated At 04/05/2017 at 03:30AM EDT")
-    expect(page).to have_content("Signed At 04/05/2017 at 04:30AM EDT")
+    expect(page).to have_content("Created At 04/04/2017 at 09:30PM EDT")
+    expect(page).to have_content("Updated At 04/04/2017 at 10:30PM EDT")
+    expect(page).to have_content("Signed At 04/04/2017 at 11:30PM EDT")
   end
 end


### PR DESCRIPTION
Customizes a partial for administrate to convert and format any DateTime fields on detail pages to the same way they're shown elsewhere in the app for SNAP applications (using SnapApplication#signed_at_est as guide). End result should be that all full timestamps in the admin dashboard are now shown in EST rather than UTC.

Does not convert Date objects on index pages to EST.

Pages & fields affected:

**On snap_application#show (e.g. admin/snap_applications/1):**

* Created at
* Updated at
* Signed at

**On export#show (e.g. admin/exports/2):**

* Completed at
* Created at
* Updated at

**On member#show (e.g. admin/member/2):**

* Created at
* Updated at