### PR TITLE
Show most members in snap application dashboard

### DIFF
--- a/app/dashboards/snap_application_dashboard.rb
+++ b/app/dashboards/snap_application_dashboard.rb
@@ -58,7 +58,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     utility_trash: Field::Boolean,
     utility_water_sewer: Field::Boolean,
     vehicle_income: Field::Boolean,
-    members: Field::HasMany,
+    members: Field::HasMany.with_options(limit: 20),
     driver_errors: Field::HasMany,
     exports: Field::HasMany,
   }.freeze


### PR DESCRIPTION
When viewing a snap application the admin would like to see all (this is
assuming there are no more than 20 members of a household) of the
members in a household.

Previously, the limit was the default of 5 records returned. To get
around having to paginate those members and to view them all in one
page, we can change the default option.

***

References bug: https://sentry.io/app73768247herokucom-6k/app73768247herokucom/issues/402208117/

```
ActionView::Template::Errorapp/views/admin/snap_applications/_collection.html.erb in block in _app_views_admin_snap_applications__collection_html_erb___1318627924288171491_53775620 at line 31
found unpermitted parameter: :members
```

[Finishes #152736200]