### PR TITLE
Add self-employed multi-member flow for Medicaid

### DIFF
--- a/app/controllers/medicaid/amounts_expenses_controller.rb
+++ b/app/controllers/medicaid/amounts_expenses_controller.rb
@@ -15,7 +15,7 @@ module Medicaid
     end
 
     def no_self_employment?
-      !current_application&.self_employed?
+      !current_application&.anyone_self_employed?
     end
 
     def no_child_support_alimony_arrears?

--- a/app/controllers/medicaid/amounts_income_controller.rb
+++ b/app/controllers/medicaid/amounts_income_controller.rb
@@ -38,7 +38,7 @@ module Medicaid
     end
 
     def not_self_employed?
-      !current_application&.self_employed?
+      !current_application&.anyone_self_employed?
     end
 
     def not_receiving_unemployment?

--- a/app/controllers/medicaid/income_self_employment_controller.rb
+++ b/app/controllers/medicaid/income_self_employment_controller.rb
@@ -2,5 +2,25 @@
 
 module Medicaid
   class IncomeSelfEmploymentController < MedicaidStepsController
+    def update
+      @step = step_class.new(step_params)
+
+      if @step.valid?
+        if single_member_household?
+          current_application.primary_member.update!(member_attrs)
+        end
+
+        current_application.update!(step_params)
+        redirect_to(next_path)
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def member_attrs
+      { self_employed: step_params[:anyone_self_employed] }
+    end
   end
 end

--- a/app/controllers/medicaid/income_self_employment_member_controller.rb
+++ b/app/controllers/medicaid/income_self_employment_member_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class IncomeSelfEmploymentMemberController <
+      Medicaid::ManyMemberStepsController
+
+    private
+
+    def skip?
+      single_member_household? || !current_application.anyone_self_employed?
+    end
+
+    def member_attrs
+      %i[self_employed]
+    end
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -49,7 +49,7 @@ class Member < ApplicationRecord
   end
 
   def monthly_income
-    if self_employed?
+    if employment_status == "self_employed"
       self_employed_monthly_income
     elsif employed?
       employed_monthly_income
@@ -60,10 +60,6 @@ class Member < ApplicationRecord
 
   def employed?
     employment_status == "employed"
-  end
-
-  def self_employed?
-    employment_status == "self_employed"
   end
 
   def not_employed?

--- a/app/steps/medicaid/income_self_employment.rb
+++ b/app/steps/medicaid/income_self_employment.rb
@@ -2,6 +2,6 @@
 
 module Medicaid
   class IncomeSelfEmployment < Step
-    step_attributes(:self_employed)
+    step_attributes(:anyone_self_employed)
   end
 end

--- a/app/steps/medicaid/income_self_employment_member.rb
+++ b/app/steps/medicaid/income_self_employment_member.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class IncomeSelfEmploymentMember < Step
+    step_attributes(:members)
+
+    def valid?
+      if members.select(&:self_employed).any?
+        true
+      else
+        errors.add(:self_employed, "Make sure you select at least one person")
+        false
+      end
+    end
+  end
+end

--- a/app/steps/medicaid/intro_college_member.rb
+++ b/app/steps/medicaid/intro_college_member.rb
@@ -11,10 +11,7 @@ module Medicaid
       if members.select(&:in_college?).any?
         true
       else
-        errors.add(
-          :in_college,
-            "Make sure you select at least one person",
-        )
+        errors.add(:in_college, "Make sure you select at least one person")
         false
       end
     end

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -37,6 +37,7 @@ module Medicaid
         Medicaid::IncomeJobNumberContinuedController,
         Medicaid::IncomeJobNumberMemberController,
         Medicaid::IncomeSelfEmploymentController,
+        Medicaid::IncomeSelfEmploymentMemberController,
         Medicaid::IncomeOtherIncomeController,
         Medicaid::IncomeOtherIncomeTypeController,
       ],

--- a/app/views/income_details_per_member/edit.html.erb
+++ b/app/views/income_details_per_member/edit.html.erb
@@ -28,7 +28,7 @@
                   "How often are you paid that amount?",
                   Member::PAYMENT_INTERVALS,
                   { layout: "inline", optional: true } %>
