### PR TITLE
Select other income types per-member for Medicaid

### DIFF
--- a/app/controllers/medicaid/income_other_income_type_controller.rb
+++ b/app/controllers/medicaid/income_other_income_type_controller.rb
@@ -1,8 +1,55 @@
 # frozen_string_literal: true
 
 module Medicaid
-  class IncomeOtherIncomeTypeController < MedicaidStepsController
+  class IncomeOtherIncomeTypeController < Medicaid::MemberStepsController
+    def edit
+      @step = step_class.new(
+        array_to_checkboxes(current_member.other_income_types).
+        merge(member_id: current_member.id),
+      )
+    end
+
+    def update
+      @step = step_class.new(
+        update_params.merge(member_id: step_params[:member_id]),
+      )
+
+      if @step.valid?
+        current_member.update(update_params)
+        redirect_to(next_path)
+      else
+        render :edit
+      end
+    end
+
+    def current_member
+      @_current_member ||= super || first_other_income_member
+    end
+
     private
+
+    def update_params
+      { other_income_types: checkboxes_to_array(step_params) }
+    end
+
+    def first_other_income_member
+      current_application.
+        members.
+        other_income.
+        limit(1).
+        first
+    end
+
+    def next_member
+      return if current_member.nil?
+
+      current_application.
+        members.
+        other_income.
+        after(current_member).
+        limit(1).
+        first
+    end
 
     def skip?
       nobody_with_other_income?
@@ -10,6 +57,10 @@ module Medicaid
 
     def nobody_with_other_income?
       !current_application&.anyone_other_income?
+    end
+
+    def checkboxes_to_array(checkboxes)
+      checkboxes.select { |_, value| value == "1" }.keys
     end
   end
 end

--- a/app/controllers/medicaid/insurance_current_type_controller.rb
+++ b/app/controllers/medicaid/insurance_current_type_controller.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 module Medicaid
-  class InsuranceCurrentTypeController < MedicaidStepsController
-    helper_method :current_member
-
+  class InsuranceCurrentTypeController < Medicaid::MemberStepsController
     def update
       @step = step_class.new(step_params)
 
@@ -16,24 +14,10 @@ module Medicaid
     end
 
     def current_member
-      @_current_member ||= begin
-                             member_from_form ||
-                               member_from_querystring ||
-                               first_insurance_holder
-                           end
+      @_current_member ||= super || first_insurance_holder
     end
 
     private
-
-    def next_path
-      next_member_path || super
-    end
-
-    def next_member_path
-      return if next_member.nil?
-
-      decoded_step_path(params: { member: next_member.id })
-    end
 
     def first_insurance_holder
       current_application.
@@ -56,27 +40,6 @@ module Medicaid
 
     def skip?
       current_application.nobody_insured?
-    end
-
-    def member_attrs
-      %i[insurance_type]
-    end
-
-    def existing_attributes
-      HashWithIndifferentAccess.new(current_member&.attributes)
-    end
-
-    def member_from_form
-      return if params.dig(:step, :member_id).blank?
-
-      member_id = params[:step].delete(:member_id)
-      current_application.members.find(member_id)
-    end
-
-    def member_from_querystring
-      return if params[:member].blank?
-
-      current_application.members.find(params[:member])
     end
   end
 end

--- a/app/controllers/medicaid/member_steps_controller.rb
+++ b/app/controllers/medicaid/member_steps_controller.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Medicaid
+  class MemberStepsController < MedicaidStepsController
+    helper_method :current_member
+
+    def current_member
+      @_current_member ||= member_from_form || member_from_querystring
+    end
+
+    private
+
+    def next_path
+      next_member_path || super
+    end
+
+    def next_member_path
+      return if next_member.nil?
+
+      decoded_step_path(params: { member: next_member.id })
+    end
+
+    def existing_attributes
+      HashWithIndifferentAccess.new(current_member&.attributes)
+    end
+
+    def member_from_form
+      return if params.dig(:step, :member_id).blank?
+
+      member_id = params[:step].delete(:member_id)
+      current_application.members.find(member_id)
+    end
+
+    def member_from_querystring
+      return if params[:member].blank?
+
+      current_application.members.find(params[:member])
+    end
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -60,6 +60,10 @@ class Member < ApplicationRecord
       order(created_at: :asc)
   end
 
+  def self.other_income
+    where(other_income: true).order(created_at: :asc)
+  end
+
   def self.after(member)
     where("created_at > ?", member.created_at)
   end

