### PR TITLE
Add employed / job number steps for multi-member flow

### DIFF
--- a/app/controllers/medicaid/income_job_number_continued_controller.rb
+++ b/app/controllers/medicaid/income_job_number_continued_controller.rb
@@ -5,11 +5,17 @@ module Medicaid
     private
 
     def skip?
-      not_employed? || current_application.number_of_jobs < 4
+      multi_member_household? ||
+        not_employed? ||
+        current_application.number_of_jobs < 4
     end
 
     def not_employed?
       !current_application.employed?
+    end
+
+    def multi_member_household?
+      current_application.members.count != 1
     end
   end
 end

--- a/app/controllers/medicaid/income_job_number_continued_controller.rb
+++ b/app/controllers/medicaid/income_job_number_continued_controller.rb
@@ -13,9 +13,5 @@ module Medicaid
     def not_employed?
       !current_application.employed?
     end
-
-    def multi_member_household?
-      current_application.members.count != 1
-    end
   end
 end

--- a/app/controllers/medicaid/income_job_number_controller.rb
+++ b/app/controllers/medicaid/income_job_number_controller.rb
@@ -24,10 +24,6 @@ module Medicaid
       multi_member_household? || not_employed?
     end
 
-    def multi_member_household?
-      current_application.members.count != 1
-    end
-
     def not_employed?
       !current_application&.employed?
     end

--- a/app/controllers/medicaid/income_job_number_controller.rb
+++ b/app/controllers/medicaid/income_job_number_controller.rb
@@ -21,7 +21,11 @@ module Medicaid
     end
 
     def skip?
-      not_employed?
+      multi_member_household? || not_employed?
+    end
+
+    def multi_member_household?
+      current_application.members.count != 1
     end
 
     def not_employed?

--- a/app/controllers/medicaid/income_job_number_member_controller.rb
+++ b/app/controllers/medicaid/income_job_number_member_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class IncomeJobNumberMemberController < Medicaid::ManyMemberStepsController
+    private
+
+    def skip?
+      not_employed? || single_member_household?
+    end
+
+    def not_employed?
+      !current_application.employed?
+    end
+
+    def member_attrs
+      %i[employed_number_of_jobs]
+    end
+  end
+end

--- a/app/controllers/medicaid/insurance_needed_controller.rb
+++ b/app/controllers/medicaid/insurance_needed_controller.rb
@@ -8,11 +8,6 @@ module Medicaid
       single_member_household?
     end
 
-    def single_member_household?
-      current_application.members.empty? ||
-        current_application.members.count == 1
-    end
-
     def member_attrs
       %i[requesting_health_insurance]
     end

--- a/app/controllers/medicaid/many_member_steps_controller.rb
+++ b/app/controllers/medicaid/many_member_steps_controller.rb
@@ -41,9 +41,5 @@ module Medicaid
     def member_attrs
       raise NotImplementedError
     end
-
-    def single_member_household?
-      current_application.members.count == 1
-    end
   end
 end

--- a/app/controllers/medicaid_steps_controller.rb
+++ b/app/controllers/medicaid_steps_controller.rb
@@ -19,6 +19,14 @@ class MedicaidStepsController < StepsController
     session[:medicaid_application_id]
   end
 
+  def single_member_household?
+    current_application.members.count == 1
+  end
+
+  def multi_member_household?
+    current_application.members.count > 1
+  end
+
   def step_navigation
     @step_navigation ||= Medicaid::StepNavigation.new(self)
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -9,10 +9,16 @@ class Member < ApplicationRecord
     "Other",
   ].freeze
 
+  EMPLOYMENT_STATUSES = ["employed", "self_employed", "not_employed"].freeze
+
   belongs_to :benefit_application, polymorphic: true
 
   validates :employed_pay_interval,
     inclusion: { in: PAYMENT_INTERVALS },
+    allow_nil: true
+
+  validates :employment_status,
+    inclusion: { in: EMPLOYMENT_STATUSES },
     allow_nil: true
 
   attribute :ssn

--- a/app/steps/medicaid/income_job_number_member.rb
+++ b/app/steps/medicaid/income_job_number_member.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class IncomeJobNumberMember < Step
+    step_attributes(:members)
+  end
+end

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -33,6 +33,7 @@ module Medicaid
         Medicaid::IncomeJobController,
         Medicaid::IncomeJobNumberController,
         Medicaid::IncomeJobNumberContinuedController,
