### PR TITLE
Enable SNAP clients to change office location

### DIFF
--- a/app/controllers/introduction_change_office_location_controller.rb
+++ b/app/controllers/introduction_change_office_location_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class IntroductionChangeOfficeLocationController < SnapStepsController
+end

--- a/app/steps/introduction_change_office_location.rb
+++ b/app/steps/introduction_change_office_location.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class IntroductionChangeOfficeLocation < Step
+  step_attributes(:office_location)
+end

--- a/app/steps/step_navigation.rb
+++ b/app/steps/step_navigation.rb
@@ -51,6 +51,8 @@ class StepNavigation
 
   SUBSTEPS = {
     HouseholdAddMemberController => HouseholdMembersOverviewController,
+    IntroductionChangeOfficeLocationController =>
+      IntroductionCompleteController,
   }.freeze
 
   class << self

--- a/app/views/introduction_change_office_location/edit.html.erb
+++ b/app/views/introduction_change_office_location/edit.html.erb
@@ -1,0 +1,21 @@
+<% content_for :header_title, "Office Submission" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Where would you like to submit your application?
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+      <%= f.mb_radio_set :office_location,
+          "",
+        [
+         { value: "clio", label: "Clio Road" },
+         { value: "union", label: "Union Street" },
+        ] %>
+      <%= render 'shared/next_step' %>
+    <% end %>
+</div>
+</div>

--- a/app/views/introduction_complete/edit.html.erb
+++ b/app/views/introduction_complete/edit.html.erb
@@ -14,9 +14,14 @@
   <div class="form-card__content">
     <h4>What happens next?</h4>
     <p>
-      Next, we'll ask you some questions to help us determine your eligibility for
-      food assistance as quickly as possible.
+      Next, we'll ask you some eligibility questions and then submit your
+      application to MDHHS on <%= current_application.receiving_office_name.capitalize %>.
     </p>
+
+    <p>
+      To change office location, click <%= link_to "here", step_path(IntroductionChangeOfficeLocationController) %>.
+    </p>
+
   </div>
   <%= render partial: 'shared/next_step_link' %>
 </div>

--- a/db/migrate/20171025184755_add_employed_as_boolean_to_medicaid.rb
+++ b/db/migrate/20171025184755_add_employed_as_boolean_to_medicaid.rb
@@ -9,5 +9,4 @@ class AddEmployedAsBooleanToMedicaid < ActiveRecord::Migration[5.1]
       remove_column :members, :employed
     end
   end
-
 end

--- a/spec/features/snap_application_change_location_spec.rb
+++ b/spec/features/snap_application_change_location_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+RSpec.feature "Submit snap application" do
+  scenario "change office location" do
+    visit root_path
+    within(".slab--hero") { click_on "Apply now" }
+
+    on_page "Introduction" do
+      fill_in_name_and_birthday
+      click_on "Continue"
+    end
+
+    fill_in "What is the best phone number to reach you?", with: "2222222222"
+    click_on "Continue"
+
+    fill_in "Address", with: "123 Main St"
+    fill_in "City", with: "Flint"
+    fill_in "ZIP code", with: "48411"
+    select_address_same_as_home_address
+    click_on "Continue"
+
+    within(".form-card__content") do
+      expect(page).to have_content("Union")
+    end
+
+    on_page "Introduction Complete" do
+      click_on "here"
+    end
+
+    on_page "Office Submission" do
+      expect(page).to have_content(
+        "Where would you like to submit your application?",
+      )
+      choose "Clio Road"
+      click_on "Continue"
+    end
+
+    on_page "Introduction Complete" do
+      within(".form-card__content") do
+        expect(page).to have_content("Clio")
+      end
+    end
+  end
+end


### PR DESCRIPTION
**WHY**:
- this surfaces the office location after the "Introduction" section of
the SNAP application flow
- if the office location is not what is expected, it can be changed.
- this is useful when someone is applying in an MDHHS office but their
address maps to a different location. We have office-specific landing
pages to override this, but sometimes people forget to use those and
they should be able to correct the location before submission.

![screen shot 2017-10-26 at 11 00 01 am](https://user-images.githubusercontent.com/601515/32069309-a13a9c74-ba3d-11e7-87f1-c3fd7b04d3aa.png)

![screen shot 2017-10-26 at 11 00 05 am](https://user-images.githubusercontent.com/601515/32069319-a62be512-ba3d-11e7-8a8c-777ea30196e4.png)

![screen shot 2017-10-26 at 11 00 09 am](https://user-images.githubusercontent.com/601515/32069323-a9767cb4-ba3d-11e7-80c5-bcfa3df4e20a.png)


