### PR TITLE
Devise route constraints for admin-only DJ access

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,8 +2,6 @@
 # We use a different name because RAILS_ENV is overloaded and is technically the
 # same across each release stage.
 
-ADMIN_PASSWORD="password"
-ADMIN_USER="admin"
 APP_RELEASE_STAGE=development
 FORM_RECIPIENT=test@example.com
 PORT=3000

--- a/app.json
+++ b/app.json
@@ -5,12 +5,6 @@
     "postdeploy": "bin/rails db:migrate db:seed"
   },
   "env": {
-    "ADMIN_PASSWORD": {
-      "required": true
-    },
-    "ADMIN_USER": {
-      "required": true
-    },
     "APP_RELEASE_STAGE": {
       "required": true
     },

--- a/config.ru
+++ b/config.ru
@@ -4,15 +4,4 @@
 
 require_relative "config/environment"
 
-if Rails.env.production?
-  DelayedJobWeb.use Rack::Auth::Basic do |username, password|
-    # rubocop:disable LineLength
-    username_match = ActiveSupport::SecurityUtils.variable_size_secure_compare(ENV["ADMIN_USER"], username)
-    password_match = ActiveSupport::SecurityUtils.variable_size_secure_compare(ENV["ADMIN_PASSWORD"], password)
-    # rubocop:enable LineLength
-
-    username_match && password_match
-  end
-end
-
 run Rails.application

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,20 +1,23 @@
 Rails.application.routes.draw do
   devise_for :admin_users
-  match "/delayed_job" => DelayedJobWeb, anchor: false, via: %i(get post)
 
-  namespace :admin do
-    resources :snap_applications do
-      post "resend_email", on: :member
-      get "pdf", on: :member
-    end
-    resources :medicaid_applications do
-      get "pdf", on: :member
-    end
-    resources :exports, only: %i[index show]
-    resources :members
-    resources :driver_errors, only: %i[index show]
+  authenticate :admin_user do
+    match "/delayed_job" => DelayedJobWeb, anchor: false, via: %i(get post)
 
-    root to: "snap_applications#index"
+    namespace :admin do
+      resources :snap_applications do
+        post "resend_email", on: :member
+        get "pdf", on: :member
+      end
+      resources :medicaid_applications do
+        get "pdf", on: :member
+      end
+      resources :exports, only: %i[index show]
+      resources :members
+      resources :driver_errors, only: %i[index show]
+
+      root to: "snap_applications#index"
+    end
   end
 
   root "static_pages#index"

--- a/spec/features/admin_user_delayed_job_spec.rb
+++ b/spec/features/admin_user_delayed_job_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.feature "Admin user access Delayed Job web" do
+  context "admin not logged in" do
+    scenario "redirected to sign-in page" do
+      visit "/delayed_job"
+
+      expect(page).to have_content "Log in"
+      expect(page).to have_content "Email"
+      expect(page).to have_content "Password"
+    end
+  end
+
+  context "admin signs in" do
+    scenario "ends up on Delayed Job Web page" do
+      create(:admin_user, email: "test@example.com", password: "password")
+      visit "/delayed_job"
+
+      fill_in "Email", with: "test@example.com"
+      fill_in "Password", with: "password"
+      click_on "Log in"
+
+      expect(page).to have_content "The list below shows an overview "\
+        "of the jobs in the delayed_job queue"
+    end
+  end
+end


### PR DESCRIPTION
Using devise's built in route helpers we can restrict access to both
delayed job AND the admin. This allows users who visit the admin or DJ
to be forced to log in first, and then be redirected back to their
intended destination.

More information can be found here:

  https://github.com/plataformatec/devise/wiki/How-To:-Define-resource-actions-that-require-authentication-using-routes.rb