### PR TITLE
Specify which members are in college for multi-member flow

### DIFF
--- a/app/controllers/medicaid/insurance_needed_controller.rb
+++ b/app/controllers/medicaid/insurance_needed_controller.rb
@@ -8,10 +8,6 @@ module Medicaid
       single_member_household?
     end
 
-    def single_member_household?
-      current_application.members.count == 1
-    end
-
     def member_attrs
       %i[requesting_health_insurance]
     end

--- a/app/controllers/medicaid/intro_college_controller.rb
+++ b/app/controllers/medicaid/intro_college_controller.rb
@@ -2,5 +2,19 @@
 
 module Medicaid
   class IntroCollegeController < MedicaidStepsController
+    def update
+      @step = step_class.new(step_params)
+
+      if @step.valid?
+        if current_application.members&.count == 1
+          current_application.primary_member.update!(in_college: true)
+        end
+
+        current_application.update!(step_params)
+        redirect_to(next_path)
+      else
+        render :edit
+      end
+    end
   end
 end

--- a/app/controllers/medicaid/intro_college_member_controller.rb
+++ b/app/controllers/medicaid/intro_college_member_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class IntroCollegeMemberController < Medicaid::ManyMemberStepsController
+    private
+
+    def skip?
+      single_member_household? || !current_application.anyone_in_college?
+    end
+
+    def member_attrs
+      %i[in_college]
+    end
+  end
+end

--- a/app/controllers/medicaid/many_member_steps_controller.rb
+++ b/app/controllers/medicaid/many_member_steps_controller.rb
@@ -41,5 +41,9 @@ module Medicaid
     def member_attrs
       raise NotImplementedError
     end
+
+    def single_member_household?
+      current_application.members.count == 1
+    end
   end
 end

--- a/app/steps/medicaid/intro_college.rb
+++ b/app/steps/medicaid/intro_college.rb
@@ -2,6 +2,6 @@
 
 module Medicaid
   class IntroCollege < Step
-    step_attributes(:college_student)
+    step_attributes(:anyone_in_college)
   end
 end

--- a/app/steps/medicaid/intro_college_member.rb
+++ b/app/steps/medicaid/intro_college_member.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class IntroCollegeMember < Step
+    step_attributes(
+      :in_college,
+      :members,
+    )
+
+    def valid?
+      if members.select(&:in_college?).any?
+        true
+      else
+        errors.add(
+          :in_college,
+            "Make sure you select at least one person",
+        )
+        false
+      end
+    end
+  end
+end

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -9,6 +9,7 @@ module Medicaid
         Medicaid::IntroNameController,
         Medicaid::IntroHouseholdController,
         Medicaid::IntroCollegeController,
+        Medicaid::IntroCollegeMemberController,
         Medicaid::IntroCitizenController,
         # multi-member Medicaid::IntroCaretakerController,
         # multi-member Medicaid::IntroCaretakerMemberController,

--- a/app/views/medicaid/intro_college/edit.html.erb
+++ b/app/views/medicaid/intro_college/edit.html.erb
@@ -2,11 +2,14 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Are you currently a college student?</div>
+    <div class="form-card__title">
+      <%= t("medicaid.intro_college.edit.title",
+            count: current_application.members.count) %>
+    </div>
     <p class="text--help text--centered">
       Students may be eligible for different health care coverage options than other adults.
     </p>
   </header>
 
-  <%= render 'shared/yes_no_form', step: @step, field: :college_student %>
+  <%= render 'shared/yes_no_form', step: @step, field: :anyone_in_college %>
 </div>

--- a/app/views/medicaid/intro_college_member/edit.html.erb
+++ b/app/views/medicaid/intro_college_member/edit.html.erb
@@ -1,0 +1,27 @@
+<% content_for :header_title, "Introduction" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Tell us who is currently a college student.
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+        <%= f.mb_form_errors :in_college %>
+        <fieldset class="form-group">
+          <% @step.members.each do |member| %>
+              <%= f.fields_for("members[]", member) do |ff| %>
+                  <%= ff.mb_checkbox(
+                          :in_college,
+                          member.full_name,
+                          { checked_value: "1", unchecked_value: "0" },
+                      ) %>
+              <% end %>
+          <% end %>
+        </fieldset>
+        <%= render "medicaid/next_step" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,3 +24,10 @@ en:
     exit_app_confirmation:
       Leaving the application process will clear your data from this computer.
       Are you sure you would like to exit?
+  medicaid:
+    intro_college:
+      edit:
+        title:
+          one: Are you currently a college student?
+          other: Is anyone currently a college student?
+

--- a/db/migrate/20171020000142_rename_college_student_to_anyone_in_college.rb
+++ b/db/migrate/20171020000142_rename_college_student_to_anyone_in_college.rb
@@ -1,0 +1,27 @@
+class RenameCollegeStudentToAnyoneInCollege < ActiveRecord::Migration[5.1]
+  def up
+    add_column :medicaid_applications, :anyone_in_college, :boolean
+
+    safety_assured do
+      execute <<~SQL
+        UPDATE medicaid_applications
+        SET anyone_in_college = college_student;
+      SQL
+
+      remove_column :medicaid_applications, :college_student
+    end
+  end
+
+  def down
+    add_column :medicaid_applications, :college_student, :boolean
+
+    safety_assured do
+      execute <<~SQL
+        UPDATE medicaid_applications
+        SET college_student = anyone_in_college;
+      SQL
+
+      remove_column :medicaid_applications, :anyone_in_college
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171019162840) do
+ActiveRecord::Schema.define(version: 20171020000142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,12 +85,12 @@ ActiveRecord::Schema.define(version: 20171019162840) do
   end
 
   create_table "medicaid_applications", force: :cascade do |t|
+    t.boolean "anyone_in_college"
     t.datetime "birthday"
     t.boolean "caretaker_or_parent"
     t.integer "child_support_alimony_arrears_expenses"
     t.boolean "citizen"
     t.integer "college_loan_interest_expenses"
-    t.boolean "college_student"
     t.datetime "created_at", null: false
     t.boolean "disabled"
     t.string "documents", default: [], array: true

--- a/spec/controllers/medicaid/amounts_income_controller_spec.rb
+++ b/spec/controllers/medicaid/amounts_income_controller_spec.rb
@@ -45,10 +45,8 @@ RSpec.describe Medicaid::AmountsIncomeController do
         )
         session[:medicaid_application_id] = medicaid_application.id
 
-        post :update, {
-          params: {
-            step: { employed_monthly_income: ["111", "222"] }
-          }
+        post :update, params: {
+          step: { employed_monthly_income: ["111", "222"] },
         }
 
         medicaid_application.reload

--- a/spec/controllers/medicaid/intro_college_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_college_controller_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IntroCollegeController do
+  describe "#update" do
+    context "single member household" do
+      it "updates the member" do
+        member = create(:member)
+
+        medicaid_application = create(
+          :medicaid_application,
+            members: [member],
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        put :update, params: { step: { anyone_in_college: true } }
+
+        member.reload
+
+        expect(member).to be_in_college
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/intro_college_member_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_college_member_controller_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IntroCollegeMemberController do
+  describe "#next_path" do
+    it "is the intro citizen path" do
+      expect(subject.next_path).to eq(
+        "/steps/medicaid/intro-citizen",
+      )
+    end
+
+    describe "#edit" do
+      context "single member household" do
+        it "redirects to the next page" do
+          medicaid_application = create(
+            :medicaid_application,
+            members: [create(:member)],
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to redirect_to(subject.next_path)
+        end
+      end
+
+      context "multi member household" do
+        it "renders edit" do
+          medicaid_application = create(
+            :medicaid_application,
+            anyone_in_college: true,
+            members: create_list(:member, 2),
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to render_template(:edit)
+        end
+
+        context "with noone in college" do
+          it "redirects to the next page" do
+            medicaid_application = create(
+              :medicaid_application,
+                anyone_in_college: false,
+                members: create_list(:member, 2),
+            )
+            session[:medicaid_application_id] = medicaid_application.id
+
+            get :edit
+
+            expect(response).to redirect_to(subject.next_path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/features/medicaid_spec.rb
+++ b/spec/features/medicaid_spec.rb
@@ -179,8 +179,16 @@ RSpec.feature "Medicaid app" do
     click_on "Next"
 
     on_page "Introduction" do
-      expect(page).to have_content("Are you currently a college student?")
-      click_on "No"
+      expect(page).to have_content("Is anyone currently a college student?")
+      click_on "Yes"
+    end
+
+    on_page "Introduction" do
+      expect(page).to have_content(
+        "Tell us who is currently a college student.",
+      )
+      check "Jessie Tester"
+      click_on "Next"
     end
 
     on_page "Introduction" do
@@ -190,8 +198,7 @@ RSpec.feature "Medicaid app" do
 
     on_page "Health Coverage Needs" do
       expect(page).to have_content(
-        "Who in your household needs healthcare coverage?
-",
+        "Who in your household needs healthcare coverage?",
       )
       uncheck "Jessie Tester"
       uncheck "Christa Tester"

--- a/spec/steps/medicaid/intro_college_member_spec.rb
+++ b/spec/steps/medicaid/intro_college_member_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IntroCollegeMember do
+  describe "Validations" do
+    context "at least one household member is a student" do
+      it "is valid" do
+        member = create(:member, in_college: true)
+        member_not_in_college =
+          create(:member, in_college: false)
+
+        step = Medicaid::IntroCollegeMember.new(
+          members: [member, member_not_in_college],
+        )
+
+        expect(step).to be_valid
+      end
+    end
+
+    context "no household member is a student" do
+      it "is invalid" do
+        members = create_list(:member, 2, in_college: false)
+
+        step = Medicaid::IntroCollegeMember.new(members: members)
+
+        expect(step).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Uses I18N for pluralization of page title for member college selection. If there is a single member, show "Are you currently a college student?" as title. Otherwise, show "Is anyone currently a college student?" as title.
* Changes 'college_student' field to 'anyone_in_college' on medicaid_application table
* On single-member, mark primary member as in_college after college intro screen

![screen shot 2017-10-19 at 5 41 28 pm](https://user-images.githubusercontent.com/3675092/31800296-cae37a76-b4f4-11e7-9ec3-a10ef6eba3dc.png)

![screen shot 2017-10-19 at 5 41 21 pm](https://user-images.githubusercontent.com/3675092/31800298-d0ae5a3e-b4f4-11e7-8ae9-8c8078eb50a9.png)
