### PR TITLE
Fix Medicaid bug for unemployed clients

### DIFF
--- a/app/controllers/medicaid/income_job_number_continued_controller.rb
+++ b/app/controllers/medicaid/income_job_number_continued_controller.rb
@@ -5,7 +5,11 @@ module Medicaid
     private
 
     def skip?
-      current_application.number_of_jobs < 4
+      not_employed? || current_application.number_of_jobs < 4
+    end
+
+    def not_employed?
+      !current_application.employed?
     end
   end
 end

--- a/app/controllers/medicaid/insurance_needed_controller.rb
+++ b/app/controllers/medicaid/insurance_needed_controller.rb
@@ -8,6 +8,11 @@ module Medicaid
       single_member_household?
     end
 
+    def single_member_household?
+      current_application.members.empty? ||
+        current_application.members.count == 1
+    end
+
     def member_attrs
       %i[requesting_health_insurance]
     end

--- a/spec/controllers/medicaid/income_job_number_continued_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_continued_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Medicaid::IncomeJobNumberContinuedController do
         medicaid_application =
           create(
             :medicaid_application,
+            employed: true,
             number_of_jobs: 4,
           )
         session[:medicaid_application_id] = medicaid_application.id
@@ -25,11 +26,26 @@ RSpec.describe Medicaid::IncomeJobNumberContinuedController do
 
     context "client has fewer than 4 jobs" do
       it "redirects to the next page" do
-        medicaid_application =
-          create(
-            :medicaid_application,
-            number_of_jobs: 3,
-          )
+        medicaid_application = create(
+          :medicaid_application,
+          employed: true,
+          number_of_jobs: 3,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "client does not have a job" do
+      it "skips the step" do
+        medicaid_application = create(
+          :medicaid_application,
+          employed: false,
+          number_of_jobs: nil,
+        )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Medicaid app" do
-  scenario "with a single member", :js do
+  scenario "with maximum info", :js do
     visit medicaid_root_path
 
     within(".slab--hero") do
@@ -22,7 +22,7 @@ RSpec.feature "Medicaid app" do
       click_on "Next"
 
       expect(page).to have_content("Are you currently a college student?")
-      click_on "No"
+      click_on "Yes"
 
       expect(page).to have_content("Are you currently a US Citizen?")
       click_on "Yes"
@@ -32,7 +32,13 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "Are you currently enrolled in a health insurance plan?",
       )
-      click_on "No"
+      click_on "Yes"
+
+      expect(page).to have_content(
+        "What type of insurance plan are you currently enrolled in?",
+      )
+      choose "Other"
+      click_on "Next"
 
       expect(page).to have_content(
         "Do you need help paying for medical expenses from the last 3 months?",
@@ -42,10 +48,10 @@ RSpec.feature "Medicaid app" do
 
     on_pages "Quick Health Questions" do
       expect(page).to have_content("Do you have a disability?")
-      click_on "No"
+      click_on "Yes"
 
       expect(page).to have_content("Have you been pregnant recently?")
-      click_on "No"
+      click_on "Yes"
     end
 
     on_pages "Quick Tax Question" do
@@ -65,7 +71,7 @@ RSpec.feature "Medicaid app" do
       click_on "Next"
 
       expect(page).to have_content("Are you self-employed?")
-      click_on "No"
+      click_on "Yes"
 
       expect(page).to have_content("Do you get income that's not from a job?")
       click_on "Yes"
@@ -81,10 +87,10 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "Do you pay child support, alimony or arrears?",
       )
-      click_on "No"
+      click_on "Yes"
 
       expect(page).to have_content("Do you pay student loan interest?")
-      click_on "No"
+      click_on "Yes"
     end
 
     on_pages "Income & Expense Amounts" do
@@ -93,16 +99,21 @@ RSpec.feature "Medicaid app" do
       fill_in "Your Current Job (#1)", with: 100
       fill_in "Your Current Job (#2)", with: 50
       fill_in "Your Current Job (#3)", with: 25
+      fill_in "Your Self-Employment", with: 100
       fill_in "Your Unemployment", with: 100
       click_on "Next"
-    end
 
-    find(".icon-arrow_back").click
+      find(".icon-arrow_back").click
 
