### PR TITLE
Ch multi current insurance

### DIFF
--- a/app/controllers/medicaid/insurance_current_controller.rb
+++ b/app/controllers/medicaid/insurance_current_controller.rb
@@ -2,25 +2,16 @@
 
 module Medicaid
   class InsuranceCurrentController < MedicaidStepsController
-    def update
-      @step = step_class.new(step_params)
+    private
 
-      if @step.valid?
-        if single_member_household?
-          current_application.primary_member.update!(member_attrs)
-        end
-
-        current_application.update!(step_params)
-        redirect_to(next_path)
-      else
-        render :edit
+    def after_successful_update_hook
+      if single_member_household?
+        current_application.primary_member.update!(member_attrs)
       end
     end
 
-    private
-
     def member_attrs
-      { is_insured: step_params[:anyone_is_insured] }
+      { insured: step_params[:anyone_insured] }
     end
   end
 end

--- a/app/controllers/medicaid/insurance_current_controller.rb
+++ b/app/controllers/medicaid/insurance_current_controller.rb
@@ -2,5 +2,25 @@
 
 module Medicaid
   class InsuranceCurrentController < MedicaidStepsController
+    def update
+      @step = step_class.new(step_params)
+
+      if @step.valid?
+        if single_member_household?
+          current_application.primary_member.update!(member_attrs)
+        end
+
+        current_application.update!(step_params)
+        redirect_to(next_path)
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def member_attrs
+      { is_insured: step_params[:anyone_is_insured] }
+    end
   end
 end

--- a/app/controllers/medicaid/insurance_current_member_controller.rb
+++ b/app/controllers/medicaid/insurance_current_member_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class InsuranceCurrentMemberController < Medicaid::ManyMemberStepsController
+    private
+
+    def skip?
+      single_member_household? || current_application.nobody_insured?
+    end
+
+    def member_attrs
+      %i[is_insured]
+    end
+  end
+end

--- a/app/controllers/medicaid/insurance_current_member_controller.rb
+++ b/app/controllers/medicaid/insurance_current_member_controller.rb
@@ -9,7 +9,7 @@ module Medicaid
     end
 
     def member_attrs
-      %i[is_insured]
+      %i[insured]
     end
   end
 end

--- a/app/controllers/medicaid/insurance_current_type_controller.rb
+++ b/app/controllers/medicaid/insurance_current_type_controller.rb
@@ -5,10 +5,6 @@ module Medicaid
     private
 
     def skip?
-      not_insured?
-    end
-
-    def not_insured?
       current_application.nobody_insured?
     end
 

--- a/app/controllers/medicaid/insurance_current_type_controller.rb
+++ b/app/controllers/medicaid/insurance_current_type_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Medicaid
-  class InsuranceCurrentTypeController < MedicaidStepsController
+  class InsuranceCurrentTypeController < Medicaid::ManyMemberStepsController
     private
 
     def skip?
@@ -9,7 +9,11 @@ module Medicaid
     end
 
     def not_insured?
-      !current_application&.insured?
+      current_application.nobody_insured?
+    end
+
+    def member_attrs
+      %i[insurance_type]
     end
   end
 end

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -17,6 +17,10 @@ class MedicaidApplication < ApplicationRecord
     "Medicaid Application"
   end
 
+  def nobody_insured?
+    !anyone_is_insured?
+  end
+
   def primary_member
     members.order(:id).first || NullMember.new
   end

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -18,7 +18,7 @@ class MedicaidApplication < ApplicationRecord
   end
 
   def nobody_insured?
-    !anyone_is_insured?
+    !anyone_insured?
   end
 
   def primary_member

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -20,10 +20,22 @@ class Member < ApplicationRecord
     female
   ].freeze
 
+  INSURANCE_TYPES = [
+    "Medicaid",
+    "CHIP/MIChild",
+    "VA health care programs",
+    "Employer or individual plan",
+    "Other",
+  ].freeze
+
   belongs_to :benefit_application, polymorphic: true
 
   validates :employed_pay_interval,
     inclusion: { in: PAYMENT_INTERVALS },
+    allow_nil: true
+
+  validates :insurance_type,
+    inclusion: { in: INSURANCE_TYPES },
     allow_nil: true
 
   validates :employment_status,

--- a/app/steps/medicaid/insurance_current.rb
+++ b/app/steps/medicaid/insurance_current.rb
@@ -2,6 +2,6 @@
 
 module Medicaid
   class InsuranceCurrent < Step
-    step_attributes(:insured)
+    step_attributes(:anyone_is_insured)
   end
 end

--- a/app/steps/medicaid/insurance_current.rb
+++ b/app/steps/medicaid/insurance_current.rb
@@ -2,6 +2,6 @@
 
 module Medicaid
   class InsuranceCurrent < Step
-    step_attributes(:anyone_is_insured)
+    step_attributes(:anyone_insured)
   end
 end

--- a/app/steps/medicaid/insurance_current_member.rb
+++ b/app/steps/medicaid/insurance_current_member.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 module Medicaid
-  class InsuranceCurrentType < Step
+  class InsuranceCurrentMember < Step
     step_attributes(
-      :insurance_type,
+      :is_insured,
       :members,
     )
 
     def valid?
-      if members.select(&:insurance_type).any?
+      if members.select(&:is_insured).any?
         true
       else
         errors.add(
-          :insurance_type,
-          "Please select a plan",
+          :is_insured,
+          "Please select a member",
         )
         false
       end

--- a/app/steps/medicaid/insurance_current_member.rb
+++ b/app/steps/medicaid/insurance_current_member.rb
@@ -3,7 +3,7 @@
 module Medicaid
   class InsuranceCurrentMember < Step
     step_attributes(
-      :is_insured,
+      :insured,
       :members,
     )
 
@@ -16,11 +16,11 @@ module Medicaid
     end
 
     def valid?
