### PR TITLE
Collect insurance type per client, per page

### DIFF
--- a/app/controllers/medicaid/insurance_current_type_controller.rb
+++ b/app/controllers/medicaid/insurance_current_type_controller.rb
@@ -1,8 +1,57 @@
 # frozen_string_literal: true
 
 module Medicaid
-  class InsuranceCurrentTypeController < Medicaid::ManyMemberStepsController
+  class InsuranceCurrentTypeController < MedicaidStepsController
+    helper_method :current_member
+
+    def update
+      @step = step_class.new(step_params)
+
+      if @step.valid?
+        current_member.update(step_params)
+        redirect_to(next_path)
+      else
+        render :edit
+      end
+    end
+
+    def current_member
+      @_current_member ||= begin
+                             member_from_form ||
+                               member_from_querystring ||
+                               first_insurance_holder
+                           end
+    end
+
     private
+
+    def next_path
+      next_member_path || super
+    end
+
+    def next_member_path
+      return if next_member.nil?
+
+      decoded_step_path(params: { member: next_member.id })
+    end
+
+    def first_insurance_holder
+      current_application.
+        members.
+        first_insurance_holder
+    end
+
+    def next_member
+      return if current_member.nil?
+
+      current_application.
+        members.
+        where(insured: true).
+        where("created_at > ?", current_member.created_at).
+        order(created_at: :asc).
+        limit(1).
+        first
+    end
 
     def skip?
       current_application.nobody_insured?
@@ -10,6 +59,23 @@ module Medicaid
 
     def member_attrs
       %i[insurance_type]
+    end
+
+    def existing_attributes
+      HashWithIndifferentAccess.new(current_member&.attributes)
+    end
+
+    def member_from_form
+      return if params.dig(:step, :member_id).blank?
+
+      member_id = params[:step].delete(:member_id)
+      current_application.members.find(member_id)
+    end
+
+    def member_from_querystring
+      return if params[:member].blank?
+
+      current_application.members.find(params[:member])
     end
   end
 end

--- a/app/controllers/medicaid/insurance_current_type_controller.rb
+++ b/app/controllers/medicaid/insurance_current_type_controller.rb
@@ -38,7 +38,9 @@ module Medicaid
     def first_insurance_holder
       current_application.
         members.
-        first_insurance_holder
+        insured.
+        limit(1).
+        first
     end
 
     def next_member
@@ -46,9 +48,8 @@ module Medicaid
 
       current_application.
         members.
-        where(insured: true).
-        where("created_at > ?", current_member.created_at).
-        order(created_at: :asc).
+        insured.
+        after(current_member).
         limit(1).
         first
     end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -60,11 +60,14 @@ class Member < ApplicationRecord
     key: Rails.application.secrets.secret_key_for_ssn_encryption,
   )
 
-  def self.first_insurance_holder
+  def self.insured
     where(insured: true).
-      order(created_at: :asc).
-      limit(1).
-      first
+      where(requesting_health_insurance: true).
+      order(created_at: :asc)
+  end
+
+  def self.after(member)
+    where("created_at > ?", member.created_at)
   end
 
   def full_name

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -60,6 +60,13 @@ class Member < ApplicationRecord
     key: Rails.application.secrets.secret_key_for_ssn_encryption,
   )
 
+  def self.first_insurance_holder
+    where(insured: true).
+      order(created_at: :asc).
+      limit(1).
+      first
+  end
+
   def full_name
     "#{first_name} #{last_name}"
   end

--- a/app/views/medicaid/insurance_current_type/edit.html.erb
+++ b/app/views/medicaid/insurance_current_type/edit.html.erb
@@ -4,25 +4,28 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.insurance_current_type.edit.title",
-            count: current_application.members.count) %>
+            name: current_member.full_name) %>
     </div>
   </header>
 
   <div class="form-card__content">
-    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-        <% @step.insured_members_requesting_insurance.each do |member| %>
-            <%= f.fields_for("members[]", member) do |ff| %>
-              <%= ff.mb_radio_set :insurance_type,
-                member.full_name,
-                [
-                  { value: "Medicaid", label: "Medicaid" },
-                  { value: "CHIP/MIChild", label: "CHIP/MIChild" },
-                  { value: "VA health care programs", label: "VA health care programs" },
-                  { value: "Employer or individual plan", label: "Policy through an employer or individual plan" },
-                  { value: "Other", label: "Other" },
-                ] %>
-            <% end %>
-        <% end %>
+    <%= form_for @step,
+      as: :step,
+      builder: MbFormBuilder,
+      url: current_path,
+      method: :put do |f| %>
+
+      <%= f.hidden_field(:member_id, value: current_member.id) %>
+
+      <%= f.mb_radio_set :insurance_type, "Insurance plans",
+        [
+          { value: "Medicaid", label: "Medicaid" },
+          { value: "CHIP/MIChild", label: "CHIP/MIChild" },
+          { value: "VA health care programs", label: "VA health care programs" },
+          { value: "Employer or individual plan", label: "Policy through an employer or individual plan" },
+          { value: "Other", label: "Other" },
+        ] %>
+
       <%= render "medicaid/next_step" %>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,9 +60,7 @@ en:
           other: You've already indicated that %{names} are not in need of additional health coverage.
     insurance_current_type:
       edit:
