### PR TITLE
Select spouses for all married people

### DIFF
--- a/app/controllers/medicaid/intro_marital_status_indicate_spouse_controller.rb
+++ b/app/controllers/medicaid/intro_marital_status_indicate_spouse_controller.rb
@@ -3,18 +3,6 @@ module Medicaid
     Medicaid::MemberStepsController
     helper_method :spouse_options
 
-    def update
-      @step = step_class.new(step_params)
-
-      if @step.valid?
-        current_member.update(step_params)
-        update_spouse_of_other_member_if_present
-        redirect_to(next_path)
-      else
-        render :edit
-      end
-    end
-
     def current_member
       @_current_member ||= super || first_married_member
     end
@@ -26,6 +14,15 @@ module Medicaid
     end
 
     private
+
+    def after_successful_update_hook
+      current_member.update(step_params)
+      update_spouse_of_other_member_if_present
+    end
+
+    def application_params
+      {}
+    end
 
     def skip?
       single_member_household? ||

--- a/app/controllers/medicaid/intro_marital_status_indicate_spouse_controller.rb
+++ b/app/controllers/medicaid/intro_marital_status_indicate_spouse_controller.rb
@@ -1,0 +1,61 @@
+module Medicaid
+  class IntroMaritalStatusIndicateSpouseController <
+    Medicaid::MemberStepsController
+    helper_method :spouse_options
+
+    def update
+      @step = step_class.new(step_params)
+
+      if @step.valid?
+        current_member.update(step_params)
+        update_spouse_of_other_member_if_present
+        redirect_to(next_path)
+      else
+        render :edit
+      end
+    end
+
+    def current_member
+      @_current_member ||= super || first_married_member
+    end
+
+    def spouse_options
+      current_application.members -
+        [current_member] +
+        [OtherSpouse.new]
+    end
+
+    private
+
+    def skip?
+      single_member_household? ||
+        current_application.nobody_married?
+    end
+
+    def first_married_member
+      current_application.
+        members.
+        married.
+        limit(1).
+        first
+    end
+
+    def next_member
+      return if current_member.nil?
+
+      current_application.
+        members.
+        married.
+        after(current_member).
+        limit(1).
+        first
+    end
+
+    def update_spouse_of_other_member_if_present
+      spouse = Member.where(id: step_params[:spouse_id]).first
+      if spouse.present?
+        spouse.update!(spouse_id: current_member.id)
+      end
+    end
+  end
+end

--- a/app/controllers/medicaid/member_steps_controller.rb
+++ b/app/controllers/medicaid/member_steps_controller.rb
@@ -8,11 +8,11 @@ module Medicaid
       @_current_member ||= member_from_form || member_from_querystring
     end
 
-    private
-
     def next_path
       next_member_path || super
     end
+
+    private
 
     def next_member_path
       return if next_member.nil?

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -28,6 +28,10 @@ class MedicaidApplication < ApplicationRecord
       anyone_other_income?
   end
 
+  def nobody_married?
+    !anyone_married?
+  end
+
   def nobody_caretaker_or_parent?
     !anyone_caretaker_or_parent?
   end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -39,6 +39,7 @@ class Member < ApplicationRecord
   ].freeze
 
   belongs_to :benefit_application, polymorphic: true
+  has_one :spouse, class_name: "Member", foreign_key: "spouse_id"
 
   validates :employed_pay_interval,
     inclusion: { in: PAYMENT_INTERVALS },
@@ -66,6 +67,10 @@ class Member < ApplicationRecord
     where(insured: true).
       where(requesting_health_insurance: true).
       order(created_at: :asc)
+  end
+
+  def self.married
+    where(married: true).order(created_at: :asc)
   end
 
   def self.other_income

--- a/app/models/other_spouse.rb
+++ b/app/models/other_spouse.rb
@@ -1,0 +1,9 @@
+class OtherSpouse
+  def id
+    0
+  end
+
+  def display_name
+    "Other - not listed"
+  end
+end

