### PR TITLE
Collect only the last 4 digits of someone's SSN

### DIFF
--- a/app/controllers/household_add_member_controller.rb
+++ b/app/controllers/household_add_member_controller.rb
@@ -29,7 +29,7 @@ class HouseholdAddMemberController < SnapStepsController
       relationship: member.relationship,
       requesting_food_assistance: member.requesting_food_assistance,
       sex: member.sex,
-      ssn: member.ssn,
+      last_four_ssn: member.last_four_ssn,
     }
   end
 

--- a/app/controllers/personal_detail_controller.rb
+++ b/app/controllers/personal_detail_controller.rb
@@ -19,7 +19,11 @@ class PersonalDetailController < SnapStepsController
   end
 
   def member_attributes
-    { sex: member.sex, marital_status: member.marital_status, ssn: member.ssn }
+    {
+      sex: member.sex,
+      marital_status: member.marital_status,
+      last_four_ssn: member.last_four_ssn,
+    }
   end
 
   def member

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -9,6 +9,12 @@ class MedicaidApplication < ApplicationRecord
     key: Rails.application.secrets.secret_key_for_ssn_encryption,
   )
 
+  attribute :last_four_ssn
+  attr_encrypted(
+    :last_four_ssn,
+      key: Rails.application.secrets.secret_key_for_ssn_encryption,
+  )
+
   def self.step_navigation
     Medicaid::StepNavigation
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -49,7 +49,13 @@ class Member < ApplicationRecord
   attribute :ssn
   attr_encrypted(
     :ssn,
-    key: Rails.application.secrets.secret_key_for_ssn_encryption,
+      key: Rails.application.secrets.secret_key_for_ssn_encryption,
+  )
+
+  attribute :last_four_ssn
+  attr_encrypted(
+    :last_four_ssn,
+      key: Rails.application.secrets.secret_key_for_ssn_encryption,
   )
 
   def full_name

--- a/app/steps/concerns/social_security_number.rb
+++ b/app/steps/concerns/social_security_number.rb
@@ -1,16 +1,16 @@
 module SocialSecurityNumber
   extend ActiveSupport::Concern
 
-  SSN_REGEX = /\A\d{9}\z/
+  SSN_REGEX = /\A\d{4}\z/
 
   included do
-    auto_strip_attributes :ssn
+    auto_strip_attributes :last_four_ssn
 
-    validates :ssn,
+    validates :last_four_ssn,
       allow_blank: true,
       format: {
         with: SSN_REGEX,
-        message: "Make sure your SSN has 9 digits",
+        message: "Make sure to provide the last 4 digits",
       }
 
     # Overriding @record[key]=val, that's only found in ActiveRecord, so we can

--- a/app/steps/household_add_member.rb
+++ b/app/steps/household_add_member.rb
@@ -13,7 +13,7 @@ class HouseholdAddMember < Step
     :relationship,
     :requesting_food_assistance,
     :sex,
-    :ssn,
+    :last_four_ssn,
   )
 
   validates :first_name,

--- a/app/steps/medicaid/contact_social_security.rb
+++ b/app/steps/medicaid/contact_social_security.rb
@@ -7,7 +7,7 @@ module Medicaid
     include SocialSecurityNumber
 
     step_attributes(
-      :ssn,
+      :last_four_ssn,
       :birthday,
     )
 