-        title:
-          one: What type of insurance plan are you currently enrolled in?
-          other: Tell us what insurance plan each person is enrolled in.
+        title: "What type of insurance plan is %{name} currently enrolled in?"
     expenses_alimony:
       edit:
         title:

--- a/spec/controllers/medicaid/insurance_current_type_controller_spec.rb
+++ b/spec/controllers/medicaid/insurance_current_type_controller_spec.rb
@@ -1,6 +1,53 @@
 require "rails_helper"
 
 RSpec.describe Medicaid::InsuranceCurrentTypeController do
+  describe "#current_member" do
+    it "defaults for first insurance holder" do
+      medicaid_application = create(:medicaid_application, anyone_insured: true)
+      _primary_member = create(
+        :member,
+        insured: false,
+        benefit_application: medicaid_application,
+      )
+      insured_member = create(
+        :member,
+        insured: true,
+        benefit_application: medicaid_application,
+      )
+
+      session[:medicaid_application_id] = medicaid_application.id
+
+      expect(subject.current_member).to eq insured_member
+    end
+
+    it "finds member from querystring" do
+      medicaid_application = create(:medicaid_application, anyone_insured: true)
+      _joel = create(:member, benefit_application: medicaid_application)
+      jessie = create(:member, benefit_application: medicaid_application)
+      session[:medicaid_application_id] = medicaid_application.id
+
+      get :edit, params: { member: jessie.id }
+
+      expect(subject.current_member).to eq jessie
+    end
+
+    it "finds member from posted form" do
+      medicaid_application = create(:medicaid_application, anyone_insured: true)
+      _joel = create(:member, benefit_application: medicaid_application)
+      jessie = create(:member, benefit_application: medicaid_application)
+      session[:medicaid_application_id] = medicaid_application.id
+
+      put :update, params: {
+        step: {
+          member_id: jessie.id,
+          insurance_type: "Employer or individual plan",
+        },
+      }
+
+      expect(subject.current_member).to eq jessie
+    end
+  end
+
   describe "#edit" do
     context "client is insured" do
       it "does not redirect" do

--- a/spec/controllers/medicaid/insurance_current_type_controller_spec.rb
+++ b/spec/controllers/medicaid/insurance_current_type_controller_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Medicaid::InsuranceCurrentTypeController do
       medicaid_application = create(:medicaid_application, anyone_insured: true)
       _primary_member = create(
         :member,
-        insured: false,
+        :not_insured,
         benefit_application: medicaid_application,
       )
       insured_member = create(
         :member,
-        insured: true,
+        :insured,
         benefit_application: medicaid_application,
       )
 
@@ -24,6 +24,7 @@ RSpec.describe Medicaid::InsuranceCurrentTypeController do
       medicaid_application = create(:medicaid_application, anyone_insured: true)
       _joel = create(:member, benefit_application: medicaid_application)
       jessie = create(:member, benefit_application: medicaid_application)
+
       session[:medicaid_application_id] = medicaid_application.id
 
       get :edit, params: { member: jessie.id }
@@ -35,6 +36,7 @@ RSpec.describe Medicaid::InsuranceCurrentTypeController do
       medicaid_application = create(:medicaid_application, anyone_insured: true)
       _joel = create(:member, benefit_application: medicaid_application)
       jessie = create(:member, benefit_application: medicaid_application)
