### PR TITLE
Migrate addresses from MedicaidApplication

### DIFF
--- a/app/controllers/medicaid/contact_home_address_controller.rb
+++ b/app/controllers/medicaid/contact_home_address_controller.rb
@@ -4,6 +4,12 @@ module Medicaid
 
     def existing_attributes
       attributes = super
+      residential_address = current_application.residential_address
+      attributes.merge!(
+        street_address: residential_address.street_address,
+        city: residential_address.city,
+        zip: residential_address.zip,
+      )
 
       if attributes[:mailing_address_same_as_residential_address].nil?
         attributes[:mailing_address_same_as_residential_address] = true
@@ -18,6 +24,29 @@ module Medicaid
 
     def unstable_housing?
       !current_application&.stable_housing?
+    end
+
+    def after_successful_update_hook
+      address.update!(address_params)
+    end
+
+    def application_params
+      step_params.except(:street_address, :city, :zip)
+    end
+
+    def address_params
+      {
+        street_address: step_params[:street_address],
+        city: step_params[:city],
+        zip: step_params[:zip],
+        county: "Genesee",
+        state: "MI",
+      }
+    end
+
+    def address
+      current_application.addresses.where(mailing: false).first ||
+        current_application.addresses.new(mailing: false)
     end
   end
 end

--- a/app/controllers/medicaid/contact_mailing_address_controller.rb
+++ b/app/controllers/medicaid/contact_mailing_address_controller.rb
@@ -2,6 +2,18 @@ module Medicaid
   class ContactMailingAddressController < MedicaidStepsController
     private
 
+    def existing_attributes
+      HashWithIndifferentAccess.new(address.attributes)
+    end
+
+    def after_successful_update_hook
+      address.update!(step_params.merge(state: "MI", county: "Genesee"))
+    end
+
+    def application_params
+      {}
+    end
+
     def skip?
       return true if no_reliable_mail_address_edge_case?
       return true if unreliable_housing?
@@ -29,7 +41,12 @@ module Medicaid
     end
 
     def mailing_address_same_as_residential_address?
-      current_application&.mailing_address_same_as_residential_address?
+      current_application.mailing_address_same_as_residential_address?
+    end
+
+    def address
+      current_application.addresses.where(mailing: true).first ||
+        current_application.addresses.new(mailing: true)
     end
   end
 end

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -32,12 +32,16 @@ class StepsController < ApplicationController
     @step = step_class.new(step_params)
 
     if @step.valid?
-      current_application.update!(step_params)
+      current_application.update!(application_params)
       after_successful_update_hook
       redirect_to(next_path)
     else
       render :edit
     end
+  end
+
+  def application_params
+    step_params
   end
 
   def self.to_param

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,3 +1,3 @@
 class Address < ApplicationRecord
-  belongs_to :snap_application
+  belongs_to :benefit_application, polymorphic: true
 end

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -2,6 +2,7 @@ class MedicaidApplication < ApplicationRecord
   include Submittable
 
   has_many :members, as: :benefit_application, dependent: :destroy