+        Medicaid::IncomeJobNumberMemberController,
         Medicaid::IncomeSelfEmploymentController,
         Medicaid::IncomeOtherIncomeController,
         Medicaid::IncomeOtherIncomeTypeController,

--- a/app/views/medicaid/income_job/edit.html.erb
+++ b/app/views/medicaid/income_job/edit.html.erb
@@ -2,7 +2,10 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Are you currently employed?</div>
+    <div class="form-card__title">
+      <%= t("medicaid.income_job.edit.title",
+        count: current_application.members.count) %>
+    </div>
     <p class="text--help text--centered">
       This includes full time, part time, and contract jobs. We'll ask you
       about the specific amounts you earn later

--- a/app/views/medicaid/income_job_number_member/_header.html.erb
+++ b/app/views/medicaid/income_job_number_member/_header.html.erb
@@ -1,0 +1,2 @@
+<div class="household-member-group" data-member-name="<%= member.full_name %>">
+  <p class="text--section-header"><%= member.full_name %></p>

--- a/app/views/medicaid/income_job_number_member/edit.html.erb
+++ b/app/views/medicaid/income_job_number_member/edit.html.erb
@@ -1,0 +1,25 @@
+<% content_for :header_title, "Current Income" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Tell us who in your household has one or more jobs.
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+      <% @step.members.each do |member| %>
+        <fieldset class="form-group">
+          <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
+            <%= render "header", member: member %>
+            <%= ff.mb_select :employed_number_of_jobs,
+              "",
+              (1..10).map { |number| [pluralize(number, "job"), number] },
+              include_blank: "0 jobs" %>
+          <% end %>
+        </fieldset>
+      <% end %>
+      <%= render "medicaid/next_step" %>
+    <% end %>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -15,4 +15,8 @@ en:
           one: Have you been affected by the Flint Water Crisis?
           other: Have you or someone in your household been affected by the
             Flint Water Crisis?
-
+    income_job:
+      edit:
+        title:
+          one: Do you currently have a job?
+          other: Does anyone in your household currently have a job?