-    on_pages "Income & Expense Amounts" do
       expect(find("#step_employed_monthly_income_0").value).to eq "100"
       expect(find("#step_employed_monthly_income_1").value).to eq "50"
       expect(find("#step_employed_monthly_income_2").value).to eq "25"
+      click_on "Next"
+
+      expect(page).to have_content("College Loan Interest")
+      fill_in "Child Support, Alimony, or Arrears", with: 100
+      fill_in "College Loan Interest", with: 50
+      fill_in "Self Employment", with: 50
       click_on "Next"
     end
 
@@ -143,77 +154,5 @@ RSpec.feature "Medicaid app" do
     end
 
     expect(page).to have_content("Get the support your family needs")
-  end
-
-  scenario "with multiple members", :js do
-    visit medicaid_root_path
-
-    within(".slab--hero") do
-      click_on "Apply for Medicaid"
-    end
-
-    on_page "Introduction" do
-      click_on "Yes"
-    end
-
-    on_page "Introduction" do
-      fill_in "What is your first name?", with: "Jessie"
-      fill_in "What is your last name?", with: "Tester"
-      select_radio(question: "What is your gender?", answer: "Female")
-      click_on "Next"
-    end
-
-    on_page "Introduction" do
-      click_on "Add a member"
-    end
-
-    on_page "Introduction" do
-      fill_in "What is their first name?", with: "Christa"
-      fill_in "What is their last name?", with: "Tester"
-      select_radio(question: "What is their gender?", answer: "Female")
-      click_on "Next"
-    end
-
-    expect(page).to have_content("Jessie Tester")
-    expect(page).to have_content("Christa Tester")
-    click_on "Next"
-
-    on_page "Introduction" do
-      expect(page).to have_content("Is anyone currently a college student?")
-      click_on "Yes"
-    end
-
-    on_page "Introduction" do
-      expect(page).to have_content(
-        "Tell us who is currently a college student.",
-      )
-      check "Jessie Tester"
-      click_on "Next"
-    end
-
-    on_page "Introduction" do
-      expect(page).to have_content("Are you currently a US Citizen?")
-      click_on "Yes"
-    end
-
-    on_page "Health Coverage Needs" do
-      expect(page).to have_content(
-        "Who in your household needs healthcare coverage?",
-      )
-      uncheck "Jessie Tester"
-      uncheck "Christa Tester"
-      click_on "Next"
-    end
-
-    on_page "Health Coverage Needs" do
-      expect(page).to have_content("Make sure you select at least one person")
-      check "Jessie Tester"
-      check "Christa Tester"
-      click_on "Next"
-    end
-
-    expect(page).to have_content(
-      "Are you currently enrolled in a health insurance plan?",
-    )
   end
 end

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -1,0 +1,138 @@
+require "rails_helper"
+
+RSpec.feature "Medicaid app" do
+  scenario "with minimal info", :js do
+    visit medicaid_root_path
+
+    within(".slab--hero") do
+      click_on "Apply for Medicaid"
+    end
+
+    on_pages "Introduction" do
+      click_on "Yes"
+
+      fill_in "What is your first name?", with: "Jessie"
+      fill_in "What is your last name?", with: "Tester"
+      select_radio(question: "What is your gender?", answer: "Female")
+      click_on "Next"
+
+      expect(page).to have_content(
+        "Now tell us about any other people residing in your household.",
+      )
+      click_on "Next"
+
+      expect(page).to have_content("Are you currently a college student?")
+      click_on "No"
+
+      expect(page).to have_content("Are you currently a US Citizen?")
+      click_on "No"
+    end
+
+    on_pages "Health Coverage Needs" do
+      expect(page).to have_content(
+        "Are you currently enrolled in a health insurance plan?",
+      )
+      click_on "No"
+
+      expect(page).to have_content(
+        "Do you need help paying for medical expenses from the last 3 months?",
+      )
+      click_on "No"
+    end
+
+    on_pages "Quick Health Questions" do
+      expect(page).to have_content("Do you have a disability?")
+      click_on "No"
+
+      expect(page).to have_content("Have you been pregnant recently?")
+      click_on "No"
+    end
+
+    on_pages "Quick Tax Question" do
+      expect(page).to have_content(
+        "Do you plan on filing a federal tax return next year?",
+      )
+
+      click_on "No"
+    end
+
+    on_pages "Current Income" do
+      expect(page).to have_content("Do you currently have a job?")
+      click_on "No"
+
+      expect(page).to have_content("Are you self-employed?")
+      click_on "No"
+
+      expect(page).to have_content("Do you get income that's not from a job?")
+      click_on "No"
+    end
+
+    on_pages "Current Expenses" do
+      expect(page).to have_content(
+        "Do you pay child support, alimony or arrears?",
+      )
+      click_on "No"
+
+      expect(page).to have_content("Do you pay student loan interest?")
+      click_on "No"
+
+      expect(page).to have_content(
+        "Okay, thanks! Now describe your income and expenses.",
+      )
+      click_on "Next"
+    end
+
+    on_pages "Contact Information & Followup" do
+      expect(page).to have_content(
+        "Do you receive mail at your current residential address?",
+      )
+      click_on "No"
+
+      expect(page).to have_content(
+        "Is there somewhere we can reliably send you mail?",
+      )
+
+      click_on "No"
+
+      expect(page).to have_content(
+        "Are you currently homeless?",
+      )
+      click_on "No"
+
+      expect(page).to have_content(
+        "What is your residential address?",
+      )
+      fill_in "Street address", with: "123 Some St."
+      fill_in "City", with: "Flint"
+      fill_in "ZIP code", with: "48501"
+      click_on "Next"
+
+      expect(page).to have_content(
+        "What is the best number for you to receive phone calls?",
+      )
+      fill_in "Phone number", with: "8005550000"
+      click_on "Next"
+
+      expect(page).to have_content(
+        "What is the best number for you to receive text messages?",
+      )
+      click_on "Next"
+
+      expect(page).to have_content(
+        "What is the best email address at which to contact you?",
+      )
+      click_on "Next"
+
+      expect(page).to have_content(
+        "Provide your Social Security Number and Date of Birth if you're ready",
+      )
+      click_on "No"
+    end
+
+    on_page "Confirmation" do
+      click_on "No"
+    end
+
+    expect(page).to have_content("Get the support your family needs")
+  end
+end

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.feature "Medicaid app" do
+  scenario "with multiple members", :js do
+    visit medicaid_root_path
+
+    within(".slab--hero") do
+      click_on "Apply for Medicaid"
+    end
+
+    on_page "Introduction" do
+      click_on "Yes"
+    end
+
+    on_page "Introduction" do
+      fill_in "What is your first name?", with: "Jessie"
+      fill_in "What is your last name?", with: "Tester"
+      select_radio(question: "What is your gender?", answer: "Female")
+      click_on "Next"
+    end
+
+    on_page "Introduction" do
+      click_on "Add a member"
+    end
+
+    on_page "Introduction" do
+      fill_in "What is their first name?", with: "Christa"
+      fill_in "What is their last name?", with: "Tester"
+      select_radio(question: "What is their gender?", answer: "Female")
+      click_on "Next"
+    end
+
+    expect(page).to have_content("Jessie Tester")
+    expect(page).to have_content("Christa Tester")
+    click_on "Next"
+
+    on_page "Introduction" do
+      expect(page).to have_content("Is anyone currently a college student?")
+      click_on "Yes"
+    end
+
+    on_page "Introduction" do
+      expect(page).to have_content(
+        "Tell us who is currently a college student.",
+      )
+      check "Jessie Tester"
+      click_on "Next"
+    end
+
+    on_page "Introduction" do
+      expect(page).to have_content("Are you currently a US Citizen?")
+      click_on "Yes"
+    end
+
+    on_page "Health Coverage Needs" do
+      expect(page).to have_content(
+        "Who in your household needs healthcare coverage?",
+      )
+      uncheck "Jessie Tester"
+      uncheck "Christa Tester"
+      click_on "Next"
+    end
+
+    on_page "Health Coverage Needs" do
+      expect(page).to have_content("Make sure you select at least one person")
+      check "Jessie Tester"
+      check "Christa Tester"
+      click_on "Next"
+    end
+
+    expect(page).to have_content(
+      "Are you currently enrolled in a health insurance plan?",
+    )
+  end
+end


### PR DESCRIPTION
* Needed to update `skip` logic in `IncomeJobNumberContinuedController`
* This was not surfaced earlier due to insufficient testing, so took
this opportunity to reorganize and add more meat to our feature specs.