+
       session[:medicaid_application_id] = medicaid_application.id
 
       put :update, params: {

--- a/spec/factories/member.rb
+++ b/spec/factories/member.rb
@@ -14,5 +14,15 @@ FactoryBot.define do
     trait :male do
       sex "male"
     end
+
+    trait :insured do
+      insured true
+      requesting_health_insurance true
+    end
+
+    trait :not_insured do
+      insured false
+      requesting_health_insurance false
+    end
   end
 end

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -35,7 +35,7 @@ RSpec.feature "Medicaid app" do
       click_on "Yes"
 
       expect(page).to have_content(
-        "What type of insurance plan are you currently enrolled in?",
+        "What type of insurance plan is Jessie Tester currently enrolled in?",
       )
       choose "Other"
       click_on "Next"

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -134,16 +134,9 @@ RSpec.feature "Medicaid app" do
 
     on_page "Health Coverage Needs" do
       expect(page).to have_content(
-        "Tell us what insurance plan each person is enrolled in.",
+        "What type of insurance plan is Jessie Tester currently enrolled in",
       )
-      expect(page).not_to have_content("Joel Tester")
-      expect(page).not_to have_content("Christa Tester")
-      expect(page).to have_content("Jessie Tester")
-      click_on "Next"
-
-      expect(page).to have_content("Please select a plan")
-
-      select_radio(question: "Jessie Tester", answer: "Medicaid")
+      select_radio(question: "Insurance plans", answer: "Medicaid")
       click_on "Next"
     end
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,6 +1,29 @@
 require "rails_helper"
 
 RSpec.describe Member do
+  describe "scopes" do
+    describe ".first_insurance_holder" do
+      it "returns the first member that is insured" do
+        create(:member, insured: false, requesting_health_insurance: true)
+        create(:member, insured: true, requesting_health_insurance: false)
+        joel = create(:member, insured: true, requesting_health_insurance: true)
+
+        expect(Member.insured).to eq [joel]
+      end
+    end
+
+    describe ".after" do
+      it "returns the next member _after_ the provided member" do
+        joel = create(:member)
+        jessie = create(:member)
+        christa = create(:member)
+
+        expect(Member.after(joel)).to eq [jessie, christa]
+        expect(Member.after(jessie)).to eq [christa]
+      end
+    end
+  end
+
   describe "#female?" do
     it "is true if the sex is female" do
       expect(build(:member, sex: "female")).to be_female

--- a/spec/steps/medicaid/insurance_current_type_spec.rb
+++ b/spec/steps/medicaid/insurance_current_type_spec.rb
@@ -2,29 +2,15 @@ require "rails_helper"
 
 RSpec.describe Medicaid::InsuranceCurrentType do
   describe "Validations" do
-    context "each insured household member has an insurance type" do
+    context "the household member has an insurance type" do
       it "is valid" do
         member = create(:member,
                         insured: true,
-                        insurance_type: "Medicaid",
                         requesting_health_insurance: true)
 
-        member_without_insurance = create(:member,
-                                          insured: false,
-                                          insurance_type: nil,
-                                          requesting_health_insurance: true)
-
-        member_not_requesting_insurance = create(:member,
-                                          requesting_health_insurance: false,
-                                          insured: true,
-                                          insurance_type: nil)
-
         step = Medicaid::InsuranceCurrentType.new(
-          members: [
-            member,
-            member_without_insurance,
-            member_not_requesting_insurance,
-          ],
+          member_id: member.id,
+          insurance_type: "Medicaid",
         )
 
         expect(step).to be_valid
@@ -33,81 +19,16 @@ RSpec.describe Medicaid::InsuranceCurrentType do
 
     context "an insured household member is missing an insurance type" do
       it "is invalid" do
-        member = create(:member,
-                        insured: true,
-                        insurance_type: "Medicaid",
-                        requesting_health_insurance: true)
-
         insured_member_without_type = create(:member,
                                              insured: true,
-                                             insurance_type: nil,
                                              requesting_health_insurance: true)
 
         step = Medicaid::InsuranceCurrentType.new(
-          members: [member, insured_member_without_type],
+          member_id: insured_member_without_type.id,
+          insurance_type: nil,
         )
 
         expect(step).not_to be_valid
-      end
-    end
-  end
-
-  describe "#insured_members_needing_insurance" do
-    context "with insured members needing insurance" do
-      it "returns only insured members needing insurance" do
-        insured_member = create(:member,
-                                insured: true,
-                                requesting_health_insurance: true)
-
-        abstaining_member = create(:member,
-                                   insured: true,
-                                   requesting_health_insurance: false)
-
-        uninsured_member = create(:member,
-                                  insured: false,
-                                  requesting_health_insurance: true)
-
-        step = Medicaid::InsuranceCurrentType.new(
-          members: [
-            insured_member,
-            abstaining_member,
-            uninsured_member,
-          ],
-        )
-
-        expect(step.insured_members_requesting_insurance).to eq(
-          [insured_member],
-        )
-      end
-    end
-
-    context "with insured members not needing insurance" do
-      it "returns an empty array" do
-        insured_member = create(:member,
-                                insured: true,
-                                requesting_health_insurance: false)
-
-        uninsured_member = create(:member,
-                                  insured: false,
-                                  requesting_health_insurance: true)
-
-        step = Medicaid::InsuranceCurrentType.new(
-          members: [insured_member, uninsured_member],
-        )
-
-        expect(step.insured_members_requesting_insurance).to eq([])
-      end
-    end
-
-    context "without insured members" do
-      it "returns an empty array" do
-        step = Medicaid::InsuranceCurrentType.new(
-          members: create_list(:member, 2,
-                               insured: false,
-                               requesting_health_insurance: true),
-        )
-
-        expect(step.insured_members_requesting_insurance).to eq([])
       end
     end
   end


### PR DESCRIPTION
We want to loop through each user and ask them what their current insurance
plan is through. To do so we must break out of our current, codified,
patterns. We have to start with *A* member, and move to the next member
after submitting and saving, until we've reached the last user.

To complicate things, we have to be able to go *back* from the next
page/section and allow the client to re-enter adjust the insurance type if
they decide to go back.

To accomplish this we need to create the concept of a _current_member_ and
determine the next and previous members and the accompanying paths.