--- a/app/steps/medicaid/income_other_income_type.rb
+++ b/app/steps/medicaid/income_other_income_type.rb
@@ -3,11 +3,44 @@
 module Medicaid
   class IncomeOtherIncomeType < Step
     step_attributes(
-      :income_unemployment,
-      :income_pension,
-      :income_social_security,
-      :income_retirement,
-      :income_alimony,
+      :alimony,
+      :other,
+      :pension,
+      :retirement,
+      :social_security,
+      :unemployment,
+      :other_income_types,
+      :member_id,
     )
+
+    def valid?
+      if member_has_other_income? && no_other_income_type_provided?
+        errors.add(
+          :other_income_types,
+          "Please select at least one other income type",
+        )
+        false
+      else
+        true
+      end
+    end
+
+    private
+
+    def member_has_other_income?
+      member.other_income?
+    end
+
+    def no_other_income_type_provided?
+      other_income_types.empty?
+    end
+
+    def existing_attributes
+      HashWithIndifferentAccess.new(current_member&.attributes)
+    end
+
+    def member
+      @_member ||= Member.find(member_id)
+    end
   end
 end

--- a/app/views/medicaid/amounts_income/edit.html.erb
+++ b/app/views/medicaid/amounts_income/edit.html.erb
@@ -28,7 +28,10 @@
           "Your Self-Employment (average monthly income)" %>
       <% end %>
 
-      <% if current_application.income_unemployment? %>
+      <% if current_application.
+          primary_member.
+          other_income_types.
+          include?("unemployment") %>
         <%= f.mb_money_field :unemployment_income,
           "Your Unemployment (average monthly income)" %>
       <% end %>

--- a/app/views/medicaid/income_other_income_type/edit.html.erb
+++ b/app/views/medicaid/income_other_income_type/edit.html.erb
@@ -2,7 +2,11 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">What type of income do you receive that’s not from a job?</div>
+    <div class="form-card__title">
+      <%= t("medicaid.income_other_income_type.edit.title",
+            count: current_application.members.count,
+            name: current_member.full_name) %>
+  </div>
     <p class="text--help text--centered">
       Check all that apply.
     </p>
@@ -10,13 +14,15 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+      <%= f.hidden_field :member_id, value: current_member.id %>
       <%= f.mb_checkbox_set(
         [
-          { method: :income_unemployment, label: "Unemployment" },
-          { method: :income_pension, label: "Pension" },
-          { method: :income_social_security, label: "Social Security" },
-          { method: :income_retirement, label: "Retirement" },
-          { method: :income_alimony, label: "Alimony" },
+          { method: :unemployment, label: "Unemployment" },
+          { method: :pension, label: "Pension" },
+          { method: :social_security, label: "Social Security" },
+          { method: :retirement, label: "Retirement" },
+          { method: :alimony, label: "Alimony" },
+          { method: :other, label: "Other" },
         ],
         label_text: "" ) %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,6 +35,11 @@ en:
         title:
           one: Do you get income that’s not from a job?
           other: Does anyone in the household get income that’s not from a job?
+    income_other_income_type:
+      edit:
+        title:
+          one: What type of income do you receive that’s not from a job?
+          other: "What type of income does %{name} receive that’s not from a job?"
     income_self_employment:
       edit:
         title:

--- a/db/migrate/20171102231333_move_other_income_types_to_members.rb
+++ b/db/migrate/20171102231333_move_other_income_types_to_members.rb
@@ -1,0 +1,7 @@
+class MoveOtherIncomeTypesToMembers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :members, :other_income_types, :string, array: true
+
+    change_column_default :members, :other_income_types, from: nil, to: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171102182715) do
+ActiveRecord::Schema.define(version: 20171102231333) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -182,6 +182,7 @@ ActiveRecord::Schema.define(version: 20171102182715) do
     t.string "marital_status"
     t.boolean "new_mom"
     t.boolean "other_income", default: false
+    t.string "other_income_types", default: [], array: true
     t.boolean "pay_child_support_alimony_arrears"
     t.boolean "pay_student_loan_interest"
     t.string "relationship"

--- a/spec/controllers/medicaid/income_other_income_type_controller_spec.rb
+++ b/spec/controllers/medicaid/income_other_income_type_controller_spec.rb
@@ -1,11 +1,77 @@
 require "rails_helper"
 
 RSpec.describe Medicaid::IncomeOtherIncomeTypeController do