-      if members_needing_insurance.select(&:is_insured).any?
+      if members_needing_insurance.select(&:insured).any?
         true
       else
         errors.add(
-          :is_insured,
+          :insured,
           "Please select a member",
         )
         false

--- a/app/steps/medicaid/insurance_current_member.rb
+++ b/app/steps/medicaid/insurance_current_member.rb
@@ -7,8 +7,16 @@ module Medicaid
       :members,
     )
 
+    def members_needing_insurance
+      members.select(&:requesting_health_insurance)
+    end
+
+    def members_not_needing_insurance
+      members.reject(&:requesting_health_insurance)
+    end
+
     def valid?
-      if members.select(&:is_insured).any?
+      if members_needing_insurance.select(&:is_insured).any?
         true
       else
         errors.add(

--- a/app/steps/medicaid/insurance_current_type.rb
+++ b/app/steps/medicaid/insurance_current_type.rb
@@ -7,12 +7,12 @@ module Medicaid
       :members,
     )
 
-    def insured_members
-      members.select(&:is_insured)
+    def insured_members_requesting_insurance
+      members.select(&:requesting_health_insurance).select(&:is_insured)
     end
 
     def valid?
-      if insured_members.all? { |m| m.insurance_type.present? }
+      if requesting_members_valid?
         true
       else
         errors.add(
@@ -25,8 +25,14 @@ module Medicaid
 
     private
 
+    def requesting_members_valid?
+      insured_members_requesting_insurance.all? do |m|
+        m.insurance_type.present?
+      end
+    end
+
     def error_message
-      if members.select(&:is_insured).count == 1
+      if insured_members_requesting_insurance.count == 1
         "Please select a plan"
       else
         "Please select a plan for each person"

--- a/app/steps/medicaid/insurance_current_type.rb
+++ b/app/steps/medicaid/insurance_current_type.rb
@@ -1,41 +1,26 @@
 # frozen_string_literal: true
 
 module Medicaid
-  class InsuranceCurrentType < Step
+  class InsuranceCurrentType < ManyMembersStep
     step_attributes(
       :insurance_type,
       :members,
     )
 
     def insured_members_requesting_insurance
-      members.select(&:requesting_health_insurance).select(&:is_insured)
-    end
-
-    def valid?
-      if requesting_members_valid?
-        true
-      else
-        errors.add(
-          :insurance_type,
-          error_message,
-        )
-        false
-      end
+      members.select(&:requesting_health_insurance).select(&:insured)
     end
 
     private
 
-    def requesting_members_valid?
-      insured_members_requesting_insurance.all? do |m|
-        m.insurance_type.present?
-      end
-    end
-
-    def error_message
-      if insured_members_requesting_insurance.count == 1
-        "Please select a plan"
-      else
-        "Please select a plan for each person"
+    def validate_household_member(member)
+      if member.requesting_health_insurance? && member.insured?
+        unless member.insurance_type.present?
+          member.errors.add(
+            :insurance_type,
+            "Please select a plan",
+          )
+        end
       end
     end
   end

--- a/app/steps/medicaid/insurance_current_type.rb
+++ b/app/steps/medicaid/insurance_current_type.rb
@@ -7,15 +7,29 @@ module Medicaid
       :members,
     )
 
+    def insured_members
+      members.select(&:is_insured)
+    end
+
     def valid?
-      if members.select(&:insurance_type).any?
+      if insured_members.all? { |m| m.insurance_type.present? }
         true
       else
         errors.add(
           :insurance_type,
-          "Please select a plan",
+          error_message,
         )
         false
+      end
+    end
+
+    private
+
+    def error_message
+      if members.select(&:is_insured).count == 1
+        "Please select a plan"
+      else
+        "Please select a plan for each person"
       end
     end
   end

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -18,6 +18,7 @@ module Medicaid
       "Insurance" => [
         Medicaid::InsuranceNeededController,
         Medicaid::InsuranceCurrentController,
+        Medicaid::InsuranceCurrentMemberController,
         Medicaid::InsuranceCurrentTypeController,
         Medicaid::InsuranceMedicalExpensesController,
       ],

--- a/app/views/medicaid/insurance_current/edit.html.erb
+++ b/app/views/medicaid/insurance_current/edit.html.erb
@@ -3,13 +3,14 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      Are you currently enrolled in a health insurance plan?
+      <%= t("medicaid.insurance_current.edit.title",
+            count: current_application.members.count) %>
     </div>
     <p class="text--help text--centered">
-      You may be eligible for dual enrollment, which can help cover additional
-      medical expenses.
+      <%= t("medicaid.insurance_current.edit.helper_text",
+            count: current_application.members.count) %>
     </p>
   </header>
 
-  <%= render 'shared/yes_no_form', step: @step, field: :insured %>
+  <%= render 'shared/yes_no_form', step: @step, field: :anyone_is_insured %>
 </div>

--- a/app/views/medicaid/insurance_current/edit.html.erb
+++ b/app/views/medicaid/insurance_current/edit.html.erb
@@ -12,5 +12,5 @@
     </p>
   </header>
 
-  <%= render 'shared/yes_no_form', step: @step, field: :anyone_is_insured %>
+  <%= render 'shared/yes_no_form', step: @step, field: :anyone_insured %>
 </div>

--- a/app/views/medicaid/insurance_current_member/edit.html.erb
+++ b/app/views/medicaid/insurance_current_member/edit.html.erb
@@ -7,24 +7,24 @@
     </div>
     <% if @step.members_not_needing_insurance.present? %>
       <p class="text--help text--centered">
-        You've already indicated that <%=@step.members_not_needing_insurance.map(&:full_name).to_sentence %>
-        <%= @step.members_not_needing_insurance.count == 1 ? "is" : "are" %>
-        not in need of additional health coverage.
+        <%= t("medicaid.insurance_current_member.edit.helper_text",
+              count: @step.members_not_needing_insurance.count,
+              names: @step.members_not_needing_insurance.map(&:full_name).to_sentence) %>
       </p>
     <% end %>
   </header>
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-        <%= f.mb_form_errors :is_insured %>
+        <%= f.mb_form_errors :insured %>
         <fieldset class="form-group">
           <% @step.members_needing_insurance.each do |member| %>
               <%= f.fields_for("members[]", member) do |ff| %>
