### PR TITLE
Use `display_name` instead of `full_name` to show member names

### DIFF
--- a/app/controllers/medicaid/intro_household_controller.rb
+++ b/app/controllers/medicaid/intro_household_controller.rb
@@ -2,9 +2,8 @@ module Medicaid
   class IntroHouseholdController < MedicaidStepsController
     def edit
       @step = step_class.new(
-        first_name: current_application.primary_member.first_name,
-        last_name: current_application.primary_member.last_name,
         non_applicant_members: current_application.non_applicant_members,
+        primary_member: current_application.primary_member,
       )
     end
   end

--- a/app/dashboards/member_dashboard.rb
+++ b/app/dashboards/member_dashboard.rb
@@ -107,6 +107,6 @@ class MemberDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how members are displayed
   # across all pages of the admin dashboard.
   def display_resource(member)
-    "#{member.first_name} #{member.last_name}"
+    member.display_name
   end
 end

--- a/app/models/employed_member_attributes.rb
+++ b/app/models/employed_member_attributes.rb
@@ -6,7 +6,7 @@ class EmployedMemberAttributes
 
   def to_h
     {
-      "#{position}_employed_full_name" => member.full_name,
+      "#{position}_employed_full_name" => member.display_name,
       "#{position}_employed_employer_name" => member.employed_employer_name,
       "#{position}_employed_hours_per_week" => member.employed_hours_per_week,
       "#{position}_employed_hours_interval" =>

--- a/app/models/extra_employed_member_attributes.rb
+++ b/app/models/extra_employed_member_attributes.rb
@@ -4,7 +4,7 @@ class ExtraEmployedMemberAttributes
   end
 
   def title
-    "Employment details for household member: #{member.full_name}"
+    "Employment details for household member: #{member.display_name}"
   end
 
   def to_a

--- a/app/models/extra_member_attributes.rb
+++ b/app/models/extra_member_attributes.rb
@@ -4,12 +4,12 @@ class ExtraMemberAttributes
   end
 
   def title
-    "Details for household member: #{member.full_name}"
+    "Details for household member: #{member.display_name}"
   end
 
   def to_a
     [
-      "1. Name: #{member.full_name}",
+      "1. Name: #{member.display_name}",
       "2. Date of birth: #{formatted_birthday(member)}",
       "3. Relationship: #{relationship(member)}",
       "4. Sex: #{member.sex}",

--- a/app/models/extra_self_employed_member_attributes.rb
+++ b/app/models/extra_self_employed_member_attributes.rb
@@ -4,7 +4,8 @@ class ExtraSelfEmployedMemberAttributes
   end
 
   def title
-    "Self-Employment income details for household member: #{member.full_name}"
+    "Self-Employment income details for household member: " +
+      member.display_name
   end
 
   def to_a

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -68,8 +68,8 @@ class Member < ApplicationRecord
     where("created_at > ?", member.created_at)
   end
 
-  def full_name
-    "#{first_name} #{last_name}"
+  def display_name
+    "#{first_name} #{last_name}".titleize
   end
 
   def primary_member?

--- a/app/models/null_member.rb
+++ b/app/models/null_member.rb
@@ -1,5 +1,5 @@
 class NullMember
-  def full_name
+  def display_name
     ""
   end
 

--- a/app/models/self_employed_member_attributes.rb
+++ b/app/models/self_employed_member_attributes.rb
@@ -6,7 +6,7 @@ class SelfEmployedMemberAttributes
 
   def to_h
     {
-      "#{position}_self_employed_full_name" => member.full_name,
+      "#{position}_self_employed_full_name" => member.display_name,
       "#{position}_self_employed_profession" => member.self_employed_profession,
       "#{position}_self_employed_monthly_income" =>
         member.self_employed_monthly_income,

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -127,8 +127,8 @@ class SnapApplication < ApplicationRecord
     residential_address.zip
   end
 
-  def full_name
-    primary_member.full_name
+  def display_name
+    primary_member.display_name
   end
 
   def birthday

--- a/app/models/snap_application_attributes.rb
+++ b/app/models/snap_application_attributes.rb
@@ -179,15 +179,15 @@ class SnapApplicationAttributes
   end
 
   def first_member_with_disability_name
-    disabled_members[0].try(:full_name)
+    disabled_members[0].try(:display_name)
   end
 
   def second_member_with_disability_name
-    disabled_members[1].try(:full_name)
+    disabled_members[1].try(:display_name)
   end
 
   def third_member_with_disability_name
-    disabled_members[2].try(:full_name)
+    disabled_members[2].try(:display_name)
   end
 
   def disabled_members
@@ -211,7 +211,7 @@ class SnapApplicationAttributes
       members.
       where.
       not(buy_food_with: true).
-      pluck('concat(first_name, \' \', last_name) AS full_name').
+      pluck('concat(first_name, \' \', last_name) AS display_name').
       to_sentence
   end
 

--- a/app/models/snap_application_member_attributes.rb
+++ b/app/models/snap_application_member_attributes.rb
@@ -6,7 +6,7 @@ class SnapApplicationMemberAttributes
 
   def to_h
     {
-      "#{position}_member_full_name" => member.full_name,
+      "#{position}_member_full_name" => member.display_name,
       "#{position}_member_sex_male" => bool_to_checkbox(member.sex == "male"),
       "#{position}_member_sex_female" =>
         bool_to_checkbox(member.sex == "female"),

--- a/app/models/verification_document.rb
+++ b/app/models/verification_document.rb
@@ -30,7 +30,7 @@ class VerificationDocument
   end
 
   def header
-    output = "Name:                  #{snap_application.full_name}\n"
+    output = "Name:                  #{snap_application.display_name}\n"
     output += "Date of Birth:        #{snap_application.birthday}\n"
     output
   end

--- a/app/steps/medicaid/intro_household.rb
+++ b/app/steps/medicaid/intro_household.rb
@@ -1,8 +1,7 @@
 module Medicaid
   class IntroHousehold < Step
     step_attributes(
-      :first_name,
-      :last_name,
+      :primary_member,
       :non_applicant_members,
     )
   end

--- a/app/views/household_more_info_per_member/_member_checkboxes.html.erb
+++ b/app/views/household_more_info_per_member/_member_checkboxes.html.erb
@@ -1,5 +1,5 @@
 <% step.members.each do |member| %>
   <%= f.fields_for('members[]', member) do |ff| %>
-    <%= ff.mb_checkbox(method, member.full_name) %>
+    <%= ff.mb_checkbox(method, member.display_name) %>
   <% end %>
 <% end %>

--- a/app/views/household_more_info_per_member/edit.html.erb
+++ b/app/views/household_more_info_per_member/edit.html.erb
@@ -16,7 +16,7 @@
               <%= f.fields_for('members[]', member) do |ff| %>
                 <%= ff.mb_checkbox(
                   :citizen,
-                  member.full_name,
+                  member.display_name,
                   { checked_value: "0", unchecked_value: "1" },
                 ) %>
               <% end %>

--- a/app/views/income_details_per_member/_header.html.erb
+++ b/app/views/income_details_per_member/_header.html.erb
@@ -1,2 +1,2 @@
-<div class="household-member-group" data-member-name="<%= member.full_name %>">
-  <p class="text--section-header"><%= member.full_name %> (<%= member.employment_status.titleize %>)</p>
+<div class="household-member-group" data-member-name="<%= member.display_name %>">
+  <p class="text--section-header"><%= member.display_name %> (<%= member.employment_status.titleize %>)</p>

--- a/app/views/income_employment_status/edit.html.erb
+++ b/app/views/income_employment_status/edit.html.erb
@@ -17,7 +17,7 @@
       <% @step.members.each do |member| %>
         <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <fieldset class="form-group">
-            <div class="household-member-group" data-member-name="<%= member.full_name %>">
+            <div class="household-member-group" data-member-name="<%= member.display_name %>">
               <h4><%= header_name(member) %></h4>
               <%= ff.mb_radio_set :employment_status,
                 "",

--- a/app/views/medicaid/contact_social_security/edit.html.erb
+++ b/app/views/medicaid/contact_social_security/edit.html.erb
@@ -22,8 +22,8 @@
         <% @step.members_requesting_health_insurance.each do |member| %>
           <fieldset class="form-group">
             <%= f.fields_for('members[]', member) do |ff| %>
-              <div class="household-member-group" data-member-name="<%= member.full_name %>">
-                <p class="text--section-header"><%= member.full_name %></p>
+              <div class="household-member-group" data-member-name="<%= member.display_name %>">
+                <p class="text--section-header"><%= member.display_name %></p>
                 <%= ff.mb_input_field :last_four_ssn,
                   "Social Security Number (last 4 digits)",
                   type: :tel,

--- a/app/views/medicaid/expenses_alimony_member/edit.html.erb
+++ b/app/views/medicaid/expenses_alimony_member/edit.html.erb
@@ -20,7 +20,7 @@
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox(:pay_child_support_alimony_arrears,
-                             member.full_name) %>
+                             member.display_name) %>
           <% end %>
         <% end %>
       </fieldset>

--- a/app/views/medicaid/expenses_student_loan_member/edit.html.erb
+++ b/app/views/medicaid/expenses_student_loan_member/edit.html.erb
@@ -19,7 +19,7 @@
       <fieldset class="form-group">
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox(:pay_student_loan_interest, member.full_name) %>
+            <%= ff.mb_checkbox(:pay_student_loan_interest, member.display_name) %>
           <% end %>
         <% end %>
       </fieldset>

--- a/app/views/medicaid/health_disability_member/edit.html.erb
+++ b/app/views/medicaid/health_disability_member/edit.html.erb
@@ -19,7 +19,7 @@
       <fieldset class="form-group">
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox :disabled, member.full_name %>
+            <%= ff.mb_checkbox :disabled, member.display_name %>
           <% end %>
         <% end %>
       </fieldset>

--- a/app/views/medicaid/health_pregnancy_member/edit.html.erb
+++ b/app/views/medicaid/health_pregnancy_member/edit.html.erb
@@ -23,7 +23,7 @@
           <%= f.fields_for("members[]", member) do |ff| %>
             <%= ff.mb_checkbox(
               :new_mom,
-              member.full_name,
+              member.display_name,
               { checked_value: "1", unchecked_value: "0" },
             ) %>
           <% end %>

--- a/app/views/medicaid/income_job_number_member/edit.html.erb
+++ b/app/views/medicaid/income_job_number_member/edit.html.erb
@@ -15,8 +15,8 @@
       <% @step.members.each do |member| %>
         <fieldset class="form-group">
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-              <div class="household-member-group" data-member-name="<%= member.full_name %>">
-                <p class="text--section-header"><%= member.full_name %></p>
+              <div class="household-member-group" data-member-name="<%= member.display_name %>">
+                <p class="text--section-header"><%= member.display_name %></p>
                 <%= ff.mb_select :employed_number_of_jobs,
                 "",
                 (1..10).map { |number| [pluralize(number, "job"), number] },

--- a/app/views/medicaid/income_other_income_member/edit.html.erb
+++ b/app/views/medicaid/income_other_income_member/edit.html.erb
@@ -19,7 +19,7 @@
           <%= f.fields_for("members[]", member) do |ff| %>
             <%= ff.mb_checkbox(
               :other_income,
-              member.full_name,
+              member.display_name,
               { checked_value: "1", unchecked_value: "0" },
             ) %>
           <% end %>

--- a/app/views/medicaid/income_other_income_type/edit.html.erb
+++ b/app/views/medicaid/income_other_income_type/edit.html.erb
@@ -5,7 +5,7 @@
     <div class="form-card__title">
       <%= t("medicaid.income_other_income_type.edit.title",
             count: current_application.members.count,
-            name: current_member.full_name) %>
+            name: current_member.display_name) %>
   </div>
     <p class="text--help text--centered">
       Check all that apply.

--- a/app/views/medicaid/income_self_employment_member/edit.html.erb
+++ b/app/views/medicaid/income_self_employment_member/edit.html.erb
@@ -15,7 +15,7 @@
               <%= f.fields_for("members[]", member) do |ff| %>
                   <%= ff.mb_checkbox(
                           :self_employed,
-                          member.full_name,
+                          member.display_name,
                           { checked_value: "1", unchecked_value: "0" },
                       ) %>
               <% end %>

--- a/app/views/medicaid/insurance_current_member/edit.html.erb
+++ b/app/views/medicaid/insurance_current_member/edit.html.erb
@@ -9,7 +9,7 @@
       <p class="text--help text--centered">
         <%= t("medicaid.insurance_current_member.edit.helper_text",
               count: @step.members_not_needing_insurance.count,
-              names: @step.members_not_needing_insurance.map(&:full_name).to_sentence) %>
+              names: @step.members_not_needing_insurance.map(&:display_name).to_sentence) %>
       </p>
     <% end %>
   </header>
@@ -22,7 +22,7 @@
               <%= f.fields_for("members[]", member) do |ff| %>
                 <%= ff.mb_checkbox(
                     :insured,
-                    member.full_name,
+                    member.display_name,
                     { checked_value: "1", unchecked_value: "0" },
                 ) %>
               <% end %>

--- a/app/views/medicaid/insurance_current_type/edit.html.erb
+++ b/app/views/medicaid/insurance_current_type/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.insurance_current_type.edit.title",
-            name: current_member.full_name) %>
+            name: current_member.display_name) %>
     </div>
   </header>
 

