### PR TITLE
Add boolean employed field to members for Medicaid flow

### DIFF
--- a/app/controllers/medicaid/income_job_controller.rb
+++ b/app/controllers/medicaid/income_job_controller.rb
@@ -11,13 +11,7 @@ module Medicaid
     end
 
     def member_attrs
-      { employment_status: employed_params }
-    end
-
-    def employed_params
-      if step_params[:anyone_employed] == "true"
-        "employed"
-      end
+      { employed: step_params[:anyone_employed] }
     end
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -51,15 +51,11 @@ class Member < ApplicationRecord
   def monthly_income
     if employment_status == "self_employed"
       self_employed_monthly_income
-    elsif employed?
+    elsif employment_status == "employed"
       employed_monthly_income
     else
       0
     end
-  end
-
-  def employed?
-    employment_status == "employed"
   end
 
   def not_employed?

--- a/app/views/income_details_per_member/edit.html.erb
+++ b/app/views/income_details_per_member/edit.html.erb
@@ -12,7 +12,7 @@
       <% @step.members.each do |member| %>
         <fieldset class="form-group">
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <% if member.employed? %>
+            <% if member.employment_status == "employed" %>
               <%= render "header", member: member %>
               <%= ff.mb_input_field :employed_employer_name,
                   "Employer name" %>

--- a/db/migrate/20171025173052_rename_self_employed_to_anyone_self_employed_on_medicaid_applications.rb
+++ b/db/migrate/20171025173052_rename_self_employed_to_anyone_self_employed_on_medicaid_applications.rb
@@ -2,7 +2,6 @@ class RenameSelfEmployedToAnyoneSelfEmployedOnMedicaidApplications < ActiveRecor
   def up
     add_column :medicaid_applications, :anyone_self_employed, :boolean
     change_column_default :medicaid_applications, :anyone_self_employed, false
-    commit_db_transaction
 
     safety_assured do
       execute "UPDATE medicaid_applications SET anyone_self_employed=self_employed"

--- a/db/migrate/20171025184755_add_employed_as_boolean_to_medicaid.rb
+++ b/db/migrate/20171025184755_add_employed_as_boolean_to_medicaid.rb
@@ -1,0 +1,13 @@
+class AddEmployedAsBooleanToMedicaid < ActiveRecord::Migration[5.1]
+  def up
+    add_column :members, :employed, :boolean
+    change_column_default :members, :employed, false
+  end
+
+  def down
+    safety_assured do
+      remove_column :members, :employed
+    end
+  end
+
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171025173052) do
+ActiveRecord::Schema.define(version: 20171025184755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 20171025173052) do
     t.boolean "citizen"
     t.datetime "created_at", null: false
     t.boolean "disabled"
+    t.boolean "employed", default: false
     t.string "employed_employer_name"
     t.integer "employed_hours_per_week"
     t.string "employed_monthly_income", default: [], array: true

--- a/spec/controllers/medicaid/income_job_controller_spec.rb
+++ b/spec/controllers/medicaid/income_job_controller_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe Medicaid::IncomeJobController do
 
           put :update, params: { step: { anyone_employed: true } }
 
-          expect(member.reload.employment_status).to eq "employed"
+          member.reload
+
+          expect(member).to be_employed
         end
       end
 
@@ -39,7 +41,9 @@ RSpec.describe Medicaid::IncomeJobController do
 
           put :update, params: { step: { anyone_employed: false } }
 
-          expect(member.reload.employment_status).to eq nil
+          member.reload
+
+          expect(member).to_not be_employed
         end
       end
     end
@@ -56,7 +60,9 @@ RSpec.describe Medicaid::IncomeJobController do
 
         put :update, params: { step: { anyone_employed: true } }
 
-        expect(member.reload.employment_status).to eq nil
+        member.reload
+
+        expect(member).to_not be_employed
       end
     end
   end


### PR DESCRIPTION
Also removes `employed?` method from Member, and updates SNAP flows that were using accordingly.

Signed-off-by: Christa Hartsock <christa@codeforamerica.org>