-                  <%= ff.mb_checkbox(
-                          :is_insured,
-                          member.full_name,
-                          { checked_value: "1", unchecked_value: "0" },
-                      ) %>
+                <%= ff.mb_checkbox(
+                    :insured,
+                    member.full_name,
+                    { checked_value: "1", unchecked_value: "0" },
+                ) %>
               <% end %>
           <% end %>
         </fieldset>

--- a/app/views/medicaid/insurance_current_member/edit.html.erb
+++ b/app/views/medicaid/insurance_current_member/edit.html.erb
@@ -1,0 +1,27 @@
+<% content_for :header_title, "Health Coverage Needs" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Tell us who is currently enrolled in a health insurance plan.
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+        <%= f.mb_form_errors :is_insured %>
+        <fieldset class="form-group">
+          <% @step.members.each do |member| %>
+              <%= f.fields_for("members[]", member) do |ff| %>
+                  <%= ff.mb_checkbox(
+                          :is_insured,
+                          member.full_name,
+                          { checked_value: "1", unchecked_value: "0" },
+                      ) %>
+              <% end %>
+          <% end %>
+        </fieldset>
+        <%= render "medicaid/next_step" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/medicaid/insurance_current_member/edit.html.erb
+++ b/app/views/medicaid/insurance_current_member/edit.html.erb
@@ -5,13 +5,20 @@
     <div class="form-card__title">
       Tell us who is currently enrolled in a health insurance plan.
     </div>
+    <% if @step.members_not_needing_insurance.present? %>
+      <p class="text--help text--centered">
+        You've already indicated that <%=@step.members_not_needing_insurance.map(&:full_name).to_sentence %>
+        <%= @step.members_not_needing_insurance.count == 1 ? "is" : "are" %>
+        not in need of additional health coverage.
+      </p>
+    <% end %>
   </header>
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
         <%= f.mb_form_errors :is_insured %>
         <fieldset class="form-group">