--- a/app/steps/personal_detail.rb
+++ b/app/steps/personal_detail.rb
@@ -7,7 +7,7 @@ class PersonalDetail < Step
   step_attributes(
     :sex,
     :marital_status,
-    :ssn,
+    :last_four_ssn,
   )
 
   validates :sex, inclusion: {

--- a/app/views/household_add_member/edit.html.erb
+++ b/app/views/household_add_member/edit.html.erb
@@ -26,10 +26,10 @@
         ['Spouse', 'Parent', 'Child', 'Sibling', 'Roommate', 'Other'],
         include_blank: "Choose one" %>
       <%= f.mb_date_select :birthday, "What is their birthday?", { options: { start_year: 1900, end_year: Time.now.year, default: Date.new(1990,1,15), order: [:month, :day, :year] } } %>
-      <%= f.mb_input_field :ssn,
-        'What is their social security number?',
+      <%= f.mb_input_field :last_four_ssn,
+        'What are the last 4 digits of their Social Security Number?',
         type: :tel,
-        options: { maxlength: 9 },
+        options: { maxlength: 4 },
         notes: ["If they don’t have one or you don’t know it you can skip this"],
         append_html: "<p class='text--secure'><i class='illustration illustration--safety'></i>Social security numbers help ensure you receive the correct benefits. MDHHS maintains strict security guidelines to protect the identities of our residents.</p>" %>
       <%= f.mb_radio_set :requesting_food_assistance,

--- a/app/views/medicaid/contact_social_security/edit.html.erb
+++ b/app/views/medicaid/contact_social_security/edit.html.erb
@@ -7,10 +7,10 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_input_field :ssn,
-        "Social Security Number",
+      <%= f.mb_input_field :last_four_ssn,
+        "Social Security Number (last 4 digits)",
         type: :tel,
-        options: { maxlength: 9 },
+        options: { maxlength: 4 },
         notes: ["If you don’t know it you can skip this"],
         append_html: "<p class='text--secure'><i class='illustration illustration--safety'></i>Social security numbers help ensure you receive the correct benefits. MDHHS maintains strict security guidelines to protect the identities of our residents.</p>" %>
 

--- a/app/views/personal_detail/edit.html.erb
+++ b/app/views/personal_detail/edit.html.erb
@@ -18,10 +18,10 @@
         'What is your marital status?',
         ['Married', 'Never married', 'Divorced', 'Widowed', 'Separated'],
         include_blank: "Choose one" %>
-      <%= f.mb_input_field :ssn,
-      "What is your social security number?",
+      <%= f.mb_input_field :last_four_ssn,
+      "What are the last 4 digits of your Social Security Number?",
       type: :tel,
-      options: { maxlength: 9 },
+      options: { maxlength: 4 },
       notes: ["If you don’t have one or don’t want to answer now it’s okay to skip this"],
       append_html: "<p class='text--secure'><i class='illustration illustration--safety'></i>Social security numbers help ensure you receive the correct benefits. MDHHS maintains strict security guidelines to protect the identities of our residents.</p>",
       optional: true %>

--- a/db/migrate/20171031224843_add_last_four_ssn_to_member_and_medicaid_application.rb
+++ b/db/migrate/20171031224843_add_last_four_ssn_to_member_and_medicaid_application.rb
@@ -1,0 +1,8 @@
+class AddLastFourSsnToMemberAndMedicaidApplication < ActiveRecord::Migration[5.1]
+  def change
+    add_column :members, :encrypted_last_four_ssn, :string
+    add_column :members, :encrypted_last_four_ssn_iv, :string
+    add_column :medicaid_applications, :encrypted_last_four_ssn, :string
+    add_column :medicaid_applications, :encrypted_last_four_ssn_iv, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -102,6 +102,8 @@ ActiveRecord::Schema.define(version: 20171101005455) do
     t.string "documents", default: [], array: true
     t.string "email"
     t.string "employed_monthly_income", default: [], array: true
+    t.string "encrypted_last_four_ssn"
+    t.string "encrypted_last_four_ssn_iv"
     t.string "encrypted_ssn"
     t.string "encrypted_ssn_iv"
     t.boolean "everyone_a_citizen"
@@ -154,6 +156,8 @@ ActiveRecord::Schema.define(version: 20171101005455) do
     t.string "employed_pay_interval"
     t.integer "employed_pay_quantity"
     t.string "employment_status"
+    t.string "encrypted_last_four_ssn"
+    t.string "encrypted_last_four_ssn_iv"
     t.string "encrypted_ssn"
     t.string "encrypted_ssn_iv"
     t.string "first_name"

--- a/spec/controllers/household_add_member_controller_spec.rb
+++ b/spec/controllers/household_add_member_controller_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe HouseholdAddMemberController do
 
         expect(step.sex).to eq("male")
         expect(step.relationship).to eq("Child")
-        expect(step.ssn).to eq("12345")
+        expect(step.last_four_ssn).to eq("1234")
       end
     end
   end
@@ -27,6 +27,6 @@ RSpec.describe HouseholdAddMemberController do
 
   def member
     @_member ||=
-      create(:member, sex: "male", relationship: "Child", ssn: "12345")
+      create(:member, sex: "male", relationship: "Child", last_four_ssn: "1234")
   end
 end

--- a/spec/controllers/personal_detail_controller_spec.rb
+++ b/spec/controllers/personal_detail_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe PersonalDetailController do
 
       expect(step.sex).to eq("male")
       expect(step.marital_status).to eq("Married")
-      expect(step.ssn).to eq("123456789")
+      expect(step.last_four_ssn).to eq("1234")
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.describe PersonalDetailController do
         valid_params = {
           sex: "female",
           marital_status: "Divorced",
-          ssn: "987654321",
+          last_four_ssn: "9876",
         }
 
         put :update, params: { step: valid_params }
@@ -50,6 +50,9 @@ RSpec.describe PersonalDetailController do
   end
 
   def member
-    create(:member, sex: "male", marital_status: "Married", ssn: "123456789")
+    create(:member,
+           sex: "male",
+           marital_status: "Married",
+           last_four_ssn: "1234")
   end
 end

--- a/spec/factories/member.rb
+++ b/spec/factories/member.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     last_name "Pad"
     sex "female"
     marital_status "Widowed"
-    ssn "123 12 1234"
     birthday { DateTime.parse("August 18, 1990") }
     benefit_application { create(:snap_application) }
 

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -152,7 +152,7 @@ RSpec.feature "Medicaid app" do
       )
       click_on "Yes"
 
