### PR TITLE
Add benefit label label to header

### DIFF
--- a/app/assets/stylesheets/atoms/_variables.scss
+++ b/app/assets/stylesheets/atoms/_variables.scss
@@ -38,7 +38,7 @@ $color-yellow:        #ffc61e;
 $color-bright-yellow: #ff0;
 $color-light-sky:     lighten($color-sky, 50%);
 $color-dark-sky:      shade($color-sky, 15%);
-
+$color-darkest-sky:      shade($color-sky, 30%);
 
 // Breakpoints
 $mobile-up:           481px;

--- a/app/assets/stylesheets/michigan-benefits/organisms/_step-header.scss
+++ b/app/assets/stylesheets/michigan-benefits/organisms/_step-header.scss
@@ -36,12 +36,27 @@
   }
 
   &__title {
+    @include margin(0 0 0 10px);
+    flex: 1;
     font-size: $font-size-small;
-    margin: 0;
-    margin-left: 10px;
+    text-align: left;
   }
 
   &__title--centered {
     justify-content: center;
+  }
+
+  &__benefit-label {
+    @include margin(0 $padding-med 0 0);
+    display: none;
+    font-size: $font-size-smallest;
+
+    @include media($mobile-up) {
+      display: flex;
+    }
+
+    @include media($tablet-up) {
+      font-size: $font-size-small;
+    }
   }
 }

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -13,6 +13,10 @@ class MedicaidApplication < ApplicationRecord
     Medicaid::StepNavigation
   end
 
+  def application_title
+    "Medicaid Application"
+  end
+
   def primary_member
     members.order(:id).first || NullMember.new
   end

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -58,6 +58,10 @@ class SnapApplication < ApplicationRecord
     StepNavigation
   end
 
+  def application_title
+    "Food Assistance Application"
+  end
+
   def exportable?
     signature.present?
   end

--- a/app/views/layouts/step.html.erb
+++ b/app/views/layouts/step.html.erb
@@ -10,6 +10,9 @@
     <h4 class="step-header__title">
       <%= content_for :header_title %>
     </h4>
+    <h4 class="step-header__benefit-label">
+      Food Assistance Application
+    </h4>
   </div>
   <%= render 'shared/debug' %>
   <%= yield %>

--- a/app/views/layouts/step.html.erb
+++ b/app/views/layouts/step.html.erb
@@ -11,7 +11,7 @@
       <%= content_for :header_title %>
     </h4>
     <h4 class="step-header__benefit-label">
-      Food Assistance Application
+      <%= current_application&.application_title %>
     </h4>
   </div>
   <%= render 'shared/debug' %>

--- a/db/migrate/20171025184755_add_employed_as_boolean_to_medicaid.rb
+++ b/db/migrate/20171025184755_add_employed_as_boolean_to_medicaid.rb
@@ -9,5 +9,4 @@ class AddEmployedAsBooleanToMedicaid < ActiveRecord::Migration[5.1]
       remove_column :members, :employed
     end
   end
-
 end


### PR DESCRIPTION
* Add "Medicaid" or "Food Assistant Application" to header
* Visual reminder for users coming from `/dual-index` on which application they are completing. 

Note to engineers: The label content will need to change based on the application.

![image](https://user-images.githubusercontent.com/7483074/32013074-298812b8-b977-11e7-9f43-cb466d0e5d8d.png)

![image](https://user-images.githubusercontent.com/7483074/32013112-3fd99b4a-b977-11e7-8459-7fa9ddd58333.png)