-          <% @step.members.each do |member| %>
+          <% @step.members_needing_insurance.each do |member| %>
               <%= f.fields_for("members[]", member) do |ff| %>
                   <%= ff.mb_checkbox(
                           :is_insured,

--- a/app/views/medicaid/insurance_current_type/edit.html.erb
+++ b/app/views/medicaid/insurance_current_type/edit.html.erb
@@ -2,21 +2,28 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">What type of insurance plan are you currently enrolled in?</div>
+    <div class="form-card__title">
+      <%= t("medicaid.insurance_current_type.edit.title",
+            count: current_application.members.count) %>
+    </div>
   </header>
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_radio_set :insurance_type,
-        '',
-        [
-          { value: "Medicaid", label: "Medicaid" },
-          { value: "CHIP/MIChild", label: "CHIP/MIChild" },
-          { value: "VA health care programs", label: "VA health care programs" },
-          { value: "Employer or individual plan", label: "Policy through an employer or individual plan" },
-          { value: "Other", label: "Other" },
-        ] %>
-
+        <% @step.members.each do |member| %>
+            <%= f.fields_for("members[]", member) do |ff| %>
+              <%= ff.mb_form_errors :insurance_type %>
+              <%= ff.mb_radio_set :insurance_type,
+                member.full_name,
+                [
+                  { value: "Medicaid", label: "Medicaid" },
+                  { value: "CHIP/MIChild", label: "CHIP/MIChild" },
+                  { value: "VA health care programs", label: "VA health care programs" },
+                  { value: "Employer or individual plan", label: "Policy through an employer or individual plan" },
+                  { value: "Other", label: "Other" },
+                ] %>
+            <% end %>
+        <% end %>
       <%= render "medicaid/next_step" %>
     <% end %>
   </div>

--- a/app/views/medicaid/insurance_current_type/edit.html.erb
+++ b/app/views/medicaid/insurance_current_type/edit.html.erb
@@ -10,7 +10,6 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-        <%= f.mb_form_errors :insurance_type %>
         <% @step.insured_members_requesting_insurance.each do |member| %>
             <%= f.fields_for("members[]", member) do |ff| %>
               <%= ff.mb_radio_set :insurance_type,

--- a/app/views/medicaid/insurance_current_type/edit.html.erb
+++ b/app/views/medicaid/insurance_current_type/edit.html.erb
@@ -11,7 +11,7 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
         <%= f.mb_form_errors :insurance_type %>
-        <% @step.insured_members.each do |member| %>
+        <% @step.insured_members_requesting_insurance.each do |member| %>
             <%= f.fields_for("members[]", member) do |ff| %>
               <%= ff.mb_radio_set :insurance_type,
                 member.full_name,

--- a/app/views/medicaid/insurance_current_type/edit.html.erb
+++ b/app/views/medicaid/insurance_current_type/edit.html.erb
@@ -10,9 +10,9 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-        <% @step.members.each do |member| %>
+        <%= f.mb_form_errors :insurance_type %>
+        <% @step.insured_members.each do |member| %>
             <%= f.fields_for("members[]", member) do |ff| %>
-              <%= ff.mb_form_errors :insurance_type %>
               <%= ff.mb_radio_set :insurance_type,
                 member.full_name,
                 [

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,9 +53,13 @@ en:
         helper_text:
           one: You may be eligible for dual enrollment, which can help cover additional medical expenses.
           other: They may be eligible for dual enrollment, which can help cover additional medical expenses.
+    insurance_current_member:
+      edit:
+        helper_text:
+          one: You've already indicated that %{names} is not in need of additional health coverage.
+          other: You've already indicated that %{names} are not in need of additional health coverage.
     insurance_current_type:
       edit:
         title:
           one: What type of insurance plan are you currently enrolled in?
           other: Tell us what insurance plan each person is enrolled in.
-

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -45,3 +45,17 @@ en:
         title:
           one: Do you have a disability?
           other: Does anyone in your household have a disability?
+    insurance_current:
+      edit:
+        title:
+          one: Are you currently enrolled in a health insurance plan?
+          other: Is anyone currently enrolled in a health insurance plan?
+        helper_text:
+          one: You may be eligible for dual enrollment, which can help cover additional medical expenses.
+          other: They may be eligible for dual enrollment, which can help cover additional medical expenses.
+    insurance_current_type:
+      edit:
+        title:
+          one: What type of insurance plan are you currently enrolled in?
+          other: Tell us what insurance plan each person is enrolled in.
+

--- a/db/migrate/20171020215318_move_insurance_info_to_member.rb
+++ b/db/migrate/20171020215318_move_insurance_info_to_member.rb
@@ -1,0 +1,65 @@
+class MoveInsuranceInfoToMember < ActiveRecord::Migration[5.1]
+  def up
+    add_column :members, :is_insured, :boolean
+    add_column :members, :insurance_type, :string
+    add_column :medicaid_applications, :anyone_is_insured, :boolean
+
+    safety_assured do
+      execute <<~SQL
+        UPDATE medicaid_applications SET anyone_is_insured=insured;
+
+        UPDATE members
+        SET
+          is_insured=medicaid_applications.insured,
+          insurance_type=medicaid_applications.insurance_type
+        FROM (
+          SELECT
+            min(id) as id, benefit_application_id
+          FROM
+            members
+          WHERE
+            benefit_application_type = 'MedicaidApplication'
+          GROUP BY benefit_application_id
+        )
+        AS primary_medicaid_members
+        JOIN medicaid_applications
+        ON benefit_application_id = medicaid_applications.id
+        WHERE members.id = primary_medicaid_members.id;
+      SQL
+
+      remove_column :medicaid_applications, :insured
+      remove_column :medicaid_applications, :insurance_type
+    end
+  end
+
+  def down
+    add_column :medicaid_applications, :insured, :boolean
+    add_column :medicaid_applications, :insurance_type, :string
+
+    safety_assured do
+      execute <<~SQL
+        UPDATE medicaid_applications SET insured=anyone_is_insured;
+
+        UPDATE medicaid_applications
+        SET
+          insured=primary_medicaid_members.is_insured,
+          insurance_type=primary_medicaid_members.insurance_type
+        FROM (
+          SELECT
+            min(id) as id, benefit_application_id, is_insured, insurance_type
+          FROM
+            members
+          WHERE
+            benefit_application_type = 'MedicaidApplication'
+          GROUP BY benefit_application_id, is_insured, insurance_type
+        )
+        AS primary_medicaid_members
+        WHERE medicaid_applications.id = primary_medicaid_members.benefit_application_id;
+      SQL
+
+      remove_column :members, :is_insured
+      remove_column :members, :insurance_type
+      remove_column :medicaid_applications, :anyone_is_insured
+    end
+  end
+end

--- a/db/migrate/20171025233008_rename_anyone_is_insured.rb
+++ b/db/migrate/20171025233008_rename_anyone_is_insured.rb
@@ -1,0 +1,29 @@
+class RenameAnyoneIsInsured < ActiveRecord::Migration[5.1]
+  def up
+    add_column :medicaid_applications, :anyone_insured, :boolean
+    add_column :members, :insured, :boolean
+    change_column_default :medicaid_applications, :anyone_insured, false
+    change_column_default :members, :insured, false
+
+    safety_assured do
+      execute "UPDATE medicaid_applications SET anyone_insured=anyone_is_insured"
+      execute "UPDATE members SET insured=is_insured"
+      remove_column :medicaid_applications, :anyone_is_insured
+      remove_column :members, :is_insured
+    end
+  end
+
+  def down
+    add_column :medicaid_applications, :anyone_is_insured, :boolean
+    add_column :members, :is_insured, :boolean
+    change_column_default :medicaid_applications, :anyone_is_insured, false
+    change_column_default :members, :is_insured, false
+
+    safety_assured do
+      execute "UPDATE medicaid_applications SET anyone_is_insured=anyone_insured"
+      execute "UPDATE members SET is_insured=insured"
+      remove_column :medicaid_applications, :anyone_insured
+      remove_column :members, :insured
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -91,6 +91,7 @@ ActiveRecord::Schema.define(version: 20171026150119) do
     t.boolean "anyone_new_mom"
     t.boolean "anyone_other_income", default: false
     t.boolean "anyone_self_employed", default: false
+    t.boolean "anyone_is_insured"
     t.datetime "birthday"
     t.boolean "caretaker_or_parent"
     t.integer "child_support_alimony_arrears_expenses"
@@ -110,8 +111,6 @@ ActiveRecord::Schema.define(version: 20171026150119) do
     t.boolean "income_retirement"
     t.boolean "income_social_security"
     t.boolean "income_unemployment"
-    t.string "insurance_type"
-    t.boolean "insured"
     t.boolean "mail_sent_to_residential"
     t.string "mailing_city"
     t.string "mailing_street_address"
@@ -155,6 +154,8 @@ ActiveRecord::Schema.define(version: 20171026150119) do
     t.string "encrypted_ssn_iv"
     t.string "first_name"
     t.boolean "in_college"
+    t.string "insurance_type"
+    t.boolean "is_insured"
     t.string "last_name"
     t.boolean "living_elsewhere"
     t.string "marital_status"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -88,10 +88,10 @@ ActiveRecord::Schema.define(version: 20171026150119) do
     t.boolean "anyone_disabled"
     t.boolean "anyone_employed"
     t.boolean "anyone_in_college"
+    t.boolean "anyone_insured", default: false
     t.boolean "anyone_new_mom"
     t.boolean "anyone_other_income", default: false
     t.boolean "anyone_self_employed", default: false
-    t.boolean "anyone_is_insured"
     t.datetime "birthday"
     t.boolean "caretaker_or_parent"
     t.integer "child_support_alimony_arrears_expenses"
@@ -155,7 +155,7 @@ ActiveRecord::Schema.define(version: 20171026150119) do
     t.string "first_name"
     t.boolean "in_college"
     t.string "insurance_type"
-    t.boolean "is_insured"
+    t.boolean "insured", default: false
     t.string "last_name"
     t.boolean "living_elsewhere"
     t.string "marital_status"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -279,3 +279,42 @@ medicaid_primary.update!(
 
 puts "Minimal medicaid application created (or found) " \
   "with id: #{medicaid_application.id}"
+
+puts "Creating a more complete medicaid application..."
+
+complete_medicaid_application = MedicaidApplication.find_or_initialize_by(
+  email: "medicaid.application2@example.com",
+)
+complete_medicaid_application.update!(
+  michigan_resident: true,
+  anyone_is_insured: true,
+)
+
+complete_medicaid_primary = Member.find_or_initialize_by(
+  benefit_application: medicaid_application,
+  first_name: "CompleteMedicaid",
+  last_name: "TestPerson",
+  sex: "female",
+)
+
+complete_medicaid_primary.update!(
+  is_insured: true,
+  insurance_type: "VA health care programs",
+)
+
+complete_medicaid_secondary = Member.find_or_initialize_by(
+  benefit_application: medicaid_application,
+  first_name: "CompleteMedicaid2",
+  last_name: "TestPerson",
+  sex: "male",
+)
+
+complete_medicaid_application.update!(
+  members: [
+    complete_medicaid_primary,
+    complete_medicaid_secondary,
+  ],
+)
+
+puts "A more complete medicaid application created (or found) " \
+  "with id: #{complete_medicaid_application.id}"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -287,7 +287,7 @@ complete_medicaid_application = MedicaidApplication.find_or_initialize_by(
 )
 complete_medicaid_application.update!(
   michigan_resident: true,
-  anyone_is_insured: true,
+  anyone_insured: true,
 )
 
 complete_medicaid_primary = Member.find_or_initialize_by(
@@ -298,7 +298,7 @@ complete_medicaid_primary = Member.find_or_initialize_by(
 )
 
 complete_medicaid_primary.update!(
-  is_insured: true,
+  insured: true,
   insurance_type: "VA health care programs",
 )
 

--- a/spec/controllers/medicaid/insurance_current_controller_spec.rb
+++ b/spec/controllers/medicaid/insurance_current_controller_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::InsuranceCurrentController do
+  describe "#update" do
+    context "single member household" do
+      context "anyone is insured" do
+        it "updates the member" do
+          member = create(:member)
+
+          medicaid_application = create(
+            :medicaid_application,
+            members: [member],
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          put :update, params: { step: { anyone_is_insured: true } }
+
+          member.reload
+
+          expect(member.is_insured?).to eq(true)
+        end
+      end
+
+      context "nobody insured" do
+        it "updates the member" do
+          member = create(:member)
+
+          medicaid_application = create(
+            :medicaid_application,
+            members: [member],
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          put :update, params: { step: { anyone_is_insured: false } }
+
+          member.reload
+
+          expect(member.is_insured?).to eq(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/insurance_current_controller_spec.rb
+++ b/spec/controllers/medicaid/insurance_current_controller_spec.rb
@@ -13,11 +13,11 @@ RSpec.describe Medicaid::InsuranceCurrentController do
           )
           session[:medicaid_application_id] = medicaid_application.id
 
-          put :update, params: { step: { anyone_is_insured: true } }
+          put :update, params: { step: { anyone_insured: true } }
 
           member.reload
 
-          expect(member.is_insured?).to eq(true)
+          expect(member).to be_insured
         end
       end
 
@@ -31,11 +31,11 @@ RSpec.describe Medicaid::InsuranceCurrentController do
           )
           session[:medicaid_application_id] = medicaid_application.id
 
-          put :update, params: { step: { anyone_is_insured: false } }
+          put :update, params: { step: { anyone_insured: false } }
 
           member.reload
 
-          expect(member.is_insured?).to eq(false)
+          expect(member).to_not be_insured
         end
       end
     end

--- a/spec/controllers/medicaid/insurance_current_type_controller_spec.rb
+++ b/spec/controllers/medicaid/insurance_current_type_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Medicaid::InsuranceCurrentTypeController do
     context "client is insured" do
       it "does not redirect" do
         medicaid_application = create(:medicaid_application,
-                                      anyone_is_insured: true,
+                                      anyone_insured: true,
                                       members: [create(:member)])
         session[:medicaid_application_id] = medicaid_application.id
 
@@ -18,7 +18,7 @@ RSpec.describe Medicaid::InsuranceCurrentTypeController do
     context "client is not insured" do
       it "redirects to next step" do
         medicaid_application = create(:medicaid_application,
-                                      anyone_is_insured: false,
+                                      anyone_insured: false,
                                       members: [create(:member)])
         session[:medicaid_application_id] = medicaid_application.id
 

--- a/spec/controllers/medicaid/insurance_current_type_controller_spec.rb
+++ b/spec/controllers/medicaid/insurance_current_type_controller_spec.rb
@@ -4,7 +4,9 @@ RSpec.describe Medicaid::InsuranceCurrentTypeController do
   describe "#edit" do
     context "client is insured" do
       it "does not redirect" do
-        medicaid_application = create(:medicaid_application, insured: true)
+        medicaid_application = create(:medicaid_application,
+                                      anyone_is_insured: true,
+                                      members: [create(:member)])
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
@@ -15,7 +17,9 @@ RSpec.describe Medicaid::InsuranceCurrentTypeController do
 
     context "client is not insured" do
       it "redirects to next step" do
-        medicaid_application = create(:medicaid_application, insured: false)
+        medicaid_application = create(:medicaid_application,
+                                      anyone_is_insured: false,
+                                      members: [create(:member)])
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -111,7 +111,7 @@ RSpec.feature "Medicaid app" do
       fill_in "Your Unemployment", with: 100
       click_on "Next"
 
-      find(".icon-arrow_back").click
+      click_back
 
       expect(find("#step_employed_monthly_income_0").value).to eq "100"
       expect(find("#step_employed_monthly_income_1").value).to eq "50"

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -110,9 +110,7 @@ RSpec.feature "Medicaid app" do
         " additional health coverage.",
       )
       click_on "Next"
-    end
 
-    on_page "Health Coverage Needs" do
       expect(page).to have_content("Please select a member")
       check "Jessie Tester"
       click_on "Next"
@@ -126,9 +124,7 @@ RSpec.feature "Medicaid app" do
       expect(page).not_to have_content("Christa Tester")
       expect(page).to have_content("Jessie Tester")
       click_on "Next"
-    end
 
-    on_page "Health Coverage Needs" do
       expect(page).to have_content("Please select a plan")
       click_back
     end
@@ -150,7 +146,7 @@ RSpec.feature "Medicaid app" do
     end
 
     on_page "Health Coverage Needs" do
-      expect(page).to have_content("Please select a plan for each person")
+      expect(page).to have_content("Please select a plan")
       select_radio(question: "Jessie Tester", answer: "Medicaid")
       select_radio(question: "Christa Tester", answer: "Other")
       click_on "Next"

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -126,29 +126,8 @@ RSpec.feature "Medicaid app" do
       click_on "Next"
 
       expect(page).to have_content("Please select a plan")
-      click_back
-    end
 
-    on_page "Health Coverage Needs" do
-      expect(page).to have_content(
-        "Tell us who is currently enrolled in a health insurance plan.",
-      )
-      check "Jessie Tester"
-      check "Christa Tester"
-      click_on "Next"
-    end
-
-    on_page "Health Coverage Needs" do
-      expect(page).to have_content(
-        "Tell us what insurance plan each person is enrolled in.",
-      )
-      click_on "Next"
-    end
-
-    on_page "Health Coverage Needs" do
-      expect(page).to have_content("Please select a plan")
       select_radio(question: "Jessie Tester", answer: "Medicaid")
-      select_radio(question: "Christa Tester", answer: "Other")
       click_on "Next"
     end
 

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -30,8 +30,20 @@ RSpec.feature "Medicaid app" do
       click_on "Next"
     end
 
+    on_page "Introduction" do
+      click_on "Add a member"
+    end
+
+    on_page "Introduction" do
+      fill_in "What is their first name?", with: "Joel"
+      fill_in "What is their last name?", with: "Tester"
+      select_radio(question: "What is their gender?", answer: "Male")
+      click_on "Next"
+    end
+
     expect(page).to have_content("Jessie Tester")
     expect(page).to have_content("Christa Tester")
+    expect(page).to have_content("Joel Tester")
     click_on "Next"
 
     on_page "Introduction" do
@@ -68,6 +80,7 @@ RSpec.feature "Medicaid app" do
       )
       uncheck "Jessie Tester"
       uncheck "Christa Tester"
+      uncheck "Joel Tester"
       click_on "Next"
     end
 
@@ -75,6 +88,7 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content("Make sure you select at least one person")
       check "Jessie Tester"
       check "Christa Tester"
+      uncheck "Joel Tester"
       click_on "Next"
     end
 
@@ -89,6 +103,12 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "Tell us who is currently enrolled in a health insurance plan.",
       )
+      expect(page).to have_content("Jessie Tester")
+      expect(page).to have_content("Christa Tester")
+      expect(page).to have_content(
+        "You've already indicated that Joel Tester is not in need of" \
+        " additional health coverage.",
+      )
       click_on "Next"
     end
 
@@ -102,7 +122,9 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "Tell us what insurance plan each person is enrolled in.",
       )
+      expect(page).not_to have_content("Joel Tester")
       expect(page).not_to have_content("Christa Tester")
+      expect(page).to have_content("Jessie Tester")
       click_on "Next"
     end
 

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -89,6 +89,11 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "Tell us who is currently enrolled in a health insurance plan.",
       )
