### PR TITLE
Redirect to office-specific landing pages after SNAP submitted

### DIFF
--- a/app/controllers/skip_send_applications_controller.rb
+++ b/app/controllers/skip_send_applications_controller.rb
@@ -1,6 +1,8 @@
-class SkipSendApplicationsController < ApplicationController
+# frozen_string_literal: true
+
+class SkipSendApplicationsController < SnapStepsController
   def create
     flash[:notice] = "Your application has been submitted."
-    redirect_to root_path(anchor: "fold")
+    redirect_to after_submit_path
   end
 end

--- a/app/controllers/snap_steps_controller.rb
+++ b/app/controllers/snap_steps_controller.rb
@@ -22,4 +22,12 @@ class SnapStepsController < StepsController
   def step_navigation
     @step_navigation ||= StepNavigation.new(self)
   end
+
+  def after_submit_path
+    if current_application.office_location.present?
+      public_send("#{current_application.office_location}_path", anchor: "fold")
+    else
+      root_path(anchor: "fold")
+    end
+  end
 end

--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -6,7 +6,7 @@ class SuccessController < SnapStepsController
   end
 
   def next_path
-    root_path(anchor: "fold")
+    after_submit_path
   end
 
   private

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe SuccessController do
 
   describe "#update" do
     context "no office location" do
-      it "redirects" do
+      it "redirects to the home page" do
         params = { step: attributes }
 
         put :update, params: params

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -119,12 +119,25 @@ RSpec.describe SuccessController do
   end
 
   describe "#update" do
-    it "redirects" do
-      params = { step: attributes }
+    context "no office location" do
+      it "redirects" do
+        params = { step: attributes }
 
-      put :update, params: params
+        put :update, params: params
 
-      expect(response).to redirect_to(root_path(anchor: "fold"))
+        expect(response).to redirect_to(root_path(anchor: "fold"))
+      end
+    end
+
+    context "office location present" do
+      it "redirects to the office specific landing page" do
+        current_app.update(office_location: "union")
+        params = { step: attributes }
+
+        put :update, params: params
+
+        expect(response).to redirect_to(union_path(anchor: "fold"))
+      end
     end
 
     context "email entered" do


### PR DESCRIPTION
**WHY**: This is a better UX and will prevent people from re-applying
from the wrong page when testing the app when in offices.