--- a/app/views/medicaid/insurance_needed/edit.html.erb
+++ b/app/views/medicaid/insurance_needed/edit.html.erb
@@ -19,7 +19,7 @@
           <%= f.fields_for("members[]", member) do |ff| %>
             <%= ff.mb_checkbox(
               :requesting_health_insurance,
-              member.full_name,
+              member.display_name,
               { checked_value: "1", unchecked_value: "0" },
             ) %>
           <% end %>

--- a/app/views/medicaid/intro_caretaker_member/edit.html.erb
+++ b/app/views/medicaid/intro_caretaker_member/edit.html.erb
@@ -16,7 +16,7 @@
         <fieldset class="form-group">
           <% @step.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-                  <%= ff.mb_checkbox :caretaker_or_parent, member.full_name %>
+                  <%= ff.mb_checkbox :caretaker_or_parent, member.display_name %>
               <% end %>
           <% end %>
         </fieldset>

--- a/app/views/medicaid/intro_citizen_member/edit.html.erb
+++ b/app/views/medicaid/intro_citizen_member/edit.html.erb
@@ -18,7 +18,7 @@
       <fieldset class="form-group">
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox :citizen, member.full_name %>
+            <%= ff.mb_checkbox :citizen, member.display_name %>
           <% end %>
         <% end %>
       </fieldset>

