### PR TITLE
In Medicaid flow, ask if anyone in household is married.

### DIFF
--- a/app/controllers/medicaid/intro_marital_status_controller.rb
+++ b/app/controllers/medicaid/intro_marital_status_controller.rb
@@ -1,0 +1,15 @@
+module Medicaid
+  class IntroMaritalStatusController < MedicaidStepsController
+    private
+
+    def after_successful_update_hook
+      if single_member_household?
+        current_application.primary_member.update!(member_attrs)
+      end
+    end
+
+    def member_attrs
+      { married: step_params[:anyone_married] }
+    end
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -30,6 +30,14 @@ class Member < ApplicationRecord
     "Other",
   ].freeze
 
+  MARITAL_STATUSES = [
+    "Married",
+    "Never married",
+    "Divorced",
+    "Widowed",
+    "Separated",
+  ].freeze
+
   belongs_to :benefit_application, polymorphic: true
 
   validates :employed_pay_interval,

--- a/app/steps/medicaid/intro_marital_status.rb
+++ b/app/steps/medicaid/intro_marital_status.rb
@@ -1,0 +1,5 @@
+module Medicaid
+  class IntroMaritalStatus < Step
+    step_attributes(:anyone_married)
+  end
+end

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -6,6 +6,7 @@ module Medicaid
         Medicaid::IntroLocationHelpController,
         Medicaid::IntroNameController,
         Medicaid::IntroHouseholdController,
+        Medicaid::IntroMaritalStatusController,
         Medicaid::IntroCollegeController,
         Medicaid::IntroCollegeMemberController,
         Medicaid::IntroCitizenController,

--- a/app/views/medicaid/intro_household/edit.html.erb
+++ b/app/views/medicaid/intro_household/edit.html.erb
@@ -40,8 +40,10 @@
   </div>
 
   <footer class="form-card__button_right">
-    <a href="/steps/medicaid/intro-college" class="button button--nav  button--cta button--full-width">
-      Next
-    </a>
+    <%= link_to(
+      next_path,
+      class: 'button button--nav  button--cta button--full-width') do %>
+        Next
+    <% end %>
   </footer>
 </div>

--- a/app/views/medicaid/intro_marital_status/edit.html.erb
+++ b/app/views/medicaid/intro_marital_status/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :header_title, "Introduction" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      <%= t("medicaid.intro_marital_status.edit.title",
+            count: current_application.members.count) %>
+    </div>
+    <p class="text--help text--centered">
+
+    </p>
+  </header>
+
+  <%= render 'shared/yes_no_form', step: @step, field: :anyone_married %>
+</div>

--- a/app/views/personal_detail/edit.html.erb
+++ b/app/views/personal_detail/edit.html.erb
@@ -16,7 +16,7 @@
           layout: "inline" %>
         <%= f.mb_select :marital_status,
         'What is your marital status?',
-        ['Married', 'Never married', 'Divorced', 'Widowed', 'Separated'],
+        Member::MARITAL_STATUSES,
         include_blank: "Choose one" %>
       <%= f.mb_input_field :ssn,
       "What is your Social Security Number?",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,11 @@ en:
       Leaving the application process will clear your data from this computer.
       Are you sure you would like to exit?
   medicaid:
+    intro_marital_status:
+      edit:
+        title:
+          one: Are you currently married?
+          other: Is anyone in your household currently married?
     intro_college:
       edit:
         title:

--- a/db/migrate/20171107224111_add_anyone_married_to_medicaid_application.rb
+++ b/db/migrate/20171107224111_add_anyone_married_to_medicaid_application.rb
@@ -1,0 +1,10 @@
+class AddAnyoneMarriedToMedicaidApplication < ActiveRecord::Migration[5.1]
+  def up
+    add_column :medicaid_applications, :anyone_married, :boolean
+    change_column_default :medicaid_applications, :anyone_married, false
+  end
+
+  def down
+    remove_column :medicaid_applications, :anyone_married
+  end
+end

--- a/db/migrate/20171108010437_add_married_to_member.rb
+++ b/db/migrate/20171108010437_add_married_to_member.rb
@@ -1,0 +1,10 @@
+class AddMarriedToMember < ActiveRecord::Migration[5.1]
+  def up
+    add_column :members, :married, :boolean
+    change_column_default :members, :married, false
+  end
+
+  def down
+    remove_column :members, :married
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107214734) do
+ActiveRecord::Schema.define(version: 20171108010437) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 20171107214734) do
     t.boolean "anyone_employed"
     t.boolean "anyone_in_college"
     t.boolean "anyone_insured", default: false
+    t.boolean "anyone_married", default: false
     t.boolean "anyone_new_mom"
     t.boolean "anyone_other_income", default: false
     t.boolean "anyone_pay_child_support_alimony_arrears"
@@ -184,6 +185,7 @@ ActiveRecord::Schema.define(version: 20171107214734) do
     t.string "last_name"
     t.boolean "living_elsewhere"
     t.string "marital_status"
+    t.boolean "married", default: false
     t.boolean "new_mom"
     t.boolean "other_income", default: false
     t.string "other_income_types", default: [], array: true

--- a/spec/controllers/medicaid/intro_marital_status_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_marital_status_controller_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IntroMaritalStatusController do
+  describe "#update" do
+    context "single member household" do
+      context "anyone married" do
+        it "updates the member" do
+          member = create(:member)
+
+          medicaid_application = create(
+            :medicaid_application,
+            members: [member],
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          put :update, params: { step: { anyone_married: true } }
+
+          member.reload
+
+          expect(member).to be_married
+        end
+      end
+
+      context "nobody married" do
+        it "updates the member" do
+          member = create(:member)
+
+          medicaid_application = create(
+            :medicaid_application,
+            members: [member],
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          put :update, params: { step: { anyone_married: false } }
+
+          member.reload
+
+          expect(member).not_to be_married
+        end
+      end
+    end
+  end
+end

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -21,6 +21,9 @@ RSpec.feature "Medicaid app" do
       )
       click_on "Next"
 
+      expect(page).to have_content("Are you currently married?")
+      click_on "Yes"
+
       expect(page).to have_content("Are you currently a college student?")
       click_on "Yes"
 

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -23,6 +23,9 @@ RSpec.feature "Medicaid app" do
       )
       click_on "Next"
 
+      expect(page).to have_content("Are you currently married?")
+      click_on "No"
+
       expect(page).to have_content("Are you currently a college student?")
       click_on "No"
 

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -47,6 +47,13 @@ RSpec.feature "Medicaid app" do
     click_on "Next"
 
     on_page "Introduction" do
+      expect(page).to have_content(
+        "Is anyone in your household currently married?",
+      )
+      click_on "No"
+    end
+
+    on_page "Introduction" do
       expect(page).to have_content("Is anyone currently a college student?")
       click_on "Yes"
     end


### PR DESCRIPTION
Specifying which members of the family are married and to whom for multi-member household come in the next step.

We've kept married status independent from SNAP's marital status, because they are used and defined differently across the two applications.

[Finishes #152548726]
https://www.pivotaltracker.com/story/show/152548726

Signed-off-by: Ben Golder <bgolder@codeforamerica.org>

![screen shot 2017-11-07 at 5 26 03 pm](https://user-images.githubusercontent.com/3675092/32526963-ed12b54e-c3e0-11e7-9699-6720e9958e76.png)
![screen shot 2017-11-07 at 5 26 46 pm](https://user-images.githubusercontent.com/3675092/32526965-eecb00b2-c3e0-11e7-807f-d4fb975438a1.png)