-      fill_in "Social Security Number", with: "000992222"
+      fill_in "Social Security Number (last 4 digits)", with: "0099"
       fill_in_birthday
       click_on "Next"
     end

--- a/spec/features/snap_application_with_maximum_info_spec.rb
+++ b/spec/features/snap_application_with_maximum_info_spec.rb
@@ -35,7 +35,8 @@ feature "SNAP application with maximum info" do
     on_page "Personal Details" do
       select_radio(question: "What is your sex?", answer: "Female")
       select "Divorced", from: "What is your marital status?"
-      fill_in "What is your social security number?", with: "123121234"
+      fill_in "What are the last 4 digits of your Social Security Number?",
+              with: "1231"
       click_on "Continue"
     end
 
@@ -48,6 +49,8 @@ feature "SNAP application with maximum info" do
       fill_in "What is their last name?", with: "Tester"
       select_radio(question: "What is their sex?", answer: "Male")
       select "Child", from: "What is their relationship to you?"
+      fill_in "What are the last 4 digits of their Social Security Number?",
+              with: "5566"
       click_on "Continue"
     end
 

--- a/spec/steps/personal_detail_spec.rb
+++ b/spec/steps/personal_detail_spec.rb
@@ -5,5 +5,5 @@ RSpec.describe PersonalDetail do
     PersonalDetail.new(marital_status: "Widowed", sex: "male")
   end
 
-  include_examples "social security number"
+  it_should_behave_like "social security number"
 end

--- a/spec/support/shared_examples/social_security_number.rb
+++ b/spec/support/shared_examples/social_security_number.rb
@@ -1,43 +1,43 @@
 RSpec.shared_examples "social security number" do
   describe "social security number" do
     it "allows nils" do
-      subject.ssn = nil
+      subject.last_four_ssn = nil
       expect(subject).to be_valid
     end
 
     it "allows ssn to start with zero" do
-      subject.ssn = "012345678"
+      subject.last_four_ssn = "0123"
       expect(subject).to be_valid
     end
 
     it "allows ssns with no delimiters" do
-      subject.ssn = "123121234"
+      subject.last_four_ssn = "1231"
       expect(subject).to be_valid
     end
 
     it "disallows bogus ssns" do
-      subject.ssn = "BOGUS"
+      subject.last_four_ssn = "BOGUS"
       expect(subject).not_to be_valid
     end
 
     it "invalidates bad SSNs with a friendly message" do
-      subject.ssn = "111 22 333"
+      subject.last_four_ssn = "11 12"
       expect(subject).not_to be_valid
-      expect(subject.errors[:ssn]).to include(
-        "Make sure your SSN has 9 digits",
+      expect(subject.errors[:last_four_ssn]).to include(
+        "Make sure to provide the last 4 digits",
       )
     end
 
     it "disallows bogus ssns with newlines" do
-      subject.ssn = "BOGUS\n'--DROP TABLE CALFRESH_APPLICATIONS"
+      subject.last_four_ssn = "BOGUS\n'--DROP TABLE CALFRESH_APPLICATIONS"
       expect(subject).not_to be_valid
     end
 
     it "does not allow dashes" do
-      subject.ssn = "  123-12-1234  "
+      subject.last_four_ssn = "  1-234  "
       expect(subject).to be_invalid
-      expect(subject.errors[:ssn]).to include(
-        "Make sure your SSN has 9 digits",
+      expect(subject.errors[:last_four_ssn]).to include(
+        "Make sure to provide the last 4 digits",
       )
     end
   end


### PR DESCRIPTION
Applies to both Medicaid and SNAP flows.

Keeps SSN as a field on both member and medicaid_application, to be pulled over to last_four_ssn in a future migration.
We have a legacy SSN field on SNAP applications, which we should also migrate away.

[#152420489]

Signed-off-by: Jessie Young <jessie@cylinder.work>