--- a/db/migrate/20171024000703_add_number_of_jobs_to_members.rb
+++ b/db/migrate/20171024000703_add_number_of_jobs_to_members.rb
@@ -1,0 +1,23 @@
+class AddNumberOfJobsToMembers < ActiveRecord::Migration[5.1]
+  def up
+    add_column :members, :employed_number_of_jobs, :integer
+    add_column :members, :employed_monthly_income, :string, array: true
+    change_column_default :members, :employed_monthly_income, []
+
+    safety_assured do
+      execute <<~SQL
+        UPDATE members
+        SET employed_number_of_jobs=medicaid_applications.number_of_jobs, employment_status='employed', employed_monthly_income=medicaid_applications.employed_monthly_income
+        FROM medicaid_applications
+        WHERE members.benefit_application_type='MedicaidApplication'
+        AND members.benefit_application_id=medicaid_applications.id
+        AND medicaid_applications.employed = true;
+      SQL
+    end
+  end
+
+  def down
+    remove_column :members, :employed_number_of_jobs, :integer
+    remove_column :members, :employed_monthly_income, :string, array: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171023164005) do
+ActiveRecord::Schema.define(version: 20171024000703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -146,6 +146,8 @@ ActiveRecord::Schema.define(version: 20171023164005) do
     t.boolean "disabled"
     t.string "employed_employer_name"
     t.integer "employed_hours_per_week"
+    t.string "employed_monthly_income", default: [], array: true
+    t.integer "employed_number_of_jobs"
     t.string "employed_pay_interval"
     t.integer "employed_pay_quantity"
     t.string "employment_status"

--- a/spec/controllers/medicaid/income_expenses_job_number_controller_spec.rb
+++ b/spec/controllers/medicaid/income_expenses_job_number_controller_spec.rb
@@ -17,7 +17,11 @@ RSpec.describe Medicaid::IncomeJobNumberController do
 
     context "client is employed" do
       it "renders edit" do
-        medicaid_application = create(:medicaid_application, employed: true)
+        medicaid_application = create(
+          :medicaid_application,
+          :with_member,
+          employed: true,
+        )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit

--- a/spec/controllers/medicaid/income_job_number_continued_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_continued_spec.rb
@@ -3,54 +3,77 @@ require "rails_helper"
 RSpec.describe Medicaid::IncomeJobNumberContinuedController do
   describe "#next_path" do
     it "is the self employment page path" do
-      expect(subject.next_path).to eq "/steps/medicaid/income-self-employment"
+      expect(subject.next_path).to eq "/steps/medicaid/income-job-number-member"
     end
   end
 
   describe "#edit" do
-    context "client is has 4+ jobs" do
-      it "renders edit " do
+    context "medicaid app has multiple members" do
+      it "redirects to the next step" do
         medicaid_application =
           create(
             :medicaid_application,
+            :with_member,
+            employed: true,
+            members: create_list(:member, 2),
+          )
+
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "medicaid app has a single member" do
+      context "client is has 4+ jobs" do
+        it "renders edit" do
+          medicaid_application = create(
+            :medicaid_application,
+            :with_member,
             employed: true,
             number_of_jobs: 4,
           )
-        session[:medicaid_application_id] = medicaid_application.id
 
-        get :edit
+          session[:medicaid_application_id] = medicaid_application.id
 
-        expect(response).to render_template(:edit)
+          get :edit
+
+          expect(response).to render_template(:edit)
+        end
       end
-    end
 
-    context "client has fewer than 4 jobs" do
-      it "redirects to the next page" do
-        medicaid_application = create(
-          :medicaid_application,
-          employed: true,
-          number_of_jobs: 3,
-        )
-        session[:medicaid_application_id] = medicaid_application.id
+      context "client has fewer than 4 jobs" do
+        it "redirects to the next page" do
+          medicaid_application = create(
+            :medicaid_application,
+            :with_member,
+            employed: true,
+            number_of_jobs: 3,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
 
-        get :edit
+          get :edit
 
-        expect(response).to redirect_to(subject.next_path)
+          expect(response).to redirect_to(subject.next_path)
+        end
       end
-    end
 
-    context "client does not have a job" do
-      it "skips the step" do
-        medicaid_application = create(
-          :medicaid_application,
-          employed: false,
-          number_of_jobs: nil,
-        )
-        session[:medicaid_application_id] = medicaid_application.id
+      context "client does not have a job" do
+        it "skips the step" do
+          medicaid_application = create(
+            :medicaid_application,
+            :with_member,
+            employed: false,
+            number_of_jobs: nil,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
 
-        get :edit
+          get :edit
 
-        expect(response).to redirect_to(subject.next_path)
+          expect(response).to redirect_to(subject.next_path)
+        end
       end
     end
   end

--- a/spec/controllers/medicaid/income_job_number_controller_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_controller_spec.rb
@@ -10,50 +10,70 @@ RSpec.describe Medicaid::IncomeJobNumberController do
   end
 
   describe "#edit" do
-    context "client has 4 or more jobs" do
-      it "sets the job number to 4" do
-        medicaid_application = create(
-          :medicaid_application,
-          employed: true,
-          number_of_jobs: 5,
-        )
-        session[:medicaid_application_id] = medicaid_application.id
-
-        get :edit
-        step = assigns(:step)
-
-        expect(response).to render_template(:edit)
-        expect(step.number_of_jobs).to eq(4)
-      end
-    end
-
-    context "client is employed" do
-      it "renders edit " do
+    context "medicaid app has multiple members" do
+      it "redirects to the next step" do
         medicaid_application =
           create(
             :medicaid_application,
             employed: true,
+            members: create_list(:member, 2),
           )
-        session[:medicaid_application_id] = medicaid_application.id
 
-        get :edit
-
-        expect(response).to render_template(:edit)
-      end
-    end
-
-    context "client is unemployed" do
-      it "redirects to the next page" do
-        medicaid_application =
-          create(
-            :medicaid_application,
-            employed: false,
-          )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
 
         expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "medicaid app has a single member" do
+      context "client has 4 or more jobs" do
+        it "sets the job number to 4" do
+          medicaid_application = create(
+            :medicaid_application,
+            :with_member,
+            employed: true,
+            number_of_jobs: 5,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+          step = assigns(:step)
+
+          expect(response).to render_template(:edit)
+          expect(step.number_of_jobs).to eq(4)
+        end
+      end
+
+      context "client is employed" do
+        it "renders edit " do
+          medicaid_application = create(
+            :medicaid_application,
+            :with_member,
+            employed: true,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to render_template(:edit)
+        end
+      end
+
+      context "client is unemployed" do
+        it "redirects to the next page" do
+          medicaid_application = create(
+            :medicaid_application,
+            :with_member,
+            employed: false,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to redirect_to(subject.next_path)
+        end
       end
     end
   end

--- a/spec/controllers/medicaid/income_job_number_member_controller_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_member_controller_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IncomeJobNumberMemberController do
+  describe "#next_path" do
+    it "is the self employment page path" do
+      expect(subject.next_path).to eq(
+        "/steps/medicaid/income-self-employment",
+      )
+    end
+  end
+
+  describe "#edit" do
+    context "medicaid app has multiple members" do
+      context "medicaid app has employed members" do
+        it "renders edit" do
+          medicaid_application = create(
+            :medicaid_application,
+            employed: true,
+            members: create_list(:member, 2),
+          )
+
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to render_template(:edit)
+        end
+      end
+
+      context "medicaid app does not have emplpyed members" do
+        it "redirects to the next page" do
+          medicaid_application = create(
+            :medicaid_application,
+            employed: false,
+            members: create_list(:member, 2),
+          )
+
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to redirect_to(subject.next_path)
+        end
+      end
+    end
+
+    context "medicaid app has a single member" do
+      it "redirects to the next page" do
+        medicaid_application = create(
+          :medicaid_application,
+          members: [create(:member)],
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+  end
+end

--- a/spec/factories/medicaid_applications.rb
+++ b/spec/factories/medicaid_applications.rb
@@ -1,5 +1,11 @@
 FactoryGirl.define do
   factory :medicaid_application do
     michigan_resident true
+
+    trait :with_member do
+      after :create do |app|
+        create(:member, benefit_application: app)
+      end
+    end
   end
 end

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "Medicaid app" do
     end
 
     on_pages "Current Income" do
-      expect(page).to have_content("Are you currently employed?")
+      expect(page).to have_content("Do you currently have a job?")
       click_on "Yes"
 
       expect(page).to have_content("Tell us how many jobs you currently have.")

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -62,7 +62,7 @@ RSpec.feature "Medicaid app" do
     end
 
     on_pages "Current Income" do
-      expect(page).to have_content("Are you currently employed?")
+      expect(page).to have_content("Do you currently have a job?")
       click_on "No"
 
       expect(page).to have_content("Are you self-employed?")

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -94,6 +94,30 @@ RSpec.feature "Medicaid app" do
       click_on "Yes"
 
       expect(page).to have_content("We've noted this on your application.")
+      click_on "Next"
+    end
+
+    on_pages "Quick Tax Question" do
+      expect(page).to have_content(
+        "Do you plan on filing a federal tax return next year?",
+      )
+
+      click_on "Yes"
+    end
+
+    on_pages "Current Income" do
+      expect(page).to have_content(
+        "Does anyone in your household currently have a job?",
+      )
+      click_on "Yes"
+
+      expect(page).to have_content(
+        "Tell us who in your household has one or more jobs.",
+      )
+      select_job_number(full_name: "Christa Tester", job_number: "2 jobs")
+      click_on "Next"
+
+      expect(page).to have_content("Are you self-employed?")
     end
   end
 end

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -28,5 +28,11 @@ module FeatureHelper
     yield
   end
 
+  def select_job_number(full_name:, job_number:)
+    within(".household-member-group[data-member-name='#{full_name}']") do
+      select(job_number)
+    end
+  end
+
   alias on_pages on_page
 end


### PR DESCRIPTION

<img width="804" alt="screen shot 2017-10-23 at 5 34 53 pm" src="https://user-images.githubusercontent.com/601515/31920484-2a3e9d94-b81e-11e7-8059-15368e17b916.png">


* This is mostly complete but will required a follow up PR to:
- update employment_status, employed_job_number attrs on primary member when only one member present
- remove job_number field from medicaid_applicatiomns table
- rename `employed` on medicaid_applications, since that column is meant to indicate whether *anyone* is employed