### PR TITLE
Update copy / design on Medicaid success page

### DIFF
--- a/app/models/concerns/submittable.rb
+++ b/app/models/concerns/submittable.rb
@@ -1,0 +1,19 @@
+module Submittable
+  extend ActiveSupport::Concern
+
+  def receiving_office_name
+    receiving_office.name
+  end
+
+  def receiving_office_email
+    receiving_office.email
+  end
+
+  def receiving_office_phone_number
+    receiving_office.phone_number
+  end
+
+  def receiving_office
+    @receiving_office ||= OfficeRecipient.new(benefit_application: self)
+  end
+end

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class MedicaidApplication < ApplicationRecord
+  include Submittable
+
   has_many :members, as: :benefit_application, dependent: :destroy
 
   attribute :last_four_ssn

--- a/app/models/office_recipient.rb
+++ b/app/models/office_recipient.rb
@@ -1,6 +1,6 @@
 class OfficeRecipient
-  def initialize(snap_application:)
-    @snap_application = snap_application
+  def initialize(benefit_application:)
+    @benefit_application = benefit_application
   end
 
   def fax_number
@@ -23,7 +23,7 @@ class OfficeRecipient
     if office_location.present?
       self.class.offices[office_location]
     else
-      self.class.find_by(zip: residential_address.zip)
+      self.class.find_by(zip: residential_address_zip)
     end
   end
 
@@ -72,13 +72,21 @@ class OfficeRecipient
 
   private
 
-  attr_reader :snap_application
+  attr_reader :benefit_application
+
+  def residential_address_zip
+    if benefit_application.respond_to?(:residential_zip)
+      benefit_application.residential_zip
+    else
+      residential_address.zip
+    end
+  end
 
   def residential_address
-    snap_application.residential_address
+    benefit_application.residential_address
   end
 
   def office_location
-    snap_application.office_location
+    benefit_application.office_location
   end
 end

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -1,4 +1,6 @@
 class SnapApplication < ApplicationRecord
+  include Submittable
+
   CARE_EXPENSES = %w[
     childcare
     disabled_adult_care
@@ -123,22 +125,6 @@ class SnapApplication < ApplicationRecord
 
   def zip
     residential_address.zip
-  end
-
-  def receiving_office_name
-    receiving_office.name
-  end
-
-  def receiving_office_email
-    receiving_office.email
-  end
-
-  def receiving_office_phone_number
-    receiving_office.phone_number
-  end
-
-  def receiving_office
-    @receiving_office ||= OfficeRecipient.new(snap_application: self)
   end
 
   def full_name

--- a/app/views/medicaid/success/edit.html.erb
+++ b/app/views/medicaid/success/edit.html.erb
@@ -1,12 +1,50 @@
 <% content_for :back_path, nil %>
-<% content_for :header_title, "Success" %>
+<% content_for :header_title, "Application Submitted" %>
 
 <div class="form-card">
-  <header class="form-card__header">
-    <div class="illustration illustration--success"></div>
-    <div class="form-card__title">Thanks for submitting an application!</div>
-  </header>
+    <header class="form-card__header">
+      <div class="illustration illustration--success"></div>
+      <div class="pre-title">Congratulations</div>
+      <div class="form-card__title">
+        Your application has been successfully submitted to MDHHS.
+      </div>
+      <div class="text--caps text--centered text--little-help nudge--med">
+        You applied for
+      </div>
+      <label class="program-selector program-selector__unbordered">
+        <h4 class="program-selector__title">Medicaid</h4>
+      </label>
+    </header>
 
-  <div class="form-card__confirmation">
-  </div>
+    <div class="form-card__content form-card__expect_next">
+      <h3 class="with-padding-med">What to expect next:</h3>
+      <div class="media-box with-padding-small">
+        <div class="media-box__media">
+          <div class="emoji emoji--med emoji--clipboard"></div>
+        </div>
+        <div class="media-box__content">
+          <p>
+          Your county will provide you with a list of paperwork you may need to
+          submit to verify your eligibility. Commonly requested items are
+          identification, paystubs, and health insurance cards if you have
+          another plan currently.
+          </p>
+        </div>
+      </div>
+
+      <div class="media-box with-padding-med">
+        <div class="media-box__media">
+          <div class="emoji emoji--med emoji--modern-phone"></div>
+        </div>
+        <div class="media-box__content">
+          <div class="media-box__content">
+            <p>
+            <b>If you have questions about your application</b>
+            contact the <%= full_office_name(current_application)  %>
+          office at <%= number_to_phone(current_application.receiving_office_phone_number) %>.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
 </div>

--- a/db/migrate/20171102231334_add_office_location_to_medicaid_applications.rb
+++ b/db/migrate/20171102231334_add_office_location_to_medicaid_applications.rb
@@ -1,0 +1,5 @@
+class AddOfficeLocationToMedicaidApplications < ActiveRecord::Migration[5.1]
+  def change
+    add_column :medicaid_applications, :office_location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171102231333) do
+ActiveRecord::Schema.define(version: 20171102231334) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -136,6 +136,7 @@ ActiveRecord::Schema.define(version: 20171102231333) do
     t.string "mailing_zip"
     t.boolean "michigan_resident", null: false
     t.boolean "need_medical_expense_help_3_months"
+    t.string "office_location"
     t.string "paperwork", array: true
     t.string "phone_number"
     t.boolean "reliable_mail_address"

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -178,5 +178,11 @@ RSpec.feature "Medicaid app" do
       )
       click_on "I'll do this later"
     end
+
+    on_pages "Application Submitted" do
+      expect(page).to have_content(
+        "Your application has been successfully submitted",
+      )
+    end
   end
 end

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -157,5 +157,11 @@ RSpec.feature "Medicaid app" do
       )
       click_on "I'll do this later"
     end
+
+    on_pages "Application Submitted" do
+      expect(page).to have_content(
+        "Your application has been successfully submitted",
+      )
+    end
   end
 end


### PR DESCRIPTION
* Make it look more like SNAP
* Needed to add `office_location` to MedicaidApplications so we could use office location logic to show the phone number.

Medicaid:

<img width="700" alt="screen shot 2017-11-03 at 1 13 02 pm" src="https://user-images.githubusercontent.com/601515/32393978-c532872a-c098-11e7-83e5-bb4dba60ed63.png">



SNAP:

<img width="728" alt="screen shot 2017-11-03 at 12 55 19 pm" src="https://user-images.githubusercontent.com/601515/32393917-92b60506-c098-11e7-8c44-da1185994429.png">


[Finishes #152423848]