--- a/app/views/medicaid/intro_college_member/edit.html.erb
+++ b/app/views/medicaid/intro_college_member/edit.html.erb
@@ -14,10 +14,10 @@
           <% @step.members.each do |member| %>
               <%= f.fields_for("members[]", member) do |ff| %>
                   <%= ff.mb_checkbox(
-                          :in_college,
-                          member.full_name,
-                          { checked_value: "1", unchecked_value: "0" },
-                      ) %>
+                    :in_college,
+                    member.display_name,
+                    { checked_value: "1", unchecked_value: "0" },
+                  ) %>
               <% end %>
           <% end %>
         </fieldset>

--- a/app/views/medicaid/intro_household/edit.html.erb
+++ b/app/views/medicaid/intro_household/edit.html.erb
@@ -17,13 +17,13 @@
       <div class="card card--narrow">
         <p>
           <i class="button__icon--left icon-check icon-check--color"></i>
-          <%= "#{@step.first_name} #{@step.last_name}" %>  (That’s you!)
+          <%= "#{@step.primary_member.display_name} (That’s you!)" %>
         </p>
         <% @step.non_applicant_members.each do |member| %>
             <div>
               <p>
                 <i class="button__icon--left icon-check icon-check--color"></i>
-                <%= "#{member.first_name.titleize} #{member.last_name.titleize}" %>
+                <%= "#{member.display_name}" %>
               </p>
             </div>
         <% end %>

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -199,7 +199,7 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "Tell us who in your household has one or more jobs.",
       )
