### PR TITLE
Add Devise auth for admin dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "bourbon", "~> 4.2.0" # to keep in sync with getcalfresh
 gem "capybara"
 gem "delayed_job_active_record"
 gem "delayed_job_web"
+gem "devise"
 gem "faraday"
 gem "good_migrations"
 gem "high_voltage"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       aws-sdk-core (= 2.10.50)
     aws-sigv4 (1.0.2)
     backports (3.8.0)
+    bcrypt (3.1.11)
     bourbon (4.2.7)
       sass (~> 3.4)
       thor (~> 0.19)
@@ -118,6 +119,12 @@ GEM
       activerecord (> 3.0.0)
       delayed_job (> 2.0.3)
       sinatra (>= 1.4.4)
+    devise (4.3.0)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0, < 5.2)
+      responders
+      warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.1.5)
     dotenv (2.2.1)
@@ -208,6 +215,7 @@ GEM
     nio4r (2.1.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    orm_adapter (0.5.0)
     overcommit (0.41.0)
       childprocess (~> 0.6, >= 0.6.3)
       iniparse (~> 1.4)
@@ -380,6 +388,8 @@ GEM
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.3.0)
+    warden (1.2.7)
+      rack (>= 1.0)
     webmock (3.0.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
@@ -409,6 +419,7 @@ DEPENDENCIES
   database_cleaner
   delayed_job_active_record
   delayed_job_web
+  devise
   dotenv-rails
   factory_bot_rails
   faraday
@@ -454,4 +465,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0.pre.3

--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -6,15 +6,8 @@
 # you're free to overwrite the RESTful controller actions.
 module Admin
   class ApplicationController < Administrate::ApplicationController
-    before_action :authenticate_admin
+    before_action :authenticate_admin_user!
     before_action :default_params
-
-    def authenticate_admin
-      authenticate_or_request_with_http_basic do |username, password|
-        username == ENV.fetch("ADMIN_USER", "admin") &&
-          password == ENV.fetch("ADMIN_PASSWORD", "password")
-      end
-    end
 
     def default_params
       params[:order] ||= "created_at"

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -1,0 +1,9 @@
+class AdminUser < ApplicationRecord
+  devise(
+    :database_authenticatable,
+    :recoverable,
+    :rememberable,
+    :trackable,
+    :validatable,
+  )
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,15 @@
+Devise.setup do |config|
+  config.mailer_sender = "hello@michiganbenefits.org"
+  require "devise/orm/active_record"
+
+  config.case_insensitive_keys = [:email]
+  config.strip_whitespace_keys = [:email]
+  config.skip_session_storage = [:http_auth]
+  config.stretches = Rails.env.test? ? 1 : 11
+  config.reconfirmable = true
+  config.expire_all_remember_me_on_sign_out = true
+  config.password_length = 6..128
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.reset_password_within = 6.hours
+  config.sign_out_via = :delete
+end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,0 +1,64 @@
+# Additional translations at https://github.com/plataformatec/devise/wiki/I18n
+
+en:
+  devise:
+    confirmations:
+      confirmed: "Your email address has been successfully confirmed."
+      send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
+    failure:
+      already_authenticated: "You are already signed in."
+      inactive: "Your account is not activated yet."
+      invalid: "Invalid %{authentication_keys} or password."
+      locked: "Your account is locked."
+      last_attempt: "You have one more attempt before your account is locked."
+      not_found_in_database: "Invalid %{authentication_keys} or password."
+      timeout: "Your session expired. Please sign in again to continue."
+      unauthenticated: "You need to sign in or sign up before continuing."
+      unconfirmed: "You have to confirm your email address before continuing."
+    mailer:
+      confirmation_instructions:
+        subject: "Confirmation instructions"
+      reset_password_instructions:
+        subject: "Reset password instructions"
+      unlock_instructions:
+        subject: "Unlock instructions"
+      email_changed:
+        subject: "Email Changed"
+      password_change:
+        subject: "Password Changed"
+    omniauth_callbacks:
+      failure: "Could not authenticate you from %{kind} because \"%{reason}\"."
+      success: "Successfully authenticated from %{kind} account."
+    passwords:
+      no_token: "You can't access this page without coming from a password reset email. If you do come from a password reset email, please make sure you used the full URL provided."
+      send_instructions: "You will receive an email with instructions on how to reset your password in a few minutes."
+      send_paranoid_instructions: "If your email address exists in our database, you will receive a password recovery link at your email address in a few minutes."
+      updated: "Your password has been changed successfully. You are now signed in."
+      updated_not_active: "Your password has been changed successfully."
+    registrations:
+      destroyed: "Bye! Your account has been successfully cancelled. We hope to see you again soon."
+      signed_up: "Welcome! You have signed up successfully."
+      signed_up_but_inactive: "You have signed up successfully. However, we could not sign you in because your account is not yet activated."
+      signed_up_but_locked: "You have signed up successfully. However, we could not sign you in because your account is locked."
+      signed_up_but_unconfirmed: "A message with a confirmation link has been sent to your email address. Please follow the link to activate your account."
+      update_needs_confirmation: "You updated your account successfully, but we need to verify your new email address. Please check your email and follow the confirm link to confirm your new email address."
+      updated: "Your account has been updated successfully."
+    sessions:
+      signed_in: "Signed in successfully."
+      signed_out: "Signed out successfully."
+      already_signed_out: "Signed out successfully."
+    unlocks:
+      send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."
+      send_paranoid_instructions: "If your account exists, you will receive an email with instructions for how to unlock it in a few minutes."
+      unlocked: "Your account has been unlocked successfully. Please sign in to continue."
+  errors:
+    messages:
+      already_confirmed: "was already confirmed, please try signing in"
+      confirmation_period_expired: "needs to be confirmed within %{period}, please request a new one"
+      expired: "has expired, please request a new one"
+      not_found: "not found"
+      not_locked: "was not locked"
+      not_saved:
+        one: "1 error prohibited this %{resource} from being saved:"
+        other: "%{count} errors prohibited this %{resource} from being saved:"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  devise_for :admin_users
   match "/delayed_job" => DelayedJobWeb, anchor: false, via: %i(get post)
 
   namespace :admin do

--- a/db/migrate/20171102182715_devise_create_admin_users.rb
+++ b/db/migrate/20171102182715_devise_create_admin_users.rb
@@ -1,0 +1,20 @@
+class DeviseCreateAdminUsers < ActiveRecord::Migration[5.1]
+  def change
+    create_table :admin_users do |t|
+      t.string :email, null: false, default: ""
+      t.string :encrypted_password, null: false, default: ""
+      t.string :reset_password_token
+      t.datetime :reset_password_sent_at
+      t.datetime :remember_created_at
+      t.integer :sign_in_count, default: 0, null: false
+      t.datetime :current_sign_in_at
+      t.datetime :last_sign_in_at
+      t.inet :current_sign_in_ip
+      t.inet :last_sign_in_ip
+      t.timestamps null: false
+    end
+
+    add_index :admin_users, :email, unique: true
+    add_index :admin_users, :reset_password_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171102154724) do
+ActiveRecord::Schema.define(version: 20171102182715) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,23 @@ ActiveRecord::Schema.define(version: 20171102154724) do
     t.datetime "updated_at", null: false
     t.string "zip", null: false
     t.index ["snap_application_id"], name: "index_addresses_on_snap_application_id"
