### PR TITLE
Set default value for mailing_address_same_as_residential to nil

### DIFF
--- a/app/controllers/medicaid/contact_home_address_controller.rb
+++ b/app/controllers/medicaid/contact_home_address_controller.rb
@@ -2,6 +2,16 @@ module Medicaid
   class ContactHomeAddressController < MedicaidStepsController
     private
 
+    def existing_attributes
+      attributes = super
+
+      if attributes[:mailing_address_same_as_residential_address].nil?
+        attributes[:mailing_address_same_as_residential_address] = true
+      end
+
+      attributes
+    end
+
     def skip?
       unstable_housing?
     end

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -284,7 +284,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     checked_value = options[:checked_value] || "1"
     unchecked_value = options[:unchecked_value] || "0"
     <<-HTML.html_safe
-      #{check_box(method, {}, checked_value, unchecked_value)} #{label_text}
+      #{check_box(method, options, checked_value, unchecked_value)} #{label_text}
     HTML
   end
 end

--- a/db/migrate/20171107204738_remove_default_value_for_medicaid_applications_mailing_address_same_as_residential.rb
+++ b/db/migrate/20171107204738_remove_default_value_for_medicaid_applications_mailing_address_same_as_residential.rb
@@ -1,0 +1,10 @@
+class RemoveDefaultValueForMedicaidApplicationsMailingAddressSameAsResidential < ActiveRecord::Migration[5.1]
+  def change
+    change_column_default(
+      :medicaid_applications,
+      :mailing_address_same_as_residential_address,
+      from: true,
+      to: nil,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107180444) do
+ActiveRecord::Schema.define(version: 20171107204738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,7 +130,7 @@ ActiveRecord::Schema.define(version: 20171107180444) do
     t.boolean "income_retirement"
     t.boolean "income_social_security"
     t.boolean "income_unemployment"
-    t.boolean "mailing_address_same_as_residential_address", default: true
+    t.boolean "mailing_address_same_as_residential_address"
     t.string "mailing_city"
     t.string "mailing_street_address"
     t.string "mailing_zip"

--- a/spec/controllers/medicaid/contact_home_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_home_address_controller_spec.rb
@@ -10,11 +10,10 @@ RSpec.describe Medicaid::ContactHomeAddressController, type: :controller do
   describe "#edit" do
     context "client has stable housing" do
       it "renders the edit page" do
-        medicaid_application =
-          create(
-            :medicaid_application,
-            stable_housing: true,
-          )
+        medicaid_application = create(
+          :medicaid_application,
+          stable_housing: true,
+        )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
@@ -24,16 +23,49 @@ RSpec.describe Medicaid::ContactHomeAddressController, type: :controller do
 
       context "client does not have stable housing" do
         it "redirects to the next page" do
-          medicaid_application =
-            create(
-              :medicaid_application,
-              stable_housing: false,
-            )
+          medicaid_application = create(
+            :medicaid_application,
+            stable_housing: false,
+          )
           session[:medicaid_application_id] = medicaid_application.id
 
           get :edit
 
           expect(response).to redirect_to(subject.next_path)
+        end
+      end
+
+      context "mailing address not the same as residential address is nil" do
+        it "sets the default of mailing_address_same_as_residential_address" do
+          medicaid_application = create(
+            :medicaid_application,
+            stable_housing: true,
+            mailing_address_same_as_residential_address: nil,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          step = assigns(:step)
+          expect(step.mailing_address_same_as_residential_address).
+            to eq true
+        end
+      end
+
+      context "mailing address not the same as residential address is false" do
+        it "sets the default of mailing_address_same_as_residential_address" do
+          medicaid_application = create(
+            :medicaid_application,
+            stable_housing: true,
+            mailing_address_same_as_residential_address: false,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          step = assigns(:step)
+          expect(step.mailing_address_same_as_residential_address).
+            to eq false
         end
       end
     end

--- a/spec/controllers/medicaid/contact_mailing_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_mailing_address_controller_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Medicaid::ContactMailingAddressController, type: :controller do
         medicaid_application = create(
           :medicaid_application,
           reliable_mail_address: false,
-          mailing_address_same_as_residential_address: true,
+          mailing_address_same_as_residential_address: nil,
         )
         session[:medicaid_application_id] = medicaid_application.id
 

--- a/spec/features/medicaid_address_flow_spec.rb
+++ b/spec/features/medicaid_address_flow_spec.rb
@@ -74,4 +74,41 @@ RSpec.feature "medicaid address flows" do
       "What is the best number for you to receive phone calls?",
     )
   end
+
+  scenario "client has same home and mailing addresses", :js do
+    visit medicaid_root_path
+
+    within(".slab--hero") do
+      click_on "Apply for Medicaid"
+    end
+
+    on_pages "Introduction" do
+      expect(page).to have_content(
+        "Before we get started, do you currently reside in Michigan?",
+      )
+
+      click_on "Yes"
+
+      fill_in "What is your first name?", with: "Jessie"
+      fill_in "What is your last name?", with: "Tester"
+      select_radio(question: "What is your gender?", answer: "Female")
+      click_on "Next"
+    end
+
+    visit "steps/medicaid/contact"
+    expect(page).to have_content("Do you have stable housing right now?")
+    click_on "Yes"
+
+    expect(page).to have_content("What is your home address?")
+
+    fill_in "Street address", with: "123 Some St."
+    fill_in "City", with: "Flint"
+    fill_in "ZIP code", with: "48501"
+
+    click_on "Next"
+
+    expect(page).to have_content(
+      "What is the best number for you to receive phone calls?",
+    )
+  end
 end


### PR DESCRIPTION
* Was true before, which made it difficult to know if someone had
actually answered that question or not
* This makes our control flow logic easier to parse

Signed-off-by: Jessie Young <jessie@cylinder.work>