+  describe "#current_member" do
+    it "defaults to the first member with other income" do
+      medicaid_application = create(
+        :medicaid_application,
+        anyone_other_income: true,
+      )
+      _primary_member = create(
+        :member,
+        other_income: false,
+        benefit_application: medicaid_application,
+      )
+      other_income_member = create(
+        :member,
+        other_income: true,
+        benefit_application: medicaid_application,
+      )
+
+      session[:medicaid_application_id] = medicaid_application.id
+
+      expect(subject.current_member).to eq other_income_member
+    end
+
+    it "finds member from querystring" do
+      medicaid_application = create(
+        :medicaid_application,
+        anyone_other_income: true,
+      )
+      _joel = create(:member, benefit_application: medicaid_application)
+      jessie = create(:member, benefit_application: medicaid_application)
+
+      session[:medicaid_application_id] = medicaid_application.id
+
+      get :edit, params: { member: jessie.id }
+
+      expect(subject.current_member).to eq jessie
+    end
+
+    it "finds member from posted form" do
+      medicaid_application = create(
+        :medicaid_application,
+        anyone_other_income: true,
+      )
+      _joel = create(:member, benefit_application: medicaid_application)
+      jessie = create(
+        :member,
+        benefit_application: medicaid_application,
+        other_income_types: [],
+      )
+
+      session[:medicaid_application_id] = medicaid_application.id
+
+      put :update, params: {
+        step: {
+          member_id: jessie.id,
+          unemployment: "1",
+        },
+      }
+
+      expect(subject.current_member).to eq jessie
+      expect(jessie.reload.other_income_types).to eq(["unemployment"])
+    end
+  end
+
   describe "#edit" do
     context "client does not have non-job income" do
       it "redirects to next step" do
-        medicaid_application =
-          create(:medicaid_application, anyone_other_income: false)
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_other_income: false,
+          members: [create(:member, other_income: false)],
+        )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
@@ -18,8 +84,11 @@ RSpec.describe Medicaid::IncomeOtherIncomeTypeController do
 
     context "client has non-job income" do
       it "renders edit" do
-        medicaid_application =
-          create(:medicaid_application, anyone_other_income: true)
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_other_income: true,
+          members: [create(:member, other_income: true)],
+        )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -220,12 +220,20 @@ RSpec.feature "Medicaid app" do
         "Tell us who gets income that’s not from a job.",
       )
       check "Jessie Tester"
+      check "Christa Tester"
       click_on "Next"
 
       expect(page).to have_content(
-        "What type of income do you receive that’s not from a job?",
+        "What type of income does Jessie Tester receive that’s not from a job?",
       )
       check "Unemployment"
+      click_on "Next"
+
+      expect(page).to have_content(
+        "What type of income does Christa Tester receive that’s not from a" +
+        " job?",
+      )
+      check "Other"
       click_on "Next"
     end
 

--- a/spec/steps/medicaid/income_other_income_type_spec.rb
+++ b/spec/steps/medicaid/income_other_income_type_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IncomeOtherIncomeType do
+  describe "Validations" do
+    context "the household member has other income" do
+      it "is valid" do
+        member = create(:member, other_income: true)
+
+        step = Medicaid::IncomeOtherIncomeType.new(
+          member_id: member.id,
+          other_income_types: ["Unemployment"],
+        )
+
+        expect(step).to be_valid
+      end
+    end
+
+    context "a member with other income is missing an other income type" do
+      it "is invalid" do
+        member = create(
+          :member,
+          other_income: true,
+          other_income_types: [],
+        )
+
+        step = Medicaid::IncomeOtherIncomeType.new(
+          member_id: member.id,
+          other_income_types: member.other_income_types,
+        )
+
+        expect(step).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
**WHY**:
- before, this was saved on the medicaid app as a series of booleans
- now, we are saving each type as as string in an array field called
"other_income_types" that is on the member.
- extracted some common controller code into an inheritance structure
- part III of https://trello.com/c/tHLD1PgG/441-medicaid-mm-flow-current-income-does-anyone-in-the-household-get-income-thats-not-from-a-job-nested-2

<img width="747" alt="screen shot 2017-11-03 at 9 46 06 am" src="https://user-images.githubusercontent.com/601515/32385792-790a20ea-c07c-11e7-92ff-e279bc19c547.png">


TODO:
- remove / migrate the old boolean fields on medicaid
- refine the "back" logic. Right now, going back from any
member page goes to '/medicaid/income-other-income-member' and going
back from "/medicaid/expenses-alimony" goes to
"/medicaid/income-other-income-type" for the primary member (rather than
going back through the pages in the member order)