### PR TITLE
FactoryGirl is no more. FactoryBot is here.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ group :development, :test do
   gem "climate_control"
   gem "codeclimate-test-reporter"
   gem "dotenv-rails" # useful for when running dev server w/o foreman
-  gem "factory_girl_rails"
+  gem "factory_bot_rails"
   gem "listen"
   gem "mailcatcher", "~> 0.2"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,10 +128,10 @@ GEM
     erubi (1.6.1)
     eventmachine (1.0.9.1)
     execjs (2.7.0)
-    factory_girl (4.8.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.8.0)
-      factory_girl (~> 4.8.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
@@ -410,7 +410,7 @@ DEPENDENCIES
   delayed_job_active_record
   delayed_job_web
   dotenv-rails
-  factory_girl_rails
+  factory_bot_rails
   faraday
   good_migrations
   high_voltage

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :address do
     street_address "123 Main St."
     city "Flint"

--- a/spec/factories/driver_application.rb
+++ b/spec/factories/driver_application.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :driver_application do
     user_id "JohnDoe"
     password "password"

--- a/spec/factories/driver_errors.rb
+++ b/spec/factories/driver_errors.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :driver_error do
     error_class "RuntimeError"
     error_message "runtime error"

--- a/spec/factories/exports.rb
+++ b/spec/factories/exports.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :export do
     snap_application
 

--- a/spec/factories/medicaid_applications.rb
+++ b/spec/factories/medicaid_applications.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :medicaid_application do
     michigan_resident true
 

--- a/spec/factories/member.rb
+++ b/spec/factories/member.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :member do
     first_name "Lilly"
     last_name "Pad"

--- a/spec/factories/snap_applications.rb
+++ b/spec/factories/snap_applications.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :snap_application do
     email "test@example.com"
     signature "Mr. RJD2"

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     name "Test user"
     password "12345678"

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -168,33 +168,33 @@ RSpec.describe SnapApplication do
   describe "#faxed?" do
     context "when no fax attempts have been made" do
       it "returns false" do
-        snap_application = FactoryGirl.create(:snap_application)
+        snap_application = create(:snap_application)
         expect(snap_application).to_not be_faxed
       end
     end
 
     context "when a failed fax attempt has been made" do
       it "returns false" do
-        snap_application = FactoryGirl.create(:snap_application,
-          exports: [FactoryGirl.create(:export, :faxed, :failed)])
+        snap_application = create(:snap_application,
+          exports: [create(:export, :faxed, :failed)])
         expect(snap_application).to_not be_faxed
       end
     end
 
     context "when a successful fax attempt has been made" do
       it "returns true" do
-        snap_application = FactoryGirl.create(:snap_application,
-          exports: [FactoryGirl.create(:export, :faxed, :succeeded)])
+        snap_application = create(:snap_application,
+          exports: [create(:export, :faxed, :succeeded)])
         expect(snap_application).to be_faxed
       end
     end
 
     context "when several fax attempts have led to mixed results" do
       it "returns true" do
-        snap_application = FactoryGirl.create(:snap_application,
-          exports: [FactoryGirl.create(:export, :faxed, :failed),
-                    FactoryGirl.create(:export, :faxed, :succeeded),
-                    FactoryGirl.create(:export, :faxed, :failed)])
+        snap_application = create(:snap_application,
+          exports: [create(:export, :faxed, :failed),
+                    create(:export, :faxed, :succeeded),
+                    create(:export, :faxed, :failed)])
         expect(snap_application).to be_faxed
       end
     end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-end


### PR DESCRIPTION
The folks at thoughtbot have made the name switch from `girl` to `bot`.

  https://robots.thoughtbot.com/factory_bot

Moving forward, all versions of the gem will continue with the new name.

(Editorial note: I, for one, welcome the change. If this made even one
person uncomfortable, let alone many, then the name needs changing)