-      select_job_number(full_name: "Christa Tester", job_number: "2 jobs")
+      select_job_number(display_name: "Christa Tester", job_number: "2 jobs")
       click_on "Next"
 
       expect(page).to have_content("Is anyone in the household self-employed?")
@@ -336,8 +336,8 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "Tell us your Social Security Number and Date of Birth",
       )
-      enter_dob_and_ssn(full_name: "Jessie Tester", last_four_ssn: "1234")
-      enter_dob_and_ssn(full_name: "Christa Tester", last_four_ssn: "0111")
+      enter_dob_and_ssn(display_name: "Jessie Tester", last_four_ssn: "1234")
+      enter_dob_and_ssn(display_name: "Christa Tester", last_four_ssn: "0111")
     end
   end
 end

--- a/spec/features/snap_application_with_maximum_info_spec.rb
+++ b/spec/features/snap_application_with_maximum_info_spec.rb
@@ -91,11 +91,11 @@ feature "SNAP application with maximum info" do
 
     on_page "Money & Income" do
       select_employment(
-        full_name: "Jessie Tester",
+        display_name: "Jessie Tester",
         employment_status: "Self Employed",
       )
       select_employment(
-        full_name: "Joey Tester",
+        display_name: "Joey Tester",
         employment_status: "Employed",
       )
       click_on "Continue"

--- a/spec/features/snap_application_with_minimal_info_spec.rb
+++ b/spec/features/snap_application_with_minimal_info_spec.rb
@@ -52,7 +52,7 @@ RSpec.feature "Submit application with minimal information" do
 
     on_page "Money & Income" do
       select_employment(
-        full_name: "Jessie Tester",
+        display_name: "Jessie Tester",
         employment_status: "Not Employed",
       )
 

