### PR TITLE
Set eager_load to false in dev mode

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -4,7 +4,7 @@ require Rails.root.join("config/smtp")
 
 Rails.application.configure do
   config.cache_classes = false
-  config.eager_load = true
+  config.eager_load = false
   config.consider_all_requests_local = true
 
   if Rails.root.join("tmp/caching-dev.txt").exist?


### PR DESCRIPTION
* We set this so we could see same setup as prod
* This leads to annoying occassional errors in dev mode
* Previous load issue is no longer around so we can safely go back to
`eager_load: false`, which is the Rails default