--- a/app/steps/medicaid/intro_marital_status_indicate_spouse.rb
+++ b/app/steps/medicaid/intro_marital_status_indicate_spouse.rb
@@ -1,0 +1,22 @@
+module Medicaid
+  class IntroMaritalStatusIndicateSpouse < Step
+    step_attributes(
+      :member_id,
+      :spouse_id,
+      :spouse,
+    )
+
+    def valid?
+      if spouse_id.present?
+        true
+      else
+        errors.add(:spouse, "Make sure you select a person")
+        false
+      end
+    end
+
+    def member
+      @_member ||= Member.find(member_id)
+    end
+  end
+end

--- a/app/steps/medicaid/intro_marital_status_indicate_spouse.rb
+++ b/app/steps/medicaid/intro_marital_status_indicate_spouse.rb
@@ -6,12 +6,11 @@ module Medicaid
       :spouse,
     )
 
-    def valid?
-      if spouse_id.present?
-        true
-      else
+    validate :spouse_present
+
+    def spouse_present
+      if spouse_id.blank?
         errors.add(:spouse, "Make sure you select a person")
-        false
       end
     end
 

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -8,6 +8,7 @@ module Medicaid
         Medicaid::IntroHouseholdController,
         Medicaid::IntroMaritalStatusController,
         Medicaid::IntroMaritalStatusMemberController,
+        Medicaid::IntroMaritalStatusIndicateSpouseController,
         Medicaid::IntroCollegeController,
         Medicaid::IntroCollegeMemberController,
         Medicaid::IntroCitizenController,

--- a/app/views/medicaid/intro_marital_status_indicate_spouse/edit.html.erb
+++ b/app/views/medicaid/intro_marital_status_indicate_spouse/edit.html.erb
@@ -1,0 +1,30 @@
+<% content_for :header_title, "Introduction" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      <%= t("medicaid.intro_marital_status_indicate_spouse.edit.title",
+            name: current_member.display_name) %>
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step,
+      as: :step,
+      builder: MbFormBuilder,
+      url: current_path,
+      method: :put do |f| %>
+
+      <%= f.mb_form_errors :spouse %>
+      <%= f.hidden_field(:member_id, value: current_member.id) %>
+
+      <%= f.mb_radio_set :spouse_id, "",
+        spouse_options.map { |member|
+        { value: member.id, label: member.display_name }
+       } %>
+
+      <%= render "medicaid/next_step" %>
+    <% end %>
+  </div>
+</div>
+

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,9 @@ en:
         title:
           one: Are you currently married?
           other: Is anyone in your household currently married?
+    intro_marital_status_indicate_spouse:
+      edit:
+        title: "Tell us who %{name} is currently married to"
     intro_college:
       edit:
         title:

