### PR TITLE
Fix subheaders on `/medicaid/steps/amounts-income`

### DIFF
--- a/app/views/medicaid/amounts_income/edit.html.erb
+++ b/app/views/medicaid/amounts_income/edit.html.erb
@@ -29,18 +29,24 @@
          :employed_monthly_income,
          "Monthly income (before taxes)",
          options: { count: current_member.employed_number_of_jobs },
-         prepend_html: "<p class=\"text--section-header\">Current Job ({index})</p>"
+         prepend_html: "<p class=\"text--section-header\">Current Job (\#{index})</p>"
        ) %>
       <% end %>
 
       <% if current_member.self_employed? %>
+        <p class="text--section-header">
+        Self-Employment
+        </p>
         <%= f.mb_money_field :self_employed_monthly_income,
-          "Self-Employment (average monthly income)" %>
+          "Monthly income (before taxes)" %>
       <% end %>
 
       <% if current_member.receives_unemployment_income? %>
+        <p class="text--section-header">
+        Other Income
+        </p>
         <%= f.mb_money_field :unemployment_income,
-          "Unemployment (average monthly income)" %>
+          "Monthly unemployment income (before taxes)" %>
       <% end %>
 
       <%= render "medicaid/next_step" %>

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -285,8 +285,8 @@ RSpec.feature "Medicaid app" do
       expect(page).to have_content(
         "Tell us Jessie Tester’s specific income received",
       )
-      fill_in "Self-Employment (average monthly income)", with: "100"
-      fill_in "Unemployment (average monthly income)", with: "100"
+      fill_in "step_self_employed_monthly_income", with: 100
+      fill_in "step_unemployment_income", with: 100
       click_on "Next"
     end
 


### PR DESCRIPTION
* These styles were added at
https://github.com/codeforamerica/michigan-benefits/pull/433 but some
were lost in a recent merge conflict.

<img width="701" alt="screen shot 2017-11-08 at 4 49 46 pm" src="https://user-images.githubusercontent.com/601515/32582857-b7023bb2-c4a5-11e7-8a84-e4b26326f1f4.png">

<img width="697" alt="screen shot 2017-11-08 at 4 50 02 pm" src="https://user-images.githubusercontent.com/601515/32582860-b97a7ed6-c4a5-11e7-87ff-d841fc404d72.png">
