### PR TITLE
New pattern for our update inheritance structure

### DIFF
--- a/app/controllers/medicaid/contact_home_address_controller.rb
+++ b/app/controllers/medicaid/contact_home_address_controller.rb
@@ -26,7 +26,8 @@ module Medicaid
       !current_application&.stable_housing?
     end
 
-    def after_successful_update_hook
+    def update_application
+      current_application.update!(application_params)
       address.update!(address_params)
     end
 

--- a/app/controllers/medicaid/contact_mailing_address_controller.rb
+++ b/app/controllers/medicaid/contact_mailing_address_controller.rb
@@ -6,12 +6,8 @@ module Medicaid
       HashWithIndifferentAccess.new(address.attributes)
     end
 
-    def after_successful_update_hook
+    def update_application
       address.update!(step_params.merge(state: "MI", county: "Genesee"))
-    end
-
-    def application_params
-      {}
     end
 
     def skip?

--- a/app/controllers/medicaid/expenses_alimony_controller.rb
+++ b/app/controllers/medicaid/expenses_alimony_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class ExpensesAlimonyController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/expenses_student_loan_controller.rb
+++ b/app/controllers/medicaid/expenses_student_loan_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class ExpensesStudentLoanController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/health_disability_controller.rb
+++ b/app/controllers/medicaid/health_disability_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class HealthDisabilityController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/health_pregnancy_controller.rb
+++ b/app/controllers/medicaid/health_pregnancy_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class HealthPregnancyController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/income_job_controller.rb
+++ b/app/controllers/medicaid/income_job_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class IncomeJobController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/income_job_number_member_controller.rb
+++ b/app/controllers/medicaid/income_job_number_member_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class IncomeJobNumberMemberController < Medicaid::ManyMemberStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+      
       current_application.members.each do |member|
         member.update(employed: member.employed_number_of_jobs&.positive?)
       end

--- a/app/controllers/medicaid/income_other_income_controller.rb
+++ b/app/controllers/medicaid/income_other_income_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class IncomeOtherIncomeController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/income_self_employment_controller.rb
+++ b/app/controllers/medicaid/income_self_employment_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class IncomeSelfEmploymentController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/insurance_current_controller.rb
+++ b/app/controllers/medicaid/insurance_current_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class InsuranceCurrentController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/intro_citizen_controller.rb
+++ b/app/controllers/medicaid/intro_citizen_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class IntroCitizenController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/intro_college_controller.rb
+++ b/app/controllers/medicaid/intro_college_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class IntroCollegeController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/intro_marital_status_controller.rb
+++ b/app/controllers/medicaid/intro_marital_status_controller.rb
@@ -2,7 +2,9 @@ module Medicaid
   class IntroMaritalStatusController < MedicaidStepsController
     private
 
-    def after_successful_update_hook
+    def update_application
+      super
+
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
       end

--- a/app/controllers/medicaid/intro_marital_status_indicate_spouse_controller.rb
+++ b/app/controllers/medicaid/intro_marital_status_indicate_spouse_controller.rb
@@ -8,13 +8,9 @@ module Medicaid
 
     private
 
-    def after_successful_update_hook
+    def update_application
       current_member.update(step_params)
       update_spouse_of_other_member_if_present
-    end
-
-    def application_params
-      {}
     end
 
     def skip?

--- a/app/controllers/medicaid/many_member_steps_controller.rb
+++ b/app/controllers/medicaid/many_member_steps_controller.rb
@@ -8,8 +8,7 @@ module Medicaid
       assign_household_member_attributes
 
       if step.valid?
-        ActiveRecord::Base.transaction { step.members.each(&:save!) }
-        after_successful_update_hook
+        update_application
         redirect_to(next_path)
       else
         render :edit
@@ -17,6 +16,10 @@ module Medicaid
     end
 
     private
+
+    def update_application
+      ActiveRecord::Base.transaction { step.members.each(&:save!) }
+    end
 
     def assign_household_member_attributes
       step.members.each do |member|

--- a/app/controllers/residential_address_controller.rb
+++ b/app/controllers/residential_address_controller.rb
@@ -1,17 +1,14 @@
 class ResidentialAddressController < SnapStepsController
-  def update
-    @step = step_class.new(step_params)
+  private
 
-    if @step.valid?
-      current_application.update!(stable_housing: stable_housing)
-      address.update(step_params.except(:unstable_housing))
-      redirect_to(next_path)
-    else
-      render :edit
-    end
+  def update_application
+    current_application.update!(stable_housing: stable_housing)
+    address.update(address_params)
   end
 
-  private
+  def address_params
+    step_params.slice(:city, :county, :state, :street_address, :zip)
+  end
 
   def existing_attributes
     attributes = address.attributes.merge(current_application.attributes)

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -32,16 +32,15 @@ class StepsController < ApplicationController
     @step = step_class.new(step_params)
 
     if @step.valid?
-      current_application.update!(application_params)
-      after_successful_update_hook
+      update_application
       redirect_to(next_path)
     else
       render :edit
     end
   end
 
-  def application_params
-    step_params
+  def update_application
+    current_application.update!(step_params)
   end
 
   def self.to_param
@@ -79,9 +78,6 @@ class StepsController < ApplicationController
   private
 
   delegate :step_class, to: :class
-
-  # This is an intentional noop
-  def after_successful_update_hook; end
 
   # This is an intentional noop
   def before_rendering_edit_hook; end

--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -27,7 +27,9 @@ class SuccessController < SnapStepsController
     )
   end
 
-  def after_successful_update_hook
+  def update_application
+    super
+
     flash[:notice] = flash_notice
     ExportFactory.create(
       destination: :client_email,


### PR DESCRIPTION
 * Still can update the current application with step params with no
 boilerplate
 * Add additional behavior to the happy path update with a call to super
 * Replace the call entirely without needing a noop update

Signed-off-by: Joel Oliveira <joel.oliveira@gmail.com>

I don't particularly care if we merge this, but I wanted to show an example for a new style of inheritance, one where we can explicitly show which fields go from the step to a specific db model.
This is going to be more important as we move fields out of the application model.

`app/controllers/residential_address_controller.rb` shows a good example of this transformation.

Let's discuss!

@jayroh @jessieay @hartsick @bengolder 