--- a/db/migrate/20171108220855_add_spouse_id_to_members.rb
+++ b/db/migrate/20171108220855_add_spouse_id_to_members.rb
@@ -1,0 +1,5 @@
+class AddSpouseIdToMembers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :members, :spouse_id, :integer, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171108012317) do
+ActiveRecord::Schema.define(version: 20171108220855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -192,6 +192,7 @@ ActiveRecord::Schema.define(version: 20171108012317) do
     t.integer "self_employed_monthly_income"
     t.string "self_employed_profession"
     t.string "sex"
+    t.integer "spouse_id"
     t.integer "unemployment_income"
     t.datetime "updated_at", null: false
   end

--- a/spec/controllers/medicaid/intro_marital_status_indicate_spouse_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_marital_status_indicate_spouse_controller_spec.rb
@@ -1,0 +1,170 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouseController do
+  describe "#current_member" do
+    it "defaults for first married member" do
+      medicaid_application = create(:medicaid_application, anyone_married: true)
+      _primary_member = create(
+        :member,
+        married: false,
+        benefit_application: medicaid_application,
+      )
+      married_member = create(
+        :member,
+        married: true,
+        benefit_application: medicaid_application,
+      )
+
+      session[:medicaid_application_id] = medicaid_application.id
+
+      expect(subject.current_member).to eq married_member
+    end
+
+    it "finds member from querystring" do
+      medicaid_application = create(:medicaid_application, anyone_married: true)
+      _joel = create(:member, benefit_application: medicaid_application)
+      jessie = create(:member, benefit_application: medicaid_application)
+
+      session[:medicaid_application_id] = medicaid_application.id
+
+      get :edit, params: { member: jessie.id }
+
+      expect(subject.current_member).to eq jessie
+    end
+
+    it "finds member from posted form" do
+      medicaid_application = create(:medicaid_application, anyone_married: true)
+      _joel = create(:member, benefit_application: medicaid_application)
+      jessie = create(:member, benefit_application: medicaid_application)
+
+      session[:medicaid_application_id] = medicaid_application.id
+
+      put :update, params: {
+        step: {
+          member_id: jessie.id,
+          spouse_id: "0",
+        },
+      }
+
+      expect(subject.current_member).to eq jessie
+    end
+  end
+
+  describe "#next_path" do
+    it "is the intro college path" do
+      medicaid_application = create(:medicaid_application)
+      session[:medicaid_application_id] = medicaid_application.id
+
+      expect(subject.next_path).to eq "/steps/medicaid/intro-college"
+    end
+  end
+
+  describe "#edit" do
+    context "single member household" do
+      it "skips this page" do
+        medicaid_application = create(
+          :medicaid_application,
+          members: [create(:member)],
+          anyone_married: true,
+        )
+
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+
+    context "multi member household" do
+      context "someone is married" do
+        it "renders :edit" do
+          medicaid_application = create(
+            :medicaid_application,
+            anyone_married: true,
+          )
+          create_list(:member, 2, benefit_application: medicaid_application)
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to render_template(:edit)
+        end
+      end
+
+      context "nobody is married" do
+        it "skips this page" do
+          medicaid_application = create(
+            :medicaid_application,
+            anyone_married: false,
+          )
+          create_list(:member, 2, benefit_application: medicaid_application)
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to redirect_to(subject.next_path)
+        end
+      end
+    end
+  end
+
+  describe "#update" do
+    context "member's spouse is updated" do
+      it "update the spouse_id of their spouse as well" do
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_married: true,
+        )
+        first_member = create(
+          :member,
+          benefit_application: medicaid_application,
+          spouse_id: nil,
+        )
+        second_member = create(
+          :member,
+          benefit_application: medicaid_application,
+          spouse_id: nil,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        put(
+          :update,
+          params: {
+            step: { member_id: first_member.id, spouse_id: second_member.id },
+          },
+        )
+        first_member.reload
+        second_member.reload
+
+        expect(second_member.spouse).to eq first_member
+        expect(first_member.spouse).to eq second_member
+      end
+    end
+
+    context "member's spouse is updated to 'other'" do
+      it "does not error" do
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_married: true,
+        )
+        first_member = create(
+          :member,
+          benefit_application: medicaid_application,
+          spouse_id: nil,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        put(
+          :update,
+          params: {
+            step: { member_id: first_member.id, spouse_id: OtherSpouse.new.id },
+          },
+        )
+        first_member.reload
+
+        expect(first_member.spouse_id).to eq OtherSpouse.new.id
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/intro_marital_status_member_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_marital_status_member_controller_spec.rb
@@ -2,41 +2,15 @@ require "rails_helper"
 
 RSpec.describe Medicaid::IntroMaritalStatusMemberController do
   describe "#next_path" do
-    it "is the intro college path" do
-      expect(subject.next_path).to eq "/steps/medicaid/intro-college"
+    it "is the indicate spouse path" do
+      expect(subject.next_path).to eq(
+        "/steps/medicaid/intro-marital-status-indicate-spouse",
+      )
     end
   end
 
-  describe "#edit" do
-    context "someone is married" do
-      it "renders :edit" do
-        medicaid_application = create(
-          :medicaid_application,
-          anyone_married: true,
-        )
-        create_list(:member, 2, benefit_application: medicaid_application)
-        session[:medicaid_application_id] = medicaid_application.id
-
-        get :edit
-
-        expect(response).to render_template(:edit)
-      end
-    end
-
-    context "no one is married" do
-      it "skips this page" do
-        medicaid_application = create(
-          :medicaid_application,
-          anyone_married: false,
-        )
-
-        create_list(:member, 2, benefit_application: medicaid_application)
-        session[:medicaid_application_id] = medicaid_application.id
-
-        get :edit
-
-        expect(response).to redirect_to(subject.next_path)
-      end
-    end
-  end
+  it_should_behave_like(
+    "Medicaid multi-member controller",
+    :anyone_married,
+  )
 end

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -58,6 +58,31 @@ RSpec.feature "Medicaid app" do
         "Who in the household is currently married?",
       )
       check "Jessie Tester"