+      click_on "Next"
+    end
+
+    on_page "Health Coverage Needs" do
+      expect(page).to have_content("Please select a member")
       check "Jessie Tester"
       click_on "Next"
     end
@@ -97,7 +102,35 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "Tell us what insurance plan each person is enrolled in.",
       )
+      expect(page).not_to have_content("Christa Tester")
+      click_on "Next"
+    end
+
+    on_page "Health Coverage Needs" do
+      expect(page).to have_content("Please select a plan")
+      click_back
+    end
+
+    on_page "Health Coverage Needs" do
+      expect(page).to have_content(
+        "Tell us who is currently enrolled in a health insurance plan.",
+      )
+      check "Jessie Tester"
+      check "Christa Tester"
+      click_on "Next"
+    end
+
+    on_page "Health Coverage Needs" do
+      expect(page).to have_content(
+        "Tell us what insurance plan each person is enrolled in.",
+      )
+      click_on "Next"
+    end
+
+    on_page "Health Coverage Needs" do
+      expect(page).to have_content("Please select a plan for each person")
       select_radio(question: "Jessie Tester", answer: "Medicaid")
+      select_radio(question: "Christa Tester", answer: "Other")
       click_on "Next"
     end
 

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -80,16 +80,34 @@ RSpec.feature "Medicaid app" do
 
     on_pages "Health Coverage Needs" do
       expect(page).to have_content(
-        "Are you currently enrolled in a health insurance plan?",
+        "Is anyone currently enrolled in a health insurance plan?",
       )
       click_on "Yes"
