### PR TITLE
Log DelayedJob access

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,4 +1,5 @@
 require_relative "boot"
+require_relative "../lib/delayed_job_web_logger"
 require "rails/all"
 
 Bundler.require(*Rails.groups)
@@ -15,5 +16,6 @@ module MichiganBenefits
     config.autoload_paths << Rails.root.join("app/steps")
     config.filter_parameters += [:ssn]
     config.autoload_paths << Rails.root.join("lib")
+    config.middleware.insert_after Warden::Manager, DelayedJobWebLogger
   end
 end

--- a/lib/delayed_job_web_logger.rb
+++ b/lib/delayed_job_web_logger.rb
@@ -1,0 +1,21 @@
+class DelayedJobWebLogger
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    if in_delayed_job?(env) && env["warden"].authenticated?
+      Rails.logger.tagged(env["warden"].user.email) do
+        @app.call(env)
+      end
+    else
+      @app.call(env)
+    end
+  end
+
+  private
+
+  def in_delayed_job?(env)
+    env["PATH_INFO"].match? %r{^/delayed_job}
+  end
+end


### PR DESCRIPTION
Using some rack middleware we can log the actions of whoever is
accessing the DelayedJob web admin.

[Finishes #152762754]