+  has_many :addresses, as: :benefit_application, dependent: :destroy
 
   attribute :ssn
   attr_encrypted(
@@ -37,5 +38,21 @@ class MedicaidApplication < ApplicationRecord
 
   def non_applicant_members
     members - [primary_member]
+  end
+
+  def residential_address
+    return NullAddress.new if unstable_housing?
+    return mailing_address if mailing_address_same_as_residential_address?
+    addresses.where.not(mailing: true).first || NullAddress.new
+  end
+
+  def mailing_address
+    addresses.where(mailing: true).first || NullAddress.new
+  end
+
+  private
+
+  def unstable_housing?
+    !stable_housing?
   end
 end

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -26,7 +26,7 @@ class SnapApplication < ApplicationRecord
   validate :medical_expenses_values
   validate :court_ordered_expenses_values
 
-  has_many :addresses, dependent: :destroy
+  has_many :addresses, as: :benefit_application, dependent: :destroy
   has_many :driver_applications, dependent: :destroy
   has_many :driver_errors, through: :driver_applications
   has_many :exports, dependent: :destroy

--- a/app/steps/medicaid/contact_home_address.rb
+++ b/app/steps/medicaid/contact_home_address.rb
@@ -1,19 +1,19 @@
 module Medicaid
   class ContactHomeAddress < Step
     step_attributes(
-      :residential_street_address,
-      :residential_city,
-      :residential_zip,
+      :street_address,
+      :city,
+      :zip,
       :mailing_address_same_as_residential_address,
     )
 
-    validates :residential_street_address,
+    validates :street_address,
       presence: { message: "Make sure to provide a street address" }
 
-    validates :residential_city,
+    validates :city,
       presence: { message: "Make sure to provide a city" }
 
-    validates :residential_zip,
+    validates :zip,
       length: { is: 5, message: "Make sure your ZIP code is 5 digits long" }
   end
 end

--- a/app/steps/medicaid/contact_mailing_address.rb
+++ b/app/steps/medicaid/contact_mailing_address.rb
@@ -1,18 +1,18 @@
 module Medicaid
   class ContactMailingAddress < Step
     step_attributes(
-      :mailing_street_address,
-      :mailing_city,
-      :mailing_zip,
+      :street_address,
+      :city,
+      :zip,
     )
 
-    validates :mailing_street_address,
+    validates :street_address,
       presence: { message: "Make sure to provide a street address" }
 
-    validates :mailing_city,
+    validates :city,
       presence: { message: "Make sure to provide a city" }
 
-    validates :mailing_zip,
+    validates :zip,
       length: { is: 5, message: "Make sure your ZIP code is 5 digits long" }
   end
 end

--- a/app/views/medicaid/contact_home_address/edit.html.erb
+++ b/app/views/medicaid/contact_home_address/edit.html.erb
@@ -9,9 +9,9 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_input_field :residential_street_address, "Street address", autofocus: true %>
-      <%= f.mb_input_field :residential_city, "City" %>
-      <%= f.mb_input_field :residential_zip, "ZIP code", type: :tel, options: { maxlength: 5 } %>
+      <%= f.mb_input_field :street_address, "Street address", autofocus: true %>
+      <%= f.mb_input_field :city, "City" %>
+      <%= f.mb_input_field :zip, "ZIP code", type: :tel, options: { maxlength: 5 } %>
 
       <%= f.mb_checkbox(
         :mailing_address_same_as_residential_address,

--- a/app/views/medicaid/contact_mailing_address/edit.html.erb
+++ b/app/views/medicaid/contact_mailing_address/edit.html.erb
@@ -9,9 +9,9 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_input_field :mailing_street_address, "Street address", autofocus: true %>
-      <%= f.mb_input_field :mailing_city, "City" %>
-      <%= f.mb_input_field :mailing_zip, "ZIP code", type: :tel, options: { maxlength: 5 } %>
+      <%= f.mb_input_field :street_address, "Street address", autofocus: true %>
+      <%= f.mb_input_field :city, "City" %>
+      <%= f.mb_input_field :zip, "ZIP code", type: :tel, options: { maxlength: 5 } %>
 
       <%= render "medicaid/next_step" %>
     <% end %>

--- a/db/migrate/20171108012317_extract_addresses_from_medicaid_applications.rb
+++ b/db/migrate/20171108012317_extract_addresses_from_medicaid_applications.rb
@@ -1,0 +1,45 @@
+class ExtractAddressesFromMedicaidApplications < ActiveRecord::Migration[5.1]
+  def up
+    add_column :addresses, :benefit_application_id, :bigint
+    add_column :addresses, :benefit_application_type, :string
+
+    safety_assured do
+      execute <<~SQL
+        UPDATE addresses SET benefit_application_id=snap_application_id;
+        UPDATE addresses SET benefit_application_type='SnapApplication';
+      SQL
+    end
+
+    change_column_null :addresses, :benefit_application_id, false
+    change_column_null :addresses, :benefit_application_type, false
+
+    safety_assured do
+      remove_column :addresses, :snap_application_id
+
+      execute <<~SQL
+        INSERT INTO addresses
+        (street_address,city,county,state,zip,created_at,updated_at, benefit_application_id, benefit_application_type, mailing)
+        SELECT residential_street_address, residential_city, 'Genesee', 'MI', residential_zip, now(), now(), id, 'MedicaidApplication', false
+        FROM medicaid_applications
+        WHERE residential_street_address IS NOT null AND residential_city IS NOT null AND residential_zip IS NOT null;
+
+        INSERT INTO addresses
+        (street_address,city,county,state,zip,created_at,updated_at, benefit_application_id, benefit_application_type, mailing)
+        SELECT mailing_street_address, mailing_city, 'Genesee', 'MI', mailing_zip, now(), now(), id, 'MedicaidApplication', true
+        FROM medicaid_applications
+        WHERE mailing_street_address IS NOT null AND mailing_city IS NOT null AND mailing_zip IS NOT null;
+      SQL
+
+      remove_column :medicaid_applications, :residential_street_address
+      remove_column :medicaid_applications, :residential_city
+      remove_column :medicaid_applications, :residential_zip
+      remove_column :medicaid_applications, :mailing_street_address
+      remove_column :medicaid_applications, :mailing_city
+      remove_column :medicaid_applications, :mailing_zip
+    end
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,22 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171108010437) do
+ActiveRecord::Schema.define(version: 20171108012317) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "addresses", force: :cascade do |t|
+    t.bigint "benefit_application_id", null: false
+    t.string "benefit_application_type", null: false
     t.string "city", null: false
     t.string "county", null: false
     t.datetime "created_at", null: false
     t.boolean "mailing", default: true, null: false
-    t.bigint "snap_application_id"
     t.string "state", null: false
     t.string "street_address", null: false
     t.datetime "updated_at", null: false
     t.string "zip", null: false
-    t.index ["snap_application_id"], name: "index_addresses_on_snap_application_id"
   end
 
   create_table "admin_users", force: :cascade do |t|
@@ -132,18 +132,12 @@ ActiveRecord::Schema.define(version: 20171108010437) do
     t.boolean "income_social_security"
     t.boolean "income_unemployment"
     t.boolean "mailing_address_same_as_residential_address"
-    t.string "mailing_city"
-    t.string "mailing_street_address"
-    t.string "mailing_zip"
     t.boolean "michigan_resident", null: false
     t.boolean "need_medical_expense_help_3_months"
     t.string "office_location"
     t.string "paperwork", array: true
     t.string "phone_number"
     t.boolean "reliable_mail_address"
-    t.string "residential_city"
-    t.string "residential_street_address"
-    t.string "residential_zip"
     t.integer "self_employed_monthly_income"
     t.integer "self_employment_expenses"
     t.string "signature"

--- a/spec/controllers/mailing_address_controller_spec.rb
+++ b/spec/controllers/mailing_address_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe MailingAddressController, type: :controller do
 
   describe "#update" do
     context "when valid" do
-      it "updates the app" do
+      it "updates the app and provides default values for county and state" do
         valid_params = {
           street_address: "321 Real St",
           city: "Shelbyville",
@@ -39,29 +39,14 @@ RSpec.describe MailingAddressController, type: :controller do
         current_app.reload
 
         valid_params.each do |key, value|
-          expect(current_app_mailing_address[key]).to eq(value)
+          expect(current_app.mailing_address[key]).to eq(value)
         end
+        expect(current_app.mailing_address["county"]).to eq("Genesee")
+        expect(current_app.mailing_address["state"]).to eq("MI")
 
         expect(current_app.mailing_address_same_as_residential_address).to be(
           false,
         )
-      end
-
-      it "always sets the county to 'Genesee' and state to 'MI'" do
-        current_app_mailing_address.update(state: "CA", county: "test")
-        valid_params = {
-          street_address: "321 Main St",
-          city: "Plymouth",
-          zip: "48170",
-          mailing_address_same_as_residential_address: true,
-        }
-
-        put :update, params: { step: valid_params }
-
-        current_app_mailing_address.reload
-
-        expect(current_app_mailing_address["county"]).to eq("Genesee")
-        expect(current_app_mailing_address["state"]).to eq("MI")
       end
 
       it "redirects to the next step" do
@@ -79,10 +64,6 @@ RSpec.describe MailingAddressController, type: :controller do
     end
   end
 
-  def current_app_mailing_address
-    current_app.addresses.where(mailing: true).first
-  end
-
   def current_app
     @_current_app ||= create(
       :snap_application,
@@ -92,7 +73,7 @@ RSpec.describe MailingAddressController, type: :controller do
   end
 
   def address
-    create(
+    build(
       :address,
       street_address: "123 Fake St",
       city: "Springfield",

--- a/spec/controllers/medicaid/contact_home_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_home_address_controller_spec.rb
@@ -21,18 +21,27 @@ RSpec.describe Medicaid::ContactHomeAddressController, type: :controller do
         expect(response).to render_template(:edit)
       end
 
-      context "client does not have stable housing" do
-        it "redirects to the next page" do
-          medicaid_application = create(
-            :medicaid_application,
-            stable_housing: false,
-          )
-          session[:medicaid_application_id] = medicaid_application.id
+      it "pre-populates the data properly" do
+        medicaid_application = create(
+          :medicaid_application,
+          stable_housing: true,
+        )
+        create(
+          :address,
+          street_address: "I live here",
+          city: "Hometown",
+          zip: "54321",
+          mailing: false,
+          benefit_application: medicaid_application,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
 
-          get :edit
+        get :edit
+        step = assigns(:step)
 
-          expect(response).to redirect_to(subject.next_path)
-        end
+        expect(step.street_address).to eq("I live here")
+        expect(step.city).to eq("Hometown")
+        expect(step.zip).to eq("54321")
       end
 
       context "mailing address not the same as residential address is nil" do
@@ -66,6 +75,107 @@ RSpec.describe Medicaid::ContactHomeAddressController, type: :controller do
           step = assigns(:step)
           expect(step.mailing_address_same_as_residential_address).
             to eq false
+        end
+      end
+    end
+
+    context "client does not have stable housing" do
+      it "redirects to the next page" do
+        medicaid_application = create(
+          :medicaid_application,
+          stable_housing: false,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+  end
+
+  describe "#update" do
+    context "when valid" do
+      it "redirects to the next step" do
+        medicaid_application = create(:medicaid_application)
+        session[:medicaid_application_id] = medicaid_application.id
+
+        params = {
+          street_address: "321 Real St",
+          city: "Shelbyville",
+          zip: "54321",
+          mailing_address_same_as_residential_address: true,
+        }
+
+        put :update, params: { step: params }
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+
+      context "and no residential address currently exists" do
+        it "updates the app and provides default values for county and state" do
+          medicaid_application = create(
+            :medicaid_application,
+            stable_housing: true,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          params = {
+            street_address: "321 Real St",
+            city: "Shelbyville",
+            zip: "54321",
+            mailing_address_same_as_residential_address: "false",
+          }
+
+          put :update, params: { step: params }
+
+          residential_address = medicaid_application.reload.residential_address
+
+          expect(residential_address.street_address).to eq "321 Real St"
+          expect(residential_address.city).to eq "Shelbyville"
+          expect(residential_address.zip).to eq "54321"
+          expect(residential_address.county).to eq("Genesee")
+          expect(residential_address.state).to eq("MI")
+          expect(
+            medicaid_application.mailing_address_same_as_residential_address,
+          ).to eq false
+        end
+      end
+
+      context "and residential address currently exists" do
+        it "updates the residential address" do
+          medicaid_application = create(
+            :medicaid_application,
+            stable_housing: true,
+          )
+          create(:address,
+                 street_address: "456 Fake Street",
+                 city: "Jackson",
+                 zip: "55555",
+                 county: "Blah",
+                 state: "CA",
+                 benefit_application: medicaid_application)
+          session[:medicaid_application_id] = medicaid_application.id
+
+          params = {
+            street_address: "321 Real St",
+            city: "Shelbyville",
+            zip: "54321",
+            mailing_address_same_as_residential_address: "false",
+          }
+
+          put :update, params: { step: params }
+
+          residential_address = medicaid_application.reload.residential_address
+
+          expect(residential_address.street_address).to eq "321 Real St"
+          expect(residential_address.city).to eq "Shelbyville"
+          expect(residential_address.zip).to eq "54321"
+          expect(residential_address.county).to eq("Genesee")
+          expect(residential_address.state).to eq("MI")
+          expect(
+            medicaid_application.mailing_address_same_as_residential_address,
+          ).to eq false
         end
       end
     end

--- a/spec/controllers/medicaid/contact_mailing_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_mailing_address_controller_spec.rb
@@ -84,6 +84,109 @@ RSpec.describe Medicaid::ContactMailingAddressController, type: :controller do
 
         expect(response).to render_template(:edit)
       end
+
+      it "pre-populates the data properly if mailing address present" do
+        medicaid_application = create(
+          :medicaid_application,
+        )
+        create(
+          :address,
+          street_address: "I live here",
+          city: "Hometown",
+          zip: "54321",
+          mailing: true,
+          benefit_application: medicaid_application,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+        step = assigns(:step)
+
+        expect(step.street_address).to eq("I live here")
+        expect(step.city).to eq("Hometown")
+        expect(step.zip).to eq("54321")
+      end
+    end
+  end
+
+  describe "#update" do
+    context "when valid" do
+      it "redirects to the next step" do
+        medicaid_application = create(:medicaid_application)
+        session[:medicaid_application_id] = medicaid_application.id
+
+        params = {
+          street_address: "321 Real St",
+          city: "Shelbyville",
+          zip: "54321",
+        }
+
+        put :update, params: { step: params }
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+
+      context "and no residential address currently exists" do
+        it "updates the app and provides default values for county and state" do
+          medicaid_application = create(
+            :medicaid_application,
+            stable_housing: true,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          params = {
+            street_address: "321 Real St",
+            city: "Shelbyville",
+            zip: "54321",
+          }
+
+          put :update, params: { step: params }
+
+          mailing_address = medicaid_application.reload.mailing_address
+
+          expect(mailing_address.street_address).to eq "321 Real St"
+          expect(mailing_address.city).to eq "Shelbyville"
+          expect(mailing_address.zip).to eq "54321"
+          expect(mailing_address.county).to eq("Genesee")
+          expect(mailing_address.state).to eq("MI")
+        end
+      end
+
+      context "and residential address currently exists" do
+        it "updates the residential address" do
+          medicaid_application = create(
+            :medicaid_application,
+            stable_housing: true,
+          )
+          create(:address,
+                 street_address: "456 Fake Street",
+                 city: "Jackson",
+                 zip: "55555",
+                 county: "Blah",
+                 state: "CA",
+                 mailing: true,
+                 benefit_application: medicaid_application)
+          session[:medicaid_application_id] = medicaid_application.id
+
+          params = {
+            street_address: "321 Real St",
+            city: "Shelbyville",
+            zip: "54321",
+          }
+
+          put :update, params: { step: params }
+
+          medicaid_application.reload
+
+          mailing_address = medicaid_application.reload.mailing_address
+
+          expect(mailing_address.street_address).to eq "321 Real St"
+          expect(mailing_address.city).to eq "Shelbyville"
+          expect(mailing_address.zip).to eq "54321"
+          expect(mailing_address.county).to eq("Genesee")
+          expect(mailing_address.state).to eq("MI")
+        end
+      end
     end
   end
 end

--- a/spec/controllers/residential_address_controller_spec.rb
+++ b/spec/controllers/residential_address_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe ResidentialAddressController, type: :controller do
   end
 
   def address
-    create(
+    build(
       :address,
       street_address: "I live here",
       city: "Hometown",

--- a/spec/models/dhs1171_pdf_spec.rb
+++ b/spec/models/dhs1171_pdf_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe Dhs1171Pdf do
   describe "#save" do
     it "saves the client info" do
-      mailing_address = create(:mailing_address)
-      residential_address = create(:address)
+      mailing_address = build(:mailing_address)
+      residential_address = build(:address)
       member = create(:member, ssn: "012345678")
       snap_application = create(
         :snap_application,

--- a/spec/models/medicaid_application_spec.rb
+++ b/spec/models/medicaid_application_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe MedicaidApplication do
+  describe "#residential_address" do
+    context "mailing_address_same_as_residential_address is true" do
+      it "returns mailing address" do
+        app = create(:medicaid_application,
+                     stable_housing: true,
+                     mailing_address_same_as_residential_address: true)
+        create(:address, benefit_application: app)
+        mailing_address = create(:mailing_address, benefit_application: app)
+
+        expect(app.residential_address).to eq mailing_address
+      end
+    end
+
+    context "mailing_address_same_as_residential_address is false" do
+      context "residential address not present" do
+        it "returns NullAddress" do
+          app = create(:medicaid_application,
+                       stable_housing: true,
+                       mailing_address_same_as_residential_address: false)
+          create(:mailing_address, benefit_application: app)
+
+          expect(app.residential_address).to be_a NullAddress
+        end
+      end
+
+      context "residential address present" do
+        context "housing is stable" do
+          it "returns residential address" do
+            app = create(:medicaid_application, stable_housing: true)
+            create(:mailing_address, benefit_application: app)
+            residential_address = create(:address, benefit_application: app)
+
+            expect(app.residential_address).to eq residential_address
+          end
+        end
+
+        context "housing is not stable" do
+          it "returns NullAddress" do
+            app = create(:medicaid_application, stable_housing: false)
+            create(:mailing_address, benefit_application: app)
+            _residential_address = create(:address, benefit_application: app)
+
+            expect(app.residential_address.class).to eq NullAddress
+          end
+        end
+      end
+    end
+  end
+
+  describe "#mailing_address" do
+    context "mailing address exists" do
+      it "returns mailing address" do
+        app = create(:medicaid_application)
+        mailing_address = create(:mailing_address, benefit_application: app)
+
+        expect(app.mailing_address).to eq(mailing_address)
+      end
+    end
+
+    context "mailing address does not exist" do
+      it "returns NullAddress" do
+        app = create(:medicaid_application)
+        create(:address, benefit_application: app)
+
+        expect(app.mailing_address.class).to eq(NullAddress)
+      end
+    end
+  end
+end

--- a/spec/models/snap_application_attributes_spec.rb
+++ b/spec/models/snap_application_attributes_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe SnapApplicationAttributes do
   describe "#to_h" do
     it "returns a hash of attributes" do
-      mailing_address = create(:mailing_address)
-      residential_address = create(:address)
+      mailing_address = build(:mailing_address)
+      residential_address = build(:address)
       snap_application = create(
         :snap_application,
         :with_member,

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe SnapApplication do
       it "returns mailing address" do
         app = create(:snap_application,
                       mailing_address_same_as_residential_address: true)
-        create(:address, snap_application: app)
-        mailing_address = create(:mailing_address, snap_application: app)
+        create(:address, benefit_application: app)
+        mailing_address = create(:mailing_address, benefit_application: app)
 
         expect(app.residential_address).to eq mailing_address
       end
@@ -111,7 +111,7 @@ RSpec.describe SnapApplication do
       context "residential address not present" do
         it "returns NullAddress" do
           app = create(:snap_application)
-          create(:mailing_address, snap_application: app)
+          create(:mailing_address, benefit_application: app)
 
           expect(app.residential_address).to be_a NullAddress
         end
@@ -121,8 +121,8 @@ RSpec.describe SnapApplication do
         context "housing is stable" do
           it "returns residential address" do
             app = create(:snap_application)
-            create(:mailing_address, snap_application: app)
-            residential_address = create(:address, snap_application: app)
+            create(:mailing_address, benefit_application: app)
+            residential_address = create(:address, benefit_application: app)
 
             expect(app.residential_address).to eq residential_address
           end
@@ -131,12 +131,32 @@ RSpec.describe SnapApplication do
         context "housing is not stable" do
           it "returns NullAddress" do
             app = create(:snap_application, stable_housing: false)
-            create(:mailing_address, snap_application: app)
-            _residential_address = create(:address, snap_application: app)
+            create(:mailing_address, benefit_application: app)
+            _residential_address = create(:address, benefit_application: app)
 
             expect(app.residential_address.class).to eq NullAddress
           end
         end
+      end
+    end
+  end
+
+  describe "#mailing_address" do
+    context "mailing address exists" do
+      it "returns mailing address" do
+        app = create(:snap_application)
+        mailing_address = create(:mailing_address, benefit_application: app)
+
+        expect(app.mailing_address).to eq(mailing_address)
+      end
+    end
+
+    context "mailing address does not exist" do
+      it "returns NullAddress" do
+        app = create(:snap_application)
+        create(:address, benefit_application: app)
+
+        expect(app.mailing_address.class).to eq(NullAddress)
       end
     end
   end

--- a/spec/steps/medicaid/contact_home_address_spec.rb
+++ b/spec/steps/medicaid/contact_home_address_spec.rb
@@ -4,21 +4,21 @@ RSpec.describe Medicaid::ContactHomeAddress do
   describe "Validations" do
     it "validates presence of address fields" do
       valid_address = Medicaid::ContactHomeAddress.new(
-        residential_street_address: "123 Main St.",
-        residential_city: "Flint",
-        residential_zip: "12345",
+        street_address: "123 Main St.",
+        city: "Flint",
+        zip: "12345",
       )
 
       invalid_nil_address = Medicaid::ContactHomeAddress.new(
-        residential_street_address: nil,
-        residential_city: nil,
-        residential_zip: nil,
+        street_address: nil,
+        city: nil,
+        zip: nil,
       )
 
       invalid_blank_address = Medicaid::ContactHomeAddress.new(
-        residential_street_address: "",
-        residential_city: "",
-        residential_zip: "",
+        street_address: "",
+        city: "",
+        zip: "",
       )
 
       expect(valid_address).to be_valid

--- a/spec/steps/medicaid/contact_mailing_address_spec.rb
+++ b/spec/steps/medicaid/contact_mailing_address_spec.rb
@@ -4,21 +4,21 @@ RSpec.describe Medicaid::ContactMailingAddress do
   describe "Validations" do
     it "validates presence of address fields" do
       valid_address = Medicaid::ContactMailingAddress.new(
-        mailing_street_address: "123 Main St.",
-        mailing_city: "Flint",
-        mailing_zip: "12345",
+        street_address: "123 Main St.",
+        city: "Flint",
+        zip: "12345",
       )
 
       invalid_nil_address = Medicaid::ContactMailingAddress.new(
-        mailing_street_address: nil,
-        mailing_city: nil,
-        mailing_zip: nil,
+        street_address: nil,
+        city: nil,
+        zip: nil,
       )
 
       invalid_blank_address = Medicaid::ContactMailingAddress.new(
-        mailing_street_address: "",
-        mailing_city: "",
-        mailing_zip: "",
+        street_address: "",
+        city: "",
+        zip: "",
       )
 
       expect(valid_address).to be_valid


### PR DESCRIPTION
 * Make polymorphic relationship between addresses and benefit_application
 * Introduce `application_params` to decouple step and application
 attributes

 [Finishes #152622153]

Signed-off-by: Christa Hartsock <christa@codeforamerica.org>