+  end
+
+  create_table "admin_users", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "current_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.datetime "last_sign_in_at"
+    t.inet "last_sign_in_ip"
+    t.datetime "remember_created_at"
+    t.datetime "reset_password_sent_at"
+    t.string "reset_password_token"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_admin_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
   create_table "delayed_jobs", force: :cascade do |t|

--- a/spec/controllers/admin/snap_application_controller_spec.rb
+++ b/spec/controllers/admin/snap_application_controller_spec.rb
@@ -2,21 +2,18 @@ require "rails_helper"
 
 RSpec.describe Admin::SnapApplicationsController do
   describe "#index" do
-    it "returns error with no proper authentication" do
-      get :index
+    context "not authenticated" do
+      it "redirects to auth page" do
+        get :index
 
-      expect(response.status).to eq 401
+        expect(response.status).to eq 302
+      end
     end
 
-    context "performing a search" do
+    context "authenticated" do
       it "returns successfully" do
-        create(:snap_application, signature: "Joel Tester")
-
-        request.env["HTTP_AUTHORIZATION"] =
-          ActionController::HttpAuthentication::Basic.encode_credentials(
-            "admin",
-            "password",
-          )
+        admin_user = create(:admin_user)
+        sign_in(admin_user)
 
         get :index, params: { search: "Joel" }
 

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :admin_user do
+    email "test@example.com"
+    password "123456"
+  end
+end

--- a/spec/features/admin_dashboard_members_spec.rb
+++ b/spec/features/admin_dashboard_members_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Admins can view members" do
   before do
-    page.driver.browser.current_session.basic_authorize("admin", "password")
+    user = create(:admin_user)
+    login_as(user)
   end
 
   scenario "Members is linked from the navigation" do

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -2,7 +2,8 @@ require "rails_helper"
 
 RSpec.feature "Submit application with minimal information" do
   before do
-    page.driver.browser.current_session.basic_authorize("admin", "password")
+    user = create(:admin_user)
+    login_as(user)
   end
 
   scenario "The stats are accurate", javascript: true do

--- a/spec/features/admin_user_login_spec.rb
+++ b/spec/features/admin_user_login_spec.rb
@@ -1,0 +1,16 @@
+require "rails_helper"
+
+RSpec.feature "Admin user login" do
+  scenario "admin not logged in" do
+    admin_user = create(:admin_user)
+
+    visit admin_root_path
+    expect(current_path).to eq "/admin_users/sign_in"
+
+    fill_in "Email", with: admin_user.email
+    fill_in "Password", with: admin_user.password
+    click_on "Log in"
+
+    expect(current_path).to eq admin_root_path
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ require "capybara/rspec"
 require "selenium/webdriver"
 require "capybara/drivers/chrome"
 require "capybara/drivers/headless_chrome"
+require "devise"
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 Capybara.javascript_driver = :headless_chrome # or `:chrome` for full browser
@@ -41,6 +42,8 @@ RSpec.configure do |config|
   config.include FeatureHelper, type: :feature
   config.include SnapApplicationFormHelper, type: :feature
   config.include MedicaidApplicationFormHelper, type: :feature
+  config.include Warden::Test::Helpers, type: :feature
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.include GenericHelper
   config.include BackgroundJobs
 end


### PR DESCRIPTION
[Finishes #152367741]

**NOTES**:
- chose Devise bc it will be easy to add 2FA later
- did not include "registerable" functionality so all new accounts will
need to be created via Rails console
- attempted to throw a "sign out" link in there but that was proving to
be difficult CSS-wise and was not a requirement in the ticket so I left
it out.
- confirmed that reset password email does work
- we still need the ADMIN_PASSWORD and ADMIN_USER env vars for delayed
job.

![screen shot 2017-11-02 at 11 58 30 am](https://user-images.githubusercontent.com/601515/32346849-0b6cf0cc-bfcc-11e7-9f2e-a10c76b4fe9d.png)