-              <% elsif member.self_employed? %>
+              <% elsif member.employment_status == "self_employed" %>
                 <%= render "header", member: member %>
                 <%= ff.mb_input_field :self_employed_profession,
                     "Type of work",

--- a/app/views/medicaid/amounts_expenses/edit.html.erb
+++ b/app/views/medicaid/amounts_expenses/edit.html.erb
@@ -17,8 +17,7 @@
           "College Loan Interest (average monthly expense)" %>
       <% end %>
 
-      <% if current_application.self_employed? %>
-        <%= f.hidden_field :self_employed %>
+      <% if current_application.anyone_self_employed? %>
         <%= f.mb_money_field :self_employment_expenses,
           "Self Employment (average monthly expense)",
           notes: ["If you have no self-employment expenses, please indicate that by entering 0"] %>

--- a/app/views/medicaid/amounts_income/edit.html.erb
+++ b/app/views/medicaid/amounts_income/edit.html.erb
@@ -22,7 +22,7 @@
         <% end %>
       <% end %>
 
-      <% if current_application.self_employed? %>
+      <% if current_application.anyone_self_employed? %>
         <%= f.mb_money_field :self_employed_monthly_income,
           "Your Self-Employment (average monthly income)" %>
       <% end %>

--- a/app/views/medicaid/income_self_employment/edit.html.erb
+++ b/app/views/medicaid/income_self_employment/edit.html.erb
@@ -2,12 +2,15 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Are you self-employed?</div>
+    <div class="form-card__title">
+      <%= t("medicaid.income_self_employment.edit.title",
+        count: current_application.members.count) %>
+    </div>
     <p class="text--help text--centered">
       You're self employed if you own your own business or perform odd jobs.
       We'll ask you about the specific amounts you earn later.
     </p>
   </header>
 
-  <%= render "shared/yes_no_form", step: @step, field: :self_employed %>
+  <%= render "shared/yes_no_form", step: @step, field: :anyone_self_employed %>
 </div>

--- a/app/views/medicaid/income_self_employment_member/edit.html.erb
+++ b/app/views/medicaid/income_self_employment_member/edit.html.erb
@@ -1,0 +1,27 @@
+<% content_for :header_title, "Current Income" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Tell us who in the household self-employed.
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+        <%= f.mb_form_errors :self_employed %>
+        <fieldset class="form-group">
+          <% @step.members.each do |member| %>
+              <%= f.fields_for("members[]", member) do |ff| %>
+                  <%= ff.mb_checkbox(
+                          :self_employed,
+                          member.full_name,
+                          { checked_value: "1", unchecked_value: "0" },
+                      ) %>
+              <% end %>
+          <% end %>
+        </fieldset>
+        <%= render "medicaid/next_step" %>
+    <% end %>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,3 +30,8 @@ en:
         title:
           one: Do you currently have a job?
           other: Does anyone in your household currently have a job?
+    income_self_employment:
+      edit:
+        title:
+          one: Are you self-employed?
+          other: Is anyone in the household self-employed?

--- a/db/migrate/20171025170306_add_self_employed_to_members.rb
+++ b/db/migrate/20171025170306_add_self_employed_to_members.rb
@@ -1,0 +1,11 @@
+class AddSelfEmployedToMembers < ActiveRecord::Migration[5.1]
+  def up
+    add_column :members, :self_employed, :boolean
+    change_column_default :members, :self_employed, false
+    commit_db_transaction
+  end
+
+  def down
+    remove_column :members, :self_employed
+  end
+end

--- a/db/migrate/20171025173052_rename_self_employed_to_anyone_self_employed_on_medicaid_applications.rb
+++ b/db/migrate/20171025173052_rename_self_employed_to_anyone_self_employed_on_medicaid_applications.rb
@@ -1,0 +1,21 @@
+class RenameSelfEmployedToAnyoneSelfEmployedOnMedicaidApplications < ActiveRecord::Migration[5.1]
+  def up
+    add_column :medicaid_applications, :anyone_self_employed, :boolean
+    change_column_default :medicaid_applications, :anyone_self_employed, false
+    commit_db_transaction
+
+    safety_assured do
+      execute "UPDATE medicaid_applications SET anyone_self_employed=self_employed"
+      remove_column :medicaid_applications, :self_employed, :boolean
+    end
+  end
+
+  def down
+    add_column :medicaid_applications, :self_employed, :boolean
+
+    safety_assured do
+      execute "UPDATE medicaid_applications SET self_employed=anyone_self_employed"
+      remove_column :medicaid_applications, :anyone_self_employed
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171025140315) do
+ActiveRecord::Schema.define(version: 20171025173052) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 20171025140315) do
     t.boolean "anyone_employed"
     t.boolean "anyone_in_college"
     t.boolean "anyone_new_mom"
