### PR TITLE
Part I of "other income" for multi-member flow

### DIFF
--- a/app/controllers/medicaid/income_other_income_type_controller.rb
+++ b/app/controllers/medicaid/income_other_income_type_controller.rb
@@ -5,11 +5,11 @@ module Medicaid
     private
 
     def skip?
-      no_income_not_from_job?
+      nobody_with_other_income?
     end
 
-    def no_income_not_from_job?
-      !current_application&.income_not_from_job?
+    def nobody_with_other_income?
+      !current_application&.anyone_other_income?
     end
   end
 end

--- a/app/steps/medicaid/income_other_income.rb
+++ b/app/steps/medicaid/income_other_income.rb
@@ -2,6 +2,6 @@
 
 module Medicaid
   class IncomeOtherIncome < Step
-    step_attributes(:income_not_from_job)
+    step_attributes(:anyone_other_income)
   end
 end

--- a/app/views/medicaid/income_other_income/edit.html.erb
+++ b/app/views/medicaid/income_other_income/edit.html.erb
@@ -2,11 +2,14 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Do you get income that's not from a job?</div>
+    <div class="form-card__title">
+      <%= t("medicaid.income_other_income.edit.title",
+        count: current_application.members.count) %>
+    </div>
     <p class="text--help text--centered">
       If so, we'll ask you about the specific amounts you earn later
     </p>
   </header>
 
-  <%= render "shared/yes_no_form", step: @step, field: :income_not_from_job %>
+  <%= render "shared/yes_no_form", step: @step, field: :anyone_other_income %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,6 +30,11 @@ en:
         title:
           one: Do you currently have a job?
           other: Does anyone in your household currently have a job?
+    income_other_income:
+      edit:
+        title:
+          one: Do you get income that’s not from a job?
+          other: Does anyone in the household get income that’s not from a job?
     income_self_employment:
       edit:
         title:

--- a/db/migrate/20171025225850_rename_income_not_from_job_to_anyone_other_income.rb
+++ b/db/migrate/20171025225850_rename_income_not_from_job_to_anyone_other_income.rb
@@ -1,0 +1,20 @@
+class RenameIncomeNotFromJobToAnyoneOtherIncome < ActiveRecord::Migration[5.1]
+  def up
+    add_column :medicaid_applications, :anyone_other_income, :boolean
+    change_column_default :medicaid_applications, :anyone_other_income, false
+
+    safety_assured do
+      execute "UPDATE medicaid_applications SET anyone_other_income=income_not_from_job"
+      remove_column :medicaid_applications, :income_not_from_job, :boolean
+    end
+  end
+
+  def down
+    add_column :medicaid_applications, :income_not_from_job, :boolean
+
+    safety_assured do
+      execute "UPDATE medicaid_applications SET income_not_from_job=anyone_other_income"
+      remove_column :medicaid_applications, :anyone_other_income
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171025184755) do
+ActiveRecord::Schema.define(version: 20171025225850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -88,6 +88,7 @@ ActiveRecord::Schema.define(version: 20171025184755) do
     t.boolean "anyone_employed"
     t.boolean "anyone_in_college"
     t.boolean "anyone_new_mom"
+    t.boolean "anyone_other_income", default: false
     t.boolean "anyone_self_employed", default: false
     t.datetime "birthday"
     t.boolean "caretaker_or_parent"
@@ -105,7 +106,6 @@ ActiveRecord::Schema.define(version: 20171025184755) do
     t.boolean "flint_water_crisis"
     t.boolean "homeless"
     t.boolean "income_alimony"
-    t.boolean "income_not_from_job"
     t.boolean "income_pension"
     t.boolean "income_retirement"
     t.boolean "income_social_security"

--- a/spec/controllers/medicaid/income_other_income_type_controller_spec.rb
+++ b/spec/controllers/medicaid/income_other_income_type_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Medicaid::IncomeOtherIncomeTypeController do
     context "client does not have non-job income" do
       it "redirects to next step" do
         medicaid_application =
-          create(:medicaid_application, income_not_from_job: false)
+          create(:medicaid_application, anyone_other_income: false)
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
@@ -19,7 +19,7 @@ RSpec.describe Medicaid::IncomeOtherIncomeTypeController do
     context "client has non-job income" do
       it "renders edit" do
         medicaid_application =
-          create(:medicaid_application, income_not_from_job: true)
+          create(:medicaid_application, anyone_other_income: true)
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -81,7 +81,7 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content("Are you self-employed?")
       click_on "Yes"
 
-      expect(page).to have_content("Do you get income that's not from a job?")
+      expect(page).to have_content("Do you get income that’s not from a job?")
       click_on "Yes"
 
       expect(page).to have_content(

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content("Are you self-employed?")
       click_on "No"
 
-      expect(page).to have_content("Do you get income that's not from a job?")
+      expect(page).to have_content("Do you get income that’s not from a job?")
       click_on "No"
     end
 

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -146,7 +146,9 @@ RSpec.feature "Medicaid app" do
       check "Jessie Tester"
       click_on "Next"
 
-      expect(page).to have_content("Do you get income that's not from a job?")
+      expect(page).to have_content(
+        "Does anyone in the household get income that’s not from a job?",
+      )
     end
   end
 end


### PR DESCRIPTION
* Adds dynamic title to other income page (for household size)
* Renames field to `anyone_other_income` for consistency
* Next steps:
  * add `other_income` boolean to members table
  * update single member household based on `yes/no` page
  * add page to determine which members receive other income for
    multi-member flow
  * add page to determine what kind of other income those people receive
    (in multi-member context, we already have that for single member)