+      check "Christa Tester"
+      check "Joel Tester"
+      click_on "Next"
+    end
+
+    on_page "Introduction" do
+      expect(page).to have_content(
+        "Tell us who Jessie Tester is currently married to",
+      )
+      choose "Christa Tester"
+      click_on "Next"
+    end
+
+    on_page "Introduction" do
+      expect(page).to have_content(
+        "Tell us who Christa Tester is currently married to",
+      )
+      click_on "Next"
+    end
+
+    on_page "Introduction" do
+      expect(page).to have_content(
+        "Tell us who Joel Tester is currently married to",
+      )
+      choose "Other - not listed"
       click_on "Next"
     end
 

--- a/spec/steps/medicaid/intro_marital_status_indicate_spouse_spec.rb
+++ b/spec/steps/medicaid/intro_marital_status_indicate_spouse_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouse do
+  describe "Validations" do
+    context "other member is selected" do
+      it "is valid" do
+        member = create(:member, married: true)
+
+        step = Medicaid::IntroMaritalStatusIndicateSpouse.new(
+          member_id: member.id,
+          spouse_id: 0,
+        )
+
+        expect(step).to be_valid
+      end
+    end
+
+    context "member is selected" do
+      it "is valid" do
+        member = create(:member, married: true)
+        spouse_member = create(:member, married: true)
+
+        step = Medicaid::IntroMaritalStatusIndicateSpouse.new(
+          member_id: member.id,
+          spouse_id: spouse_member.id,
+        )
+
+        expect(step).to be_valid
+      end
+    end
+
+    context "nobody is selected" do
+      it "is invalid" do
+        member = create(:member, married: true)
+
+        step = Medicaid::IntroMaritalStatusIndicateSpouse.new(
+          member_id: member.id,
+          spouse_id: nil,
+        )
+
+        expect(step.valid?).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
* [Finishes #152550364]
GIVEN I am multi-member Medicaid applicant
WHEN I select which members are currently married
THEN I should go to a NEW page (for each member), where I can select which person they are married to

* Only show members of household who have marked that they were married on previous step.

NOTE: the following was included as part of the feature request:
* If someone has indicated they are married to someone in the same
household, we should assume that person is also married to the original
person and not ask them.

If it is indicated that Person 1 is married to Person 2, I am marking
Person 1 as the spouse of Person 2 as well. *BUT* I am not skipping over
Person 2. The reason for this is that if we go back and update the
spouse of Person 1 to Person 3, we would need to clear out the spouse of
Person 2 in order to get everyone's spouse recorded properly. It felt
more straightforward to just show each person with info pre-populated
for spouse than to do this complicated clearing stuff. But, we totally
can do that if we need to.

<img width="707" alt="screen shot 2017-11-08 at 3 42 47 pm" src="https://user-images.githubusercontent.com/601515/32581401-b2413954-c49e-11e7-8316-3f9fe0b144df.png">

<img width="695" alt="screen shot 2017-11-08 at 3 42 52 pm" src="https://user-images.githubusercontent.com/601515/32581409-be54c71a-c49e-11e7-8ab5-7fdf86779090.png">

<img width="772" alt="screen shot 2017-11-08 at 3 43 00 pm" src="https://user-images.githubusercontent.com/601515/32581412-c198b26a-c49e-11e7-994c-5ab4adf4881b.png">

<img width="712" alt="screen shot 2017-11-08 at 3 47 00 pm" src="https://user-images.githubusercontent.com/601515/32581415-c4b1ea7a-c49e-11e7-99f6-8a50806197e5.png">