+    end
 
+    on_page "Health Coverage Needs" do
       expect(page).to have_content(
-        "What type of insurance plan are you currently enrolled in?",
+        "Tell us who is currently enrolled in a health insurance plan.",
       )
-      choose "Other"
+      check "Jessie Tester"
       click_on "Next"
+    end
 
+    on_page "Health Coverage Needs" do
+      expect(page).to have_content(
+        "Tell us what insurance plan each person is enrolled in.",
+      )
+      select_radio(question: "Jessie Tester", answer: "Medicaid")
+      click_on "Next"
+    end
+
+    on_page "Health Coverage Needs" do
+      expect(page).to have_content(
+        "Do you need help paying for medical expenses from the last 3 months?",
+      )
+    end
+
+    on_pages "Health Coverage Needs" do
       expect(page).to have_content(
         "Do you need help paying for medical expenses from the last 3 months?",
       )

--- a/spec/steps/medicaid/insurance_current_member_spec.rb
+++ b/spec/steps/medicaid/insurance_current_member_spec.rb
@@ -4,9 +4,12 @@ RSpec.describe Medicaid::InsuranceCurrentMember do
   describe "Validations" do
     context "at least one household member is insured" do
       it "is valid" do
-        member = create(:member, is_insured: true)
-        member_not_insured =
-          create(:member, is_insured: false)
+        member = create(:member,
+                        requesting_health_insurance: true,
+                        insured: true)
+        member_not_insured = create(:member,
+                                    requesting_health_insurance: true,
+                                    insured: false)
 
         step = Medicaid::InsuranceCurrentMember.new(
           members: [member, member_not_insured],
@@ -18,7 +21,9 @@ RSpec.describe Medicaid::InsuranceCurrentMember do
 
     context "no household member is insured" do
       it "is invalid" do
-        members = create_list(:member, 2, is_insured: false)
+        members = create_list(:member, 2,
+                              requesting_health_insurance: true,
+                              insured: false)
 
         step = Medicaid::InsuranceCurrentMember.new(members: members)
 

--- a/spec/steps/medicaid/insurance_current_member_spec.rb
+++ b/spec/steps/medicaid/insurance_current_member_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::InsuranceCurrentMember do
+  describe "Validations" do
+    context "at least one household member is insured" do
+      it "is valid" do
+        member = create(:member, is_insured: true)
+        member_not_insured =
+          create(:member, is_insured: false)
+
+        step = Medicaid::InsuranceCurrentMember.new(
+          members: [member, member_not_insured],
+        )
+
+        expect(step).to be_valid
+      end
+    end
+
+    context "no household member is insured" do
+      it "is invalid" do
+        members = create_list(:member, 2, is_insured: false)
+
+        step = Medicaid::InsuranceCurrentMember.new(members: members)
+
+        expect(step).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/steps/medicaid/insurance_current_type_spec.rb
+++ b/spec/steps/medicaid/insurance_current_type_spec.rb
@@ -5,15 +5,26 @@ RSpec.describe Medicaid::InsuranceCurrentType do
     context "each insured household member has an insurance type" do
       it "is valid" do
         member = create(:member,
-                        is_insured: true,
-                        insurance_type: "Medicaid")
+                        insured: true,
+                        insurance_type: "Medicaid",
+                        requesting_health_insurance: true)
 
         member_without_insurance = create(:member,
-                                          is_insured: false,
+                                          insured: false,
+                                          insurance_type: nil,
+                                          requesting_health_insurance: true)
+
+        member_not_requesting_insurance = create(:member,
+                                          requesting_health_insurance: false,
+                                          insured: true,
                                           insurance_type: nil)
 
         step = Medicaid::InsuranceCurrentType.new(
-          members: [member, member_without_insurance],
+          members: [
+            member,
+            member_without_insurance,
+            member_not_requesting_insurance,
+          ],
         )
 
         expect(step).to be_valid
