### PR TITLE
Extract step attrib reconciliation to own object

### DIFF
--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -18,9 +18,10 @@ class StepsController < ApplicationController
   end
 
   def edit
-    @step = step_class.new(existing_attributes.slice(*step_attrs))
+    attribute_keys = Step::Attributes.new(step_attrs).to_sym
+    @step = step_class.new(existing_attributes.slice(*attribute_keys))
 
-    if step_class.attribute_names&.include?(:members)
+    if attribute_keys.include?(:members)
       @step.members = current_application&.members
     end
 

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -12,6 +12,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     optional: false
   )
     classes = classes.append(%w[text-input])
+
     text_field_options = {
       autofocus: autofocus,
       type: type,
@@ -21,11 +22,25 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
       autocapitalize: "off",
       spellcheck: "false",
     }.merge(options)
+
+    if object.hash_key_attribute?(method)
+      text_field_options[:name] = "#{object_name}[#{method}][]"
+    end
+
     text_field_html = text_field(method, text_field_options)
+    label_and_field_html = label_and_field(
+      method,
+      label_text,
+      text_field_html,
+      notes: notes,
+      prefix: prefix,
+      optional: optional,
+      options: options,
+    )
 
     <<-HTML.html_safe
       <fieldset class="form-group#{error_state(object, method)}">
-        #{label_and_field(method, label_text, text_field_html, notes: notes, prefix: prefix, optional: optional, options: options)}
+        #{label_and_field_html}
         #{errors_for(object, method)}
         #{append_html}
       </fieldset>

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -23,7 +23,9 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
       spellcheck: "false",
     }.merge(options)
 
-    if object.hash_key_attribute?(method)
+    if object.respond_to?(:hash_key_attribute?) &&
+        object.hash_key_attribute?(method)
+
       text_field_options[:name] = "#{object_name}[#{method}][]"
     end
 

--- a/app/steps/step.rb
+++ b/app/steps/step.rb
@@ -8,14 +8,16 @@ class Step
   def self.step_attributes(*attribute_names)
     self.attribute_names = attribute_names
 
-    attributes_or_keys = attribute_names.map do |attr|
-      if attr.class == Symbol
-        attr
-      else
-        attr.keys
-      end
-    end
+    attribute_strings = Step::Attributes.
+      new(attribute_names).
+      to_s
 
-    attr_accessor(*attributes_or_keys.flatten.map(&:to_s))
+    attr_accessor(*attribute_strings)
+  end
+
+  def hash_key_attribute?(attribute)
+    Step::Attributes.
+      new(self.class.attribute_names).
+      hash_key?(attribute)
   end
 end

--- a/app/steps/step/attributes.rb
+++ b/app/steps/step/attributes.rb
@@ -21,6 +21,8 @@ class Step
     attr_reader :attribute_names
 
     def symbols_or_hash_keys
+      return [] if attribute_names.nil?
+
       attribute_names.map do |attr|
         if attr.class == Symbol
           attr

--- a/app/steps/step/attributes.rb
+++ b/app/steps/step/attributes.rb
@@ -8,6 +8,10 @@ class Step
       symbols_or_hash_keys.flatten.map(&:to_s)
     end
 
+    def to_sym
+      symbols_or_hash_keys.flatten.map(&:to_sym)
+    end
+
     def hash_key?(attribute)
       hashes = attribute_names.select do |attr|
         attr.is_a? Hash

--- a/app/steps/step/attributes.rb
+++ b/app/steps/step/attributes.rb
@@ -1,0 +1,33 @@
+class Step
+  class Attributes
+    def initialize(attribute_names)
+      @attribute_names = attribute_names
+    end
+
+    def to_s
+      symbols_or_hash_keys.flatten.map(&:to_s)
+    end
+
+    def hash_key?(attribute)
+      hashes = attribute_names.select do |attr|
+        attr.is_a? Hash
+      end
+
+      hashes.map(&:keys).flatten.include? attribute.to_sym
+    end
+
+    private
+
+    attr_reader :attribute_names
+
+    def symbols_or_hash_keys
+      attribute_names.map do |attr|
+        if attr.class == Symbol
+          attr
+        else
+          attr.keys
+        end
+      end
+    end
+  end
+end

--- a/app/views/documents/edit.html.erb
+++ b/app/views/documents/edit.html.erb
@@ -30,6 +30,7 @@
       <div class="form-card__uploadables" id="form-card__uploadables">
         <%= render partial: 'shared/uploadable',
           collection: current_application.documents,
+          locals: { attribute_name: "documents" },
           as: :url %>
       </div>
 

--- a/app/views/shared/_uploadable.html.erb
+++ b/app/views/shared/_uploadable.html.erb
@@ -1,9 +1,7 @@
 <div class="uploadable-preview">
   <div class="uploadable-preview__info">
     <h4><%= File.basename(url) %></h4>
