### PR TITLE
Use shared example group in `_member` controllers

### DIFF
--- a/spec/controllers/medicaid/expenses_student_loan_member_controller_spec.rb
+++ b/spec/controllers/medicaid/expenses_student_loan_member_controller_spec.rb
@@ -7,65 +7,8 @@ RSpec.describe Medicaid::ExpensesStudentLoanMemberController do
     end
   end
 
-  describe "#edit" do
-    context "no one pays student loan interest" do
-      it "skips this page" do
-        medicaid_application =
-          create(
-            :medicaid_application,
-            anyone_pay_student_loan_interest: false,
-          )
-        session[:medicaid_application_id] = medicaid_application.id
-
-        get :edit
-
-        expect(response).to redirect_to(subject.next_path)
-      end
-    end
-
-    context "someone pays student loan interest" do
-      context "multiple members in the household" do
-        it "renders :edit" do
-          medicaid_application = create(
-            :medicaid_application,
-            anyone_pay_student_loan_interest: true,
-          )
-          create_list(:member, 2, benefit_application: medicaid_application)
-          session[:medicaid_application_id] = medicaid_application.id
-
-          get :edit
-
-          expect(response).to render_template(:edit)
-        end
-      end
-
-      context "single member household" do
-        it "skips this page if they pay student loan interest" do
-          medicaid_application = create(
-            :medicaid_application,
-            anyone_pay_student_loan_interest: true,
-          )
-          create(:member, benefit_application: medicaid_application)
-          session[:medicaid_application_id] = medicaid_application.id
-
-          get :edit
-
-          expect(response).to redirect_to(subject.next_path)
-        end
-
-        it "skips this page if they are not a citizen" do
-          medicaid_application = create(
-            :medicaid_application,
-            anyone_pay_student_loan_interest: false,
-          )
-          create(:member, benefit_application: medicaid_application)
-          session[:medicaid_application_id] = medicaid_application.id
-
-          get :edit
-
-          expect(response).to redirect_to(subject.next_path)
-        end
-      end
-    end
-  end
+  it_should_behave_like(
+    "Medicaid multi-member controller",
+    :anyone_pay_student_loan_interest,
+  )
 end

--- a/spec/controllers/medicaid/health_disability_member_controller_spec.rb
+++ b/spec/controllers/medicaid/health_disability_member_controller_spec.rb
@@ -7,5 +7,8 @@ RSpec.describe Medicaid::HealthDisabilityMemberController, type: :controller do
     end
   end
 
-  it_should_behave_like "Medicaid multi-member controller", :anyone_disabled
+  it_should_behave_like(
+    "Medicaid multi-member controller",
+    :anyone_disabled,
+  )
 end

--- a/spec/controllers/medicaid/income_job_number_member_controller_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_member_controller_spec.rb
@@ -9,5 +9,8 @@ RSpec.describe Medicaid::IncomeJobNumberMemberController do
     end
   end
 
-  it_should_behave_like "Medicaid multi-member controller", :anyone_employed
+  it_should_behave_like(
+    "Medicaid multi-member controller",
+    :anyone_employed,
+  )
 end

--- a/spec/controllers/medicaid/income_other_income_member_controller_spec.rb
+++ b/spec/controllers/medicaid/income_other_income_member_controller_spec.rb
@@ -7,5 +7,8 @@ RSpec.describe Medicaid::IncomeOtherIncomeMemberController, type: :controller do
     end
   end
 
-  it_should_behave_like "Medicaid multi-member controller", :anyone_other_income
+  it_should_behave_like(
+    "Medicaid multi-member controller",
+    :anyone_other_income,
+  )
 end

--- a/spec/controllers/medicaid/intro_college_member_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_college_member_controller_spec.rb
@@ -9,5 +9,8 @@ RSpec.describe Medicaid::IntroCollegeMemberController do
     end
   end
 
-  it_should_behave_like "Medicaid multi-member controller", :anyone_in_college
+  it_should_behave_like(
+    "Medicaid multi-member controller",
+    :anyone_in_college,
+  )
 end

--- a/spec/controllers/medicaid/intro_marital_status_member_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_marital_status_member_controller_spec.rb
@@ -7,36 +7,8 @@ RSpec.describe Medicaid::IntroMaritalStatusMemberController do
     end
   end
 
-  describe "#edit" do
-    context "someone is married" do
-      it "renders :edit" do
-        medicaid_application = create(
-          :medicaid_application,
-          anyone_married: true,
-        )
-        create_list(:member, 2, benefit_application: medicaid_application)
-        session[:medicaid_application_id] = medicaid_application.id
-
-        get :edit
-
-        expect(response).to render_template(:edit)
-      end
-    end
-
-    context "no one is married" do
-      it "skips this page" do
-        medicaid_application = create(
-          :medicaid_application,
-          anyone_married: false,
-        )
-
-        create_list(:member, 2, benefit_application: medicaid_application)
-        session[:medicaid_application_id] = medicaid_application.id
-
-        get :edit
-
-        expect(response).to redirect_to(subject.next_path)
-      end
-    end
-  end
+  it_should_behave_like(
+    "Medicaid multi-member controller",
+    :anyone_married,
+  )
 end


### PR DESCRIPTION
* We had this before but it was not being used everywhere
* The only controllers for `_member` where we cannot use this is
Pregnancy, because that has gender-specific behavior, and Citizen,
because citizen status affects control flow in the opposite way that
other member controllers do (usually "True" for an attribute means you
see the associated member controller but "True" for "Everyone a citizen"
means you do NOT see the citizen member controller)