+    t.boolean "anyone_self_employed", default: false
     t.datetime "birthday"
     t.boolean "caretaker_or_parent"
     t.integer "child_support_alimony_arrears_expenses"
@@ -124,7 +125,6 @@ ActiveRecord::Schema.define(version: 20171025140315) do
     t.string "residential_city"
     t.string "residential_street_address"
     t.string "residential_zip"
-    t.boolean "self_employed"
     t.integer "self_employed_monthly_income"
     t.integer "self_employment_expenses"
     t.boolean "sms_consented", default: true
@@ -161,6 +161,7 @@ ActiveRecord::Schema.define(version: 20171025140315) do
     t.string "relationship"
     t.boolean "requesting_food_assistance", default: true
     t.boolean "requesting_health_insurance", default: true
+    t.boolean "self_employed", default: false
     t.string "self_employed_monthly_expenses"
     t.integer "self_employed_monthly_income"
     t.string "self_employed_profession"

--- a/spec/controllers/medicaid/amounts_expenses_controller_spec.rb
+++ b/spec/controllers/medicaid/amounts_expenses_controller_spec.rb
@@ -10,13 +10,12 @@ RSpec.describe Medicaid::AmountsExpensesController, type: :controller do
   describe "#edit" do
     context "client not self employed with no student loans or child support" do
       it "redirects to next step" do
-        medicaid_application =
-          create(
-            :medicaid_application,
-            pay_student_loan_interest: false,
-            pay_child_support_alimony_arrears: false,
-            self_employed: false,
-          )
+        medicaid_application = create(
+          :medicaid_application,
+          pay_student_loan_interest: false,
+          pay_child_support_alimony_arrears: false,
+          anyone_self_employed: false,
+        )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
@@ -27,12 +26,11 @@ RSpec.describe Medicaid::AmountsExpensesController, type: :controller do
 
     context "client with a student loan" do
       it "renders edit" do
-        medicaid_application =
-          create(
-            :medicaid_application,
-            pay_student_loan_interest: true,
-            pay_child_support_alimony_arrears: false,
-          )
+        medicaid_application = create(
+          :medicaid_application,
+          pay_student_loan_interest: true,
+          pay_child_support_alimony_arrears: false,
+        )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
@@ -43,12 +41,11 @@ RSpec.describe Medicaid::AmountsExpensesController, type: :controller do
 
     context "client with child support costs" do
       it "renders edit" do
-        medicaid_application =
-          create(
-            :medicaid_application,
-            pay_student_loan_interest: false,
-            pay_child_support_alimony_arrears: true,
-          )
+        medicaid_application = create(
+          :medicaid_application,
+          pay_student_loan_interest: false,
+          pay_child_support_alimony_arrears: true,
+        )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
@@ -59,13 +56,12 @@ RSpec.describe Medicaid::AmountsExpensesController, type: :controller do
 
     context "client is self employed" do
       it "renders edit" do
-        medicaid_application =
-          create(
-            :medicaid_application,
-            pay_student_loan_interest: false,
-            pay_child_support_alimony_arrears: false,
-            self_employed: true,
-          )
+        medicaid_application = create(
+          :medicaid_application,
+          pay_student_loan_interest: false,
+          pay_child_support_alimony_arrears: false,
+          anyone_self_employed: true,
+        )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit

--- a/spec/controllers/medicaid/amounts_income_controller_spec.rb
+++ b/spec/controllers/medicaid/amounts_income_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Medicaid::AmountsIncomeController do
         medicaid_application = create(
           :medicaid_application,
           anyone_employed: false,
-          self_employed: false,
+          anyone_self_employed: false,
           unemployment_income: false,
         )
         session[:medicaid_application_id] = medicaid_application.id
@@ -24,7 +24,7 @@ RSpec.describe Medicaid::AmountsIncomeController do
           :medicaid_application,
           :with_member,
           anyone_employed: false,