-    <%= hidden_field_tag attribute_name,
-      url,
-      name: "step[#{attribute_name}][]" %>
+    <%= hidden_field_tag attribute_name, url %>
     <p class="text--help"><%= link_to 'Delete', '#', class: "link--subtle link--delete" %></p>
   </div>
 </div>

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe MbFormBuilder do
+  describe "#field_values" do
+    it "returns value that is present wrapped in an array" do
+      class SampleStep < Step
+        step_attributes(:phone_number)
+      end
+
+      sample = SampleStep.new
+      sample.phone_number = "5551009000"
+      form = MbFormBuilder.new("sample", sample, nil, {})
+
+      expect(form.field_values({}, :phone_number)).to eq ["5551009000"]
+    end
+
+    it "returns existing array of values" do
+      class SampleStep < Step
+        step_attributes(numbers: [])
+      end
+
+      sample = SampleStep.new
+      sample.numbers = [1, 2]
+      form = MbFormBuilder.new("sample", sample, nil, {})
+
+      expect(form.field_values({}, :numbers)).to eq [1, 2]
+    end
+
+    it "returns a single empty string if attribute is not set" do
+      class SampleStep < Step
+        step_attributes(numbers: [])
+      end
+
+      sample = SampleStep.new
+      form = MbFormBuilder.new("sample", sample, nil, {})
+
+      expect(form.field_values({}, :numbers)).to eq [""]
+    end
+
+    it "returns however many blank strings according to options[:count]" do
+      class SampleStep < Step
+        step_attributes(numbers: [])
+      end
+
+      sample = SampleStep.new
+      form = MbFormBuilder.new("sample", sample, nil, {})
+
+      expect(form.field_values({ count: 3 }, :numbers)).to eq ["", "", ""]
+    end
+  end
+end

--- a/spec/steps/step/attributes_spec.rb
+++ b/spec/steps/step/attributes_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Step do
+  describe "#hash_key?" do
+    it "returns true if the attribute is a hash key" do
+      names = [
+        { foo: [] },
+        :bar,
+      ]
+      attrs = Step::Attributes.new(names)
+
+      expect(attrs.hash_key?(:foo)).to eq true
+    end
+
+    it "returns false if the attribute is a symbol" do
+      names = [
+        { foo: [] },
+        :bar,
+      ]
+      attrs = Step::Attributes.new(names)
+
+      expect(attrs.hash_key?(:bar)).to eq false
+    end
+  end
+end

--- a/spec/steps/step/attributes_spec.rb
+++ b/spec/steps/step/attributes_spec.rb
@@ -1,6 +1,46 @@
 require "rails_helper"
 
 RSpec.describe Step do
+  describe "#to_s" do
+    it "returns strings of hash keys or symbols in attribute names" do
+      names = [
+        { foo: [] },
+        :bar,
+      ]
+      attrs = Step::Attributes.new(names)
+
+      expect(attrs.to_s).to eq %w[foo bar]
+    end
+
+    context "when passed attribute names is nil" do
+      it "returns empty array" do
+        attrs = Step::Attributes.new(nil)
+
+        expect(attrs.to_s).to eq []
+      end
+    end
+  end
+
+  describe "#to_sym" do
+    it "returns symbols of hash keys or symbols in attribute names" do
+      names = [
+        { foo: [] },
+        :bar,
+      ]
+      attrs = Step::Attributes.new(names)
+
+      expect(attrs.to_sym).to eq %i[foo bar]
+    end
+
+    context "when passed attribute names is nil" do
+      it "returns empty array" do
+        attrs = Step::Attributes.new(nil)
+
+        expect(attrs.to_sym).to eq []
+      end
+    end
+  end
+
   describe "#hash_key?" do
     it "returns true if the attribute is a hash key" do
       names = [

--- a/spec/steps/step_spec.rb
+++ b/spec/steps/step_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe Step, type: :model do
+  describe ".step_attributes" do
+    it "creates setters and getters" do
+      class TestStep < Step
+        step_attributes(:foo, :bar)
+      end
+
+      expected_methods = %i[foo foo= bar bar=]
+
+      expect(TestStep.new.methods).to include(*expected_methods)
+    end
+
+    it "allows hashes with collections for attributes" do
+      class TestStep < Step
+        step_attributes(
+          {
+            foo: [],
+            bar: [],
+          },
+          :baz,
+        )
+      end
+
+      expected_methods = %i[foo foo= bar bar= baz baz=]
+
+      expect(TestStep.new.methods).to include(*expected_methods)
+    end
+  end
+end


### PR DESCRIPTION
... and make the form builder behave accordingly when an attribute is of
type "array".

The majority of the attributes on our steps are mapped plain vanilla
literals - strings, integers, bools, etc. On the VERY rare occasion there
are fields that map to arrays of those literals. For example - documents
and paperwork.

Documents and paperwork share one partial that has explicitly overwritten
the value of the "name" option in the form input field.

For example. A normal form field comes out like so:

`<input type="text" name="step[first_name]">`

But when we would like N number of values for a field that maps to a
*array* column in the database, we'd like the html instead to be as
follows:

`<input type="text" name="step[monthly_income][]">`

Before this commit, the only way to do that would be to override the name
option with something akin to:

```
<%= f.mb_money_field :monthly_income,
 "Job N",
 name: "step[monthly_income][]" %>
```

After this commit, the form builder will be smart enough to know that that
attribute is hash key for an array/collection.

***

Also!

In addition to the above, the work that's been done inside the base step
class to munge/extract information about the attribute definitions that are
provided by the `step_attributes` class method has been extracted to its
own class to do the work of extracting the string values that are passed to
`attr_accessor`.

Lastly - a method to ask "is this attribute a symbol or hash key" is in
this attributes class to allow the form builder to decide whether the form
field needs to allow for multiple values (for arrays) or not (for object
literals)

***

Also: Only ask abt `hash_key_attribute?` on Step objects

In some cases the form builder is being used with a straight model object,
therefore the `hash_key_attribute?` method will most certainly not work.