### PR TITLE
Better prompt when asking about household pregnancy

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -21,6 +21,10 @@ class StepsController < ApplicationController
   def edit
     @step = step_class.new(existing_attributes.slice(*step_attrs))
 
+    if step_class.attribute_names&.include?(:members)
+      @step.members = current_application&.members
+    end
+
     before_rendering_edit_hook
   end
 

--- a/app/steps/medicaid/health_pregnancy.rb
+++ b/app/steps/medicaid/health_pregnancy.rb
@@ -10,5 +10,17 @@ module Medicaid
     def female_members
       members.select(&:female?)
     end
+
+    def single_female_start_of_question
+      if primary_member_is_female?
+        "Have you"
+      else
+        "Has #{female_members.first.first_name}"
+      end
+    end
+
+    def primary_member_is_female?
+      members.sort_by(&:id).first.female?
+    end
   end
 end

--- a/app/views/medicaid/health_pregnancy/edit.html.erb
+++ b/app/views/medicaid/health_pregnancy/edit.html.erb
@@ -4,7 +4,8 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.health_pregnancy.edit.title",
-            count: current_application.members.count) %>
+         count: @step.female_members.count,
+         start_of_question: @step.single_female_start_of_question) %>
     </div>
     <p class="text--help text--centered">
       Currently pregnant or pregnant in the past three months.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,7 +23,7 @@ en:
     health_pregnancy:
       edit:
         title:
-          one: Have you been pregnant recently?
+          one: "%{start_of_question} been pregnant recently?"
           other: Has anyone been pregnant recently?
     income_job:
       edit:

--- a/spec/factories/member.rb
+++ b/spec/factories/member.rb
@@ -7,5 +7,13 @@ FactoryBot.define do
     ssn "123 12 1234"
     birthday { DateTime.parse("August 18, 1990") }
     benefit_application { create(:snap_application) }
+
+    trait :female do
+      sex "female"
+    end
+
+    trait :male do
+      sex "male"
+    end
   end
 end

--- a/spec/views/medicaid/health_pregnancy/edit.html.erb_spec.rb
+++ b/spec/views/medicaid/health_pregnancy/edit.html.erb_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+describe "medicaid/health_pregnancy/edit.html.erb" do
+  before do
+    controller.singleton_class.class_eval do
+      def current_path
+        "/steps/medicaid/health-pregnancy"
+      end
+
+      helper_method :current_path
+    end
+  end
+
+  context "2 members - primary member is male" do
+    it "asks if the only *other* female is pregnant" do
+      app = create(:medicaid_application, anyone_new_mom: true)
+      create(:member, :male, first_name: "Joel", benefit_application: app)
+      create(:member, :female, first_name: "Sara", benefit_application: app)
+      pregnancy_step = Medicaid::HealthPregnancy.new(
+        anyone_new_mom: true,
+        members: app.members,
+      )
+
+      assign(:step, pregnancy_step)
+
+      render
+
+      expect(rendered).to include("Has Sara been pregnant recently?")
+    end
+  end
+
+  context "2 members - primary member is female" do
+    it "asks if *YOU*, the primary member, has been pregnant" do
+      app = create(:medicaid_application, anyone_new_mom: true)
+      create(:member, :female, first_name: "Sara", benefit_application: app)
+      create(:member, :male, first_name: "Joel", benefit_application: app)
+      pregnancy_step = Medicaid::HealthPregnancy.new(
+        anyone_new_mom: true,
+        members: app.members,
+      )
+
+      assign(:step, pregnancy_step)
+
+      render
+
+      expect(rendered).to include("Have you been pregnant recently?")
+    end
+  end
+
+  context "2 members - both are female" do
+    it "asks if anyone has been pregnant recently" do
+      app = create(:medicaid_application, anyone_new_mom: true)
+      create(:member, :female, first_name: "Sara", benefit_application: app)
+      create(:member, :female, first_name: "Jessie", benefit_application: app)
+      pregnancy_step = Medicaid::HealthPregnancy.new(
+        anyone_new_mom: true,
+        members: app.members,
+      )
+
+      assign(:step, pregnancy_step)
+
+      render
+
+      expect(rendered).to include("Has anyone been pregnant recently?")
+    end
+  end
+end


### PR DESCRIPTION
Because the pregnancy question is specific to how many females are among
the members, the question for this should be catered to several
different contexts, or states:

1. Multiple members. One female. That female is you. - "Are YOU pregnant"
2. Multiple members. One female. That female is someone else - "Is SHE pregnant"
3. Multiple members. Several females. "Is ANYONE pregnant"

When there is a single female in the household that's pregnant we should
not show them the page where we ask who. It's a given that if there's
only one female in the house, and someone is pregnant - then she is that
person.

This commit revises the view and the locale to specify how those
questions start and personalizes them accordingly.

A view spec is added as well so we don't exercise the entirety of the
application in a feature spec.

Is the other member, a female, pregnant?
==============================

![quick_health_questions](https://user-images.githubusercontent.com/28194/32075319-7790eb12-ba6a-11e7-8e1c-a69044aa040f.jpg)

Are you, the only female, pregnant?
==========================

![quick_health_questions](https://user-images.githubusercontent.com/28194/32075401-b9f4624a-ba6a-11e7-8451-9053e78194d0.jpg)

Has anyone, amongst the 2 females in the house, been pregnant?
================================================

![quick_health_questions](https://user-images.githubusercontent.com/28194/32075456-e0cd3626-ba6a-11e7-95e6-9e201b132cd3.jpg)