--- a/spec/models/dhs1171_pdf_spec.rb
+++ b/spec/models/dhs1171_pdf_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Dhs1171Pdf do
         primary_member_relationship: "",
         primary_member_sex_male: nil,
         primary_member_sex_female: "Yes",
-        primary_member_full_name: member.full_name,
+        primary_member_full_name: member.display_name,
       }
 
       file = Dhs1171Pdf.new(snap_application: snap_application).completed_file
@@ -66,10 +66,10 @@ RSpec.describe Dhs1171Pdf do
         result = filled_in_values(file: file.path)
 
         expect(result["primary_member_full_name"]).to eq(
-          first_member.full_name,
+          first_member.display_name,
         )
         expect(result["second_member_full_name"]).to eq(
-          second_member.full_name,
+          second_member.display_name,
         )
       end
     end
@@ -88,10 +88,10 @@ RSpec.describe Dhs1171Pdf do
         result = filled_in_values(file: file.path)
 
         expect(result["first_employed_full_name"]).to eq(
-          employed_member.full_name,
+          employed_member.display_name,
         )
         expect(result["first_self_employed_full_name"]).to eq(
-          self_employed_member.full_name,
+          self_employed_member.display_name,
         )
       end
     end

--- a/spec/models/extra_member_attributes_spec.rb
+++ b/spec/models/extra_member_attributes_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ExtraMemberAttributes do
   describe "#title" do
     it "returns the member's full name" do
-      member = double(full_name: "BooBoo")
+      member = double(display_name: "BooBoo")
 
       title = ExtraMemberAttributes.new(member: member).title
 
@@ -28,7 +28,7 @@ RSpec.describe ExtraMemberAttributes do
 
       expect(array).to eq(
         [
-          "1. Name: #{member.full_name}",
+          "1. Name: #{member.display_name}",
           "2. Date of birth: 06/20/1900",
           "3. Relationship: SELF",
           "4. Sex: #{member.sex}",

--- a/spec/models/null_member_spec.rb
+++ b/spec/models/null_member_spec.rb
@@ -1,9 +1,9 @@
 require "rails_helper"
 
 RSpec.describe NullMember do
-  describe "#full_name" do
+  describe "#display_name" do
     it "returns empty string" do
-      expect(NullMember.new.full_name).to eq ""
+      expect(NullMember.new.display_name).to eq ""
     end
   end
 

--- a/spec/models/snap_application_attributes_spec.rb
+++ b/spec/models/snap_application_attributes_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe SnapApplicationAttributes do
         mailing_address_zip: "12345",
         members_buy_food_with_no: "Yes",
         members_buy_food_with_yes: nil,
-        members_not_buy_food_with: member.full_name,
+        members_not_buy_food_with: member.display_name,
         phone_number_0: "2",
         phone_number_1: "2",
         phone_number_2: "2",

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -28,8 +28,8 @@ module FeatureHelper
     yield
   end
 
-  def select_job_number(full_name:, job_number:)
-    within(".household-member-group[data-member-name='#{full_name}']") do
+  def select_job_number(display_name:, job_number:)
+    within(".household-member-group[data-member-name='#{display_name}']") do
       select(job_number)
     end
   end

--- a/spec/support/medicaid_application_form_helper.rb
+++ b/spec/support/medicaid_application_form_helper.rb
@@ -1,6 +1,6 @@
 module MedicaidApplicationFormHelper
-  def enter_dob_and_ssn(full_name:, last_four_ssn:)
-    within(".household-member-group[data-member-name='#{full_name}']") do
+  def enter_dob_and_ssn(display_name:, last_four_ssn:)
+    within(".household-member-group[data-member-name='#{display_name}']") do
       select("January")
       select("1")
       select("1969")

--- a/spec/support/snap_application_form_helper.rb
+++ b/spec/support/snap_application_form_helper.rb
@@ -52,8 +52,8 @@ module SnapApplicationFormHelper
     end
   end
 
-  def select_employment(full_name:, employment_status:)
-    within(".household-member-group[data-member-name='#{full_name}']") do
+  def select_employment(display_name:, employment_status:)
+    within(".household-member-group[data-member-name='#{display_name}']") do
       choose(employment_status)
     end
   end


### PR DESCRIPTION
**WHY**: in the future, we may want to change how we do this - maybe we
show first name and DOB, for example, or first name and last initial.
This way of naming the method makes it more flexible.

I also took this opp to move to use of `display_name` in places where we
were just concatenating first name and last name.

I also also took this opp to titleize first name and last name. :)

Finishes https://www.pivotaltracker.com/story/show/152565843