@@ -23,12 +34,14 @@ RSpec.describe Medicaid::InsuranceCurrentType do
     context "an insured household member is missing an insurance type" do
       it "is invalid" do
         member = create(:member,
-                        is_insured: true,
-                        insurance_type: "Medicaid")
+                        insured: true,
+                        insurance_type: "Medicaid",
+                        requesting_health_insurance: true)
 
         insured_member_without_type = create(:member,
-                                             is_insured: true,
-                                             insurance_type: nil)
+                                             insured: true,
+                                             insurance_type: nil,
+                                             requesting_health_insurance: true)
 
         step = Medicaid::InsuranceCurrentType.new(
           members: [member, insured_member_without_type],
@@ -43,15 +56,15 @@ RSpec.describe Medicaid::InsuranceCurrentType do
     context "with insured members needing insurance" do
       it "returns only insured members needing insurance" do
         insured_member = create(:member,
-                                is_insured: true,
+                                insured: true,
                                 requesting_health_insurance: true)
 
         abstaining_member = create(:member,
-                                   is_insured: true,
+                                   insured: true,
                                    requesting_health_insurance: false)
 
         uninsured_member = create(:member,
-                                  is_insured: false,
+                                  insured: false,
                                   requesting_health_insurance: true)
 
         step = Medicaid::InsuranceCurrentType.new(
@@ -71,11 +84,11 @@ RSpec.describe Medicaid::InsuranceCurrentType do
     context "with insured members not needing insurance" do
       it "returns an empty array" do
         insured_member = create(:member,
-                                is_insured: true,
+                                insured: true,
                                 requesting_health_insurance: false)
 
         uninsured_member = create(:member,
-                                  is_insured: false,
+                                  insured: false,
                                   requesting_health_insurance: true)
 
         step = Medicaid::InsuranceCurrentType.new(
@@ -90,7 +103,7 @@ RSpec.describe Medicaid::InsuranceCurrentType do
       it "returns an empty array" do
         step = Medicaid::InsuranceCurrentType.new(
           members: create_list(:member, 2,
-                               is_insured: false,
+                               insured: false,
                                requesting_health_insurance: true),
         )
 

--- a/spec/steps/medicaid/insurance_current_type_spec.rb
+++ b/spec/steps/medicaid/insurance_current_type_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::InsuranceCurrentType do
+  describe "Validations" do
+    context "at least one household member has an insurance type" do
+      it "is valid" do
+        member = create(:member, insurance_type: "Medicaid")
+        member_without_insurance =
+          create(:member, insurance_type: nil)
+
+        step = Medicaid::InsuranceCurrentType.new(
+          members: [member, member_without_insurance],
+        )
+
+        expect(step).to be_valid
+      end
+    end
+
+    context "no household member has an insurance type" do
+      it "is invalid" do
+        members = create_list(:member, 2, insurance_type: nil)
+
+        step = Medicaid::InsuranceCurrentType.new(members: members)
+
+        expect(step).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/steps/medicaid/insurance_current_type_spec.rb
+++ b/spec/steps/medicaid/insurance_current_type_spec.rb
@@ -2,11 +2,15 @@ require "rails_helper"
 
 RSpec.describe Medicaid::InsuranceCurrentType do
   describe "Validations" do
-    context "at least one household member has an insurance type" do
+    context "each insured household member has an insurance type" do
       it "is valid" do
-        member = create(:member, insurance_type: "Medicaid")
-        member_without_insurance =
-          create(:member, insurance_type: nil)
+        member = create(:member,
+                        is_insured: true,
+                        insurance_type: "Medicaid")
+
+        member_without_insurance = create(:member,
+                                          is_insured: false,
+                                          insurance_type: nil)
 
         step = Medicaid::InsuranceCurrentType.new(
           members: [member, member_without_insurance],
@@ -16,13 +20,46 @@ RSpec.describe Medicaid::InsuranceCurrentType do
       end
     end
 
-    context "no household member has an insurance type" do
+    context "an insured household member is missing an insurance type" do
       it "is invalid" do
-        members = create_list(:member, 2, insurance_type: nil)
+        member = create(:member,
+                        is_insured: true,
+                        insurance_type: "Medicaid")
 
-        step = Medicaid::InsuranceCurrentType.new(members: members)
+        insured_member_without_type = create(:member,
+                                             is_insured: true,
+                                             insurance_type: nil)
+
+        step = Medicaid::InsuranceCurrentType.new(
+          members: [member, insured_member_without_type],
+        )
 
         expect(step).not_to be_valid
+      end
+    end
+  end
+
+  describe "#insured_members" do
+    context "with insured members" do
+      it "returns all insured" do
+        insured_member = create(:member, is_insured: true)
+        uninsured_member = create(:member, is_insured: false)
+
+        step = Medicaid::InsuranceCurrentType.new(
+          members: [insured_member, uninsured_member],
+        )
+
+        expect(step.insured_members).to eq([insured_member])
+      end
+    end
+
+    context "without insured members" do
+      it "returns an empty array" do
+        step = Medicaid::InsuranceCurrentType.new(
+          members: create_list(:member, 2, is_insured: false),
+        )
+
+        expect(step.insured_members).to eq([])
       end
     end
   end

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -34,5 +34,11 @@ module FeatureHelper
     end
   end
 
+  def click_back
+    within(".step-header") do
+      find(".icon-arrow_back").click
+    end
+  end
+
   alias on_pages on_page
 end


### PR DESCRIPTION
Add a multi-member flow for entering information about additional insurance.

This PR ended up being a big one, and I'd love input! I used a lot of the patterns we used before, but kept the insurance type selection in one controller (rather than splitting for single member and multi member). This might be something to refactor—there's a good amount of view logic and some potentially off language for the single-member flow as a result. But, wanted to get this up for review!

Here are the changes, with expected behavior:

**/steps/medicaid/insurance-current**
Asks whether any household members seeking insurance are currently insured 

If single-member, updates `anyone_is_insured` accordingly on primary member.
If multi-member, continues to page to select who is insured.

**/steps/medicaid/insurance-current-member**
Asks who is currently insured. Only shows people seeking insurance.
Shows error if no members are selected.

**/steps/medicaid/insurance-current-type**
For each person requesting insurance with a current insurance plan, asks which kind of insurance they have. The form is currently all on one page (iterate over the eligible members), which we'll want to change going forward—see note below.

And here are some behind-the-scenes changes:
* Moves `insurance_type` and copies `insured` as `is_insured` from `medicaid_applications` to `members` table
* Renames `insured` to `anyone_is_insured` on `medicaid_applications`

![screen shot 2017-10-24 at 6 14 38 pm](https://user-images.githubusercontent.com/3675092/31975607-52bbf338-b8e7-11e7-955f-89616bb09f29.png)

![screen shot 2017-10-24 at 6 14 45 pm](https://user-images.githubusercontent.com/3675092/31975610-5967e0de-b8e7-11e7-99f6-075feb612f24.png)

![screen shot 2017-10-24 at 6 22 04 pm](https://user-images.githubusercontent.com/3675092/31975784-5f8fba94-b8e8-11e7-8526-ccc26596b571.png)


![screen shot 2017-10-24 at 6 14 59 pm](https://user-images.githubusercontent.com/3675092/31975621-6919c948-b8e7-11e7-8d5a-caad00b79ed1.png)

![screen shot 2017-10-24 at 6 15 04 pm](https://user-images.githubusercontent.com/3675092/31975623-6bec8660-b8e7-11e7-8863-aa0ffa274453.png)

Because this ticket was already fairly big, I punted on breaking the healthcare plan selection into one page per member, which was requested by design. As a result, we'll still need to break out selecting healthcare for multiple members to individual pages, rather than having all members listed on one like it is now (`steps/medicaid/insurance-current-type`). I added a separate ticket for this in Trello: https://trello.com/c/NnQdaKae/434-medicaid-mm-flow-health-coverage-needs-what-type-of-plan-is-member-enrolled-in

