### PR TITLE
Remove Insurance Plans sub-header copy

### DIFF
--- a/app/views/medicaid/insurance_current_type/edit.html.erb
+++ b/app/views/medicaid/insurance_current_type/edit.html.erb
@@ -17,7 +17,7 @@
 
       <%= f.hidden_field(:member_id, value: current_member.id) %>
 
-      <%= f.mb_radio_set :insurance_type, "Insurance plans",
+      <%= f.mb_radio_set :insurance_type, "",
         [
           { value: "Medicaid", label: "Medicaid" },
           { value: "CHIP/MIChild", label: "CHIP/MIChild" },

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -136,7 +136,7 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "What type of insurance plan is Jessie Tester currently enrolled in",
       )
-      select_radio(question: "Insurance plans", answer: "Medicaid")
+      choose("Medicaid")
       click_on "Next"
     end
 


### PR DESCRIPTION
- Remove "Insurance Plans" to keep subheader patter consistent
![image](https://user-images.githubusercontent.com/7483074/32386536-36c079fe-c087-11e7-9480-68a371b3f0c5.png)