-          self_employed: true,
+          anyone_self_employed: true,
           unemployment_income: false,
         )
         session[:medicaid_application_id] = medicaid_application.id

--- a/spec/controllers/medicaid/income_self_employment_controller_spec.rb
+++ b/spec/controllers/medicaid/income_self_employment_controller_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IncomeSelfEmploymentController do
+  describe "#next_path" do
+    it "is the self income job number" do
+      expect(subject.next_path).to eq(
+        "/steps/medicaid/income-self-employment-member",
+      )
+    end
+  end
+
+  describe "#update" do
+    context "medicaid app has a single member" do
+      context "someone in the household is self employed" do
+        it "updates the self_employment attr of the primary member" do
+          member = create(:member)
+          medicaid_application = create(
+            :medicaid_application,
+            members: [member],
+          )
+
+          session[:medicaid_application_id] = medicaid_application.id
+
+          put :update, params: { step: { anyone_self_employed: true } }
+          member.reload
+
+          expect(member).to be_self_employed
+        end
+      end
+
+      context "nobody in the household has a job" do
+        it "does not update the employment status of the primary member" do
+          member = create(:member)
+          medicaid_application = create(
+            :medicaid_application,
+            members: [member],
+          )
+
+          session[:medicaid_application_id] = medicaid_application.id
+
+          put :update, params: { step: { anyone_self_employed: false } }
+
+          expect(member.reload).not_to be_self_employed
+        end
+      end
+    end
+
+    context "medicaid app has multiple members" do
+      it "does not update the employment status of the primary member" do
+        member = create(:member)
+        medicaid_application = create(
+          :medicaid_application,
+          members: [member, create(:member)],
+        )
+
+        session[:medicaid_application_id] = medicaid_application.id
+
+        put :update, params: { step: { anyone_self_employed: true } }
+
+        expect(member.reload).not_to be_self_employed
+      end
+    end
+  end
+end

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -137,7 +137,16 @@ RSpec.feature "Medicaid app" do
       select_job_number(full_name: "Christa Tester", job_number: "2 jobs")
       click_on "Next"
 
-      expect(page).to have_content("Are you self-employed?")
+      expect(page).to have_content("Is anyone in the household self-employed?")
+      click_on "Yes"
+
+      expect(page).to have_content(
+        "Tell us who in the household self-employed.",
+      )
+      check "Jessie Tester"
+      click_on "Next"
+
+      expect(page).to have_content("Do you get income that's not from a job?")
     end
   end
 end

--- a/spec/steps/medicaid/income_self_employment_member_spec.rb
+++ b/spec/steps/medicaid/income_self_employment_member_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IncomeSelfEmploymentMember do
+  describe "Validations" do
+    context "at least one household member is self employed" do
+      it "is valid" do
+        member = create(:member, self_employed: true)
+        member_not_self_employed = create(:member, self_employed: nil)
+
+        step = Medicaid::IncomeSelfEmploymentMember.new(
+          members: [member, member_not_self_employed],
+        )
+
+        expect(step).to be_valid
+      end
+    end
+
+    context "no household member is self employed" do
+      it "is invalid" do
+        members = create_list(:member, 2, self_employed: nil)
+
+        step = Medicaid::IncomeSelfEmploymentMember.new(members: members)
+
+        expect(step).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
* If anyone is self employed, show page with checkboxes to indicate WHO
* If single member household, mark member as self employed if "yes" to
general question of "are you self employed"
* Rename `self_employed` to `anyone_self_employed` on medicaid apps for
consistency
* Add `self_employed` boolean field to `members` table because a member
can be self employed AND employed in medicaid flow, so string for `employment_status` was
not enabling our medicaid app flow.
* Remove `self_employed?` method on `Member` to avoid collision with
boolean predicate methods provided by Rails.

![screen shot 2017-10-25 at 11 00 43 am](https://user-images.githubusercontent.com/601515/32015173-239fc4a6-b975-11e7-9438-bd246cdf3ab1.png)

![screen shot 2017-10-25 at 11 00 49 am](https://user-images.githubusercontent.com/601515/32015179-27dd3a3a-b975-11e7-8782-868c74608803.png)



Signed-off-by: Jessie Young <jessie@cylinder.work>