### PR TITLE
Verify us citizenship across all household members

### DIFF
--- a/app/controllers/medicaid/citizens_controller.rb
+++ b/app/controllers/medicaid/citizens_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class CitizensController < Medicaid::ManyMemberStepsController
+    private
+
+    def skip?
+      everyone_a_citizen?
+    end
+
+    def member_attrs
+      %i[citizen]
+    end
+
+    def everyone_a_citizen?
+      current_application.citizen?
+    end
+  end
+end

--- a/app/controllers/medicaid/citizens_controller.rb
+++ b/app/controllers/medicaid/citizens_controller.rb
@@ -5,7 +5,8 @@ module Medicaid
     private
 
     def skip?
-      everyone_a_citizen?
+      everyone_a_citizen? ||
+        (single_member_not_a_citizen? && update_single_member)
     end
 
     def member_attrs
@@ -13,7 +14,23 @@ module Medicaid
     end
 
     def everyone_a_citizen?
-      current_application.citizen?
+      current_application.everyone_a_citizen?
+    end
+
+    def single_member_not_a_citizen?
+      single_member? && not_a_citizen?
+    end
+
+    def single_member?
+      current_application.members.count == 1
+    end
+
+    def not_a_citizen?
+      !current_application.everyone_a_citizen?
+    end
+
+    def update_single_member
+      current_application.primary_member.update(citizen: false)
     end
   end
 end

--- a/app/steps/many_members_step.rb
+++ b/app/steps/many_members_step.rb
@@ -11,4 +11,10 @@ class ManyMembersStep < Step
 
     members.map(&:errors).all?(&:blank?)
   end
+
+  private
+
+  def validate_household_member(_member)
+    raise NotImplementedError
+  end
 end

--- a/app/steps/medicaid/citizen.rb
+++ b/app/steps/medicaid/citizen.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class Citizen < ManyMembersStep
+    private
+
+    def validate_household_member(member)
+      # noop
+    end
+  end
+end

--- a/app/steps/medicaid/intro_citizen.rb
+++ b/app/steps/medicaid/intro_citizen.rb
@@ -2,6 +2,6 @@
 
 module Medicaid
   class IntroCitizen < Step
-    step_attributes(:citizen)
+    step_attributes(:everyone_a_citizen)
   end
 end

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -11,6 +11,7 @@ module Medicaid
         Medicaid::IntroCollegeController,
         Medicaid::IntroCollegeMemberController,
         Medicaid::IntroCitizenController,
+        Medicaid::CitizensController,
         # multi-member Medicaid::IntroCaretakerController,
         # multi-member Medicaid::IntroCaretakerMemberController,
       ],

--- a/app/views/medicaid/citizens/edit.html.erb
+++ b/app/views/medicaid/citizens/edit.html.erb
@@ -1,0 +1,28 @@
+<% content_for :header_title, "Introduction" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Tell us who in your household is not currently a US citizen.
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step,
+      as: :step,
+      builder: MbFormBuilder,
+      url: current_path,
+      method: :put do |f| %>
+
+      <fieldset class="form-group">
+        <% @step.members.each do |member| %>
+          <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
+            <%= ff.mb_checkbox :citizen, member.full_name %>
+          <% end %>
+        <% end %>
+      </fieldset>
+
+      <%= render 'medicaid/next_step' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/medicaid/intro_citizen/edit.html.erb
+++ b/app/views/medicaid/intro_citizen/edit.html.erb
@@ -3,7 +3,8 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      Is everyone in your household currently a US citizen?
+      <%= t("medicaid.intro_citizen.edit.title",
+         count: current_application.members.count) %>
     </div>
     <p class="text--help text--centered">
       You don't always have to be a citizen to receive benefits. If you are not
@@ -12,5 +13,5 @@
     </p>
   </header>
 
-  <%= render 'shared/yes_no_form', step: @step, field: :citizen %>
+  <%= render 'shared/yes_no_form', step: @step, field: :everyone_a_citizen %>
 </div>

--- a/app/views/medicaid/intro_citizen/edit.html.erb
+++ b/app/views/medicaid/intro_citizen/edit.html.erb
@@ -2,7 +2,9 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Are you currently a US Citizen?</div>
+    <div class="form-card__title">
+      Is everyone in your household currently a US citizen?
+    </div>
     <p class="text--help text--centered">
       You don't always have to be a citizen to receive benefits. If you are not
       a citizen, you'll be asked to provide paperwork about your immigration

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,11 @@ en:
         title:
           one: Are you currently a college student?
           other: Is anyone currently a college student?
+    intro_citizen:
+      edit:
+        title:
+          one: Are you currently a US citizen?
+          other: Is everyone in your household currently a US citizen?
     health_flint_water_crisis:
       edit:
         title:

--- a/db/migrate/20171024202046_rename_citizen_to_everyone_a_citizen.rb
+++ b/db/migrate/20171024202046_rename_citizen_to_everyone_a_citizen.rb
@@ -1,0 +1,19 @@
+class RenameCitizenToEveryoneACitizen < ActiveRecord::Migration[5.1]
+  def up
+    add_column :medicaid_applications, :everyone_a_citizen, :boolean
+
+    safety_assured do
+      execute "UPDATE medicaid_applications SET everyone_a_citizen=citizen"
+      remove_column :medicaid_applications, :citizen
+    end
+  end
+
+  def down
+    add_column :medicaid_applications, :citizen, :boolean
+
+    safety_assured do
+      execute "UPDATE medicaid_applications SET citizen=everyone_a_citizen"
+      remove_column :medicaid_applications, :everyone_a_citizen
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171024183517) do
+ActiveRecord::Schema.define(version: 20171024202046) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,7 +90,6 @@ ActiveRecord::Schema.define(version: 20171024183517) do
     t.datetime "birthday"
     t.boolean "caretaker_or_parent"
     t.integer "child_support_alimony_arrears_expenses"
-    t.boolean "citizen"
     t.integer "college_loan_interest_expenses"
     t.datetime "created_at", null: false
     t.boolean "disabled"
@@ -99,6 +98,7 @@ ActiveRecord::Schema.define(version: 20171024183517) do
     t.string "employed_monthly_income", default: [], array: true
     t.string "encrypted_ssn"
     t.string "encrypted_ssn_iv"
+    t.boolean "everyone_a_citizen"
     t.boolean "filing_federal_taxes_next_year"
     t.boolean "flint_water_crisis"
     t.boolean "homeless"

--- a/spec/controllers/medicaid/citizens_controller_spec.rb
+++ b/spec/controllers/medicaid/citizens_controller_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::CitizensController, type: :controller do
+  describe "#next_path" do
+    it "is the citizen selector page path" do
+      expect(subject.next_path).to eq "/steps/medicaid/insurance-needed"
+    end
+  end
+
+  describe "#edit" do
+    context "everyone in the home is a citizen" do
+      it "skips this page" do
+        medicaid_application =
+          create(
+            :medicaid_application,
+            citizen: true,
+          )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "someone in the home is not a use citizen" do
+      it "renders :edit" do
+        medicaid_application =
+          create(
+            :medicaid_application,
+            citizen: false,
+          )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/intro_citizen_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_citizen_controller_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IntroCitizenController, type: :controller do
+  describe "#next_path" do
+    it "is the citizen selector page path" do
+      expect(subject.next_path).to eq "/steps/medicaid/citizens"
+    end
+  end
+end

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -24,9 +24,7 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content("Are you currently a college student?")
       click_on "Yes"
 
-      expect(page).to have_content(
-        "Is everyone in your household currently a US citizen",
-      )
+      expect(page).to have_content("Are you currently a US citizen?")
       click_on "Yes"
     end
 

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -24,7 +24,9 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content("Are you currently a college student?")
       click_on "Yes"
 
-      expect(page).to have_content("Are you currently a US Citizen?")
+      expect(page).to have_content(
+        "Is everyone in your household currently a US citizen",
+      )
       click_on "Yes"
     end
 

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -25,9 +25,9 @@ RSpec.feature "Medicaid app" do
       click_on "No"
 
       expect(page).to have_content(
-        "Is everyone in your household currently a US citizen",
+        "Are you currently a US citizen",
       )
-      click_on "Yes"
+      click_on "No"
     end
 
     on_pages "Health Coverage Needs" do

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -24,8 +24,10 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content("Are you currently a college student?")
       click_on "No"
 
-      expect(page).to have_content("Are you currently a US Citizen?")
-      click_on "No"
+      expect(page).to have_content(
+        "Is everyone in your household currently a US citizen",
+      )
+      click_on "Yes"
     end
 
     on_pages "Health Coverage Needs" do

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -48,7 +48,9 @@ RSpec.feature "Medicaid app" do
     end
 
     on_page "Introduction" do
-      expect(page).to have_content("Are you currently a US Citizen?")
+      expect(page).to have_content(
+        "Is everyone in your household currently a US citizen",
+      )
       click_on "Yes"
     end
 

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -51,7 +51,15 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "Is everyone in your household currently a US citizen",
       )
-      click_on "Yes"
+      click_on "No"
+    end
+
+    on_page "Introduction" do
+      expect(page).to have_content(
+        "Tell us who in your household is not currently a US citizen",
+      )
+      check "Jessie Tester"
+      click_on "Next"
     end
 
     on_page "Health Coverage Needs" do


### PR DESCRIPTION
If the primary client answers that there is someone in the household that
is not a US citizen then they should be taken to a page that asks them
*who* is not a citizen.