### PR TITLE
Bootstrap filling out 1426 PDF

### DIFF
--- a/app/controllers/admin/medicaid_applications_controller.rb
+++ b/app/controllers/admin/medicaid_applications_controller.rb
@@ -1,0 +1,29 @@
+module Admin
+  class MedicaidApplicationsController < Admin::ApplicationController
+    # To customize the behavior of this controller,
+    # you can overwrite any of the RESTful actions. For example:
+    #
+    # def index
+    #   super
+    #   @resources = MedicaidApplication.
+    #     page(params[:page]).
+    #     per(10)
+    # end
+
+    # Define a custom finder by overriding the `find_resource` method:
+    # def find_resource(param)
+    #   MedicaidApplication.find_by!(slug: param)
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+
+    def pdf
+      application = MedicaidApplication.find(params[:id])
+      send_data(application.pdf.read,
+                filename: "medicaid-application-#{application.signature}.pdf",
+                type: "application/pdf",
+                disposition: "inline")
+    end
+  end
+end

--- a/app/dashboards/medicaid_application_dashboard.rb
+++ b/app/dashboards/medicaid_application_dashboard.rb
@@ -1,0 +1,185 @@
+require "administrate/base_dashboard"
+
+class MedicaidApplicationDashboard < Administrate::BaseDashboard
+  # ATTRIBUTE_TYPES
+  # a hash that describes the type of each of the model's fields.
+  #
+  # Each different type represents an Administrate::Field object,
+  # which determines how the attribute is displayed
+  # on pages throughout the dashboard.
+  ATTRIBUTE_TYPES = {
+    members: Field::HasMany,
+    addresses: Field::HasMany,
+    id: Field::Number,
+    michigan_resident: Field::Boolean,
+    created_at: Field::DateTime,
+    updated_at: Field::DateTime,
+    submit_ssn: Field::Boolean,
+    homeless: Field::Boolean,
+    reliable_mail_address: Field::Boolean,
+    need_medical_expense_help_3_months: Field::Boolean,
+    income_unemployment: Field::Boolean,
+    income_pension: Field::Boolean,
+    income_social_security: Field::Boolean,
+    income_retirement: Field::Boolean,
+    income_alimony: Field::Boolean,
+    filing_federal_taxes_next_year: Field::Boolean,
+    self_employed_monthly_income: Field::Number,
+    college_loan_interest_expenses: Field::Number,
+    child_support_alimony_arrears_expenses: Field::Number,
+    phone_number: Field::String,
+    sms_phone_number: Field::String,
+    email: Field::String,
+    sms_consented: Field::Boolean,
+    birthday: Field::DateTime,
+    self_employment_expenses: Field::Number,
+    employed_monthly_income: Field::String,
+    anyone_in_college: Field::Boolean,
+    flint_water_crisis: Field::Boolean,
+    anyone_employed: Field::Boolean,
+    everyone_a_citizen: Field::Boolean,
+    anyone_new_mom: Field::Boolean,
+    anyone_self_employed: Field::Boolean,
+    anyone_other_income: Field::Boolean,
+    anyone_insured: Field::Boolean,
+    anyone_disabled: Field::Boolean,
+    anyone_pay_child_support_alimony_arrears: Field::Boolean,
+    anyone_pay_student_loan_interest: Field::Boolean,
+    anyone_caretaker_or_parent: Field::Boolean,
+    consent_to_terms: Field::Boolean,
+    encrypted_last_four_ssn: Field::String,
+    encrypted_last_four_ssn_iv: Field::String,
+    signature: Field::String,
+    signed_at: Field::DateTime,
+    upload_paperwork: Field::Boolean,
+    paperwork: Field::String,
+    office_location: Field::String,
+    mailing_address_same_as_residential_address: Field::Boolean,
+    stable_housing: Field::Boolean,
+    anyone_married: Field::Boolean,
+  }.freeze
+
+  # COLLECTION_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's index page.
+  #
+  # By default, it's limited to four items to reduce clutter on index pages.
+  # Feel free to add, remove, or rearrange items.
+  COLLECTION_ATTRIBUTES = %i[
+    id
+    phone_number
+    signed_at
+  ].freeze
+
+  # SHOW_PAGE_ATTRIBUTES
+  # an array of attributes that will be displayed on the model's show page.
+  SHOW_PAGE_ATTRIBUTES = %i[
+    members
+    addresses
+    id
+    michigan_resident
+    created_at
+    updated_at
+    submit_ssn
+    homeless
+    reliable_mail_address
+    need_medical_expense_help_3_months
+    income_unemployment
+    income_pension
+    income_social_security
+    income_retirement
+    income_alimony
+    filing_federal_taxes_next_year
+    self_employed_monthly_income
+    college_loan_interest_expenses
+    child_support_alimony_arrears_expenses
+    phone_number
+    sms_phone_number
+    email
+    sms_consented
+    birthday
+    self_employment_expenses
+    employed_monthly_income
+    anyone_in_college
+    flint_water_crisis
+    anyone_employed
+    everyone_a_citizen
+    anyone_new_mom
+    anyone_self_employed
+    anyone_other_income
+    anyone_insured
+    anyone_disabled
+    anyone_pay_child_support_alimony_arrears
+    anyone_pay_student_loan_interest
+    anyone_caretaker_or_parent
+    consent_to_terms
+    encrypted_last_four_ssn
+    encrypted_last_four_ssn_iv
+    signature
+    signed_at
+    upload_paperwork
+    paperwork
+    office_location
+    mailing_address_same_as_residential_address
+    stable_housing
+    anyone_married
+  ].freeze
+
+  # FORM_ATTRIBUTES
+  # an array of attributes that will be displayed
+  # on the model's form (`new` and `edit`) pages.
+  FORM_ATTRIBUTES = %i[
+    members
+    addresses
+    michigan_resident
+    submit_ssn
+    homeless
+    reliable_mail_address
+    need_medical_expense_help_3_months
+    income_unemployment
+    income_pension
+    income_social_security
+    income_retirement
+    income_alimony
+    filing_federal_taxes_next_year
+    self_employed_monthly_income
+    college_loan_interest_expenses
+    child_support_alimony_arrears_expenses
+    phone_number
+    sms_phone_number
+    email
+    sms_consented
+    birthday
+    self_employment_expenses
+    employed_monthly_income
+    anyone_in_college
+    flint_water_crisis
+    anyone_employed
+    everyone_a_citizen
+    anyone_new_mom
+    anyone_self_employed
+    anyone_other_income
+    anyone_insured
+    anyone_disabled
+    anyone_pay_child_support_alimony_arrears
+    anyone_pay_student_loan_interest
+    anyone_caretaker_or_parent
+    consent_to_terms
+    encrypted_last_four_ssn
+    encrypted_last_four_ssn_iv
+    signature
+    signed_at
+    upload_paperwork
+    paperwork
+    office_location
+    mailing_address_same_as_residential_address
+    stable_housing
+    anyone_married
+  ].freeze
+
+  # Overwrite this method to customize how medicaid applications are displayed
+  # across all pages of the admin dashboard.
+  #
+  # def display_resource(medicaid_application)
+  #   "MedicaidApplication ##{medicaid_application.id}"
+  # end
+end

--- a/app/models/dhs1171_pdf.rb
+++ b/app/models/dhs1171_pdf.rb
@@ -12,10 +12,10 @@ class Dhs1171Pdf
 
   def completed_file
     complete_template_pdf_with_client_data
-    assemble_pdf
+    assemble_complete_application
   ensure
-    filled_in_form.close
-    filled_in_form.unlink
+    filled_in_application.close
+    filled_in_application.unlink
   end
 
   private
@@ -23,15 +23,15 @@ class Dhs1171Pdf
   attr_reader :snap_application
 
   def complete_template_pdf_with_client_data
-    PdfForms.new.fill_form(SOURCE_PDF, filled_in_form.path, client_data)
+    PdfForms.new.fill_form(SOURCE_PDF, filled_in_application.path, client_data)
   end
 
-  def assemble_pdf
+  def assemble_complete_application
     PdfBuilder.new(
-      output_file: complete_form_with_cover_and_documents,
+      output_file: complete_application_with_cover_and_documents,
       file_paths: [
         COVERSHEET_PDF,
-        filled_in_form.path,
+        filled_in_application.path,
         additional_household_member_pages_path,
         additional_employed_pages_path,
         additional_self_employed_pages_path,
@@ -40,13 +40,13 @@ class Dhs1171Pdf
     ).pdf
   end
 
-  def complete_form_with_cover_and_documents
-    @_complete_form_with_cover_and_documents ||=
+  def complete_application_with_cover_and_documents
+    @_complete_application_with_cover_and_documents ||=
       Tempfile.new(["snap_app_with_cover_and_documents", ".pdf"], "tmp/")
   end
 
-  def filled_in_form
-    @_filled_in_form ||= Tempfile.new(["snap_app", ".pdf"], "tmp/")
+  def filled_in_application
+    @_filled_in_application ||= Tempfile.new(["snap_app", ".pdf"], "tmp/")
   end
 
   def additional_household_member_pages_path

--- a/app/models/dhs1426_pdf.rb
+++ b/app/models/dhs1426_pdf.rb
@@ -1,0 +1,81 @@
+class Dhs1426Pdf
+  PDF_DIRECTORY = "lib/pdfs".freeze
+  SOURCE_PDF = "#{PDF_DIRECTORY}/DHS_1426.pdf".freeze
+
+  def initialize(medicaid_application:)
+    @medicaid_application = medicaid_application
+  end
+
+  def completed_file
+    complete_template_pdf_with_client_data
+    assemble_complete_application
+  ensure
+    filled_in_application.close
+    filled_in_application.unlink
+  end
+
+  private
+
+  attr_reader :medicaid_application
+
+  def complete_template_pdf_with_client_data
+    PdfForms.new.fill_form(SOURCE_PDF, filled_in_application.path, client_data)
+  end
+
+  def assemble_complete_application
+    PdfBuilder.new(
+      output_file: complete_application,
+      file_paths: [
+        filled_in_application.path,
+      ].reject(&:blank?).flatten,
+    ).pdf
+  end
+
+  def filled_in_application
+    @_filled_in_application ||= Tempfile.new(["medicaid_app", ".pdf"], "tmp/")
+  end
+
+  def complete_application
+    @_complete_application ||= Tempfile.new(
+      ["medicaid_app_complete", ".pdf"],
+      "tmp/",
+    )
+  end
+
+  def client_data
+    medicaid_application_attributes.
+      merge(member_attributes)
+  end
+
+  def medicaid_application_attributes
+    MedicaidApplicationAttributes.
+      new(medicaid_application: medicaid_application).
+      to_h
+  end
+
+  def member_attributes
+    map_attributes(
+      records: first_two_members,
+      klass: MedicaidApplicationMemberAttributes,
+    )
+  end
+
+  def map_attributes(records:, klass:)
+    records.map do |record|
+      if record[:member].present?
+        klass.new(record).to_h
+      end
+    end.compact.reduce({}, :merge)
+  end
+
+  def application_members
+    @_application_members ||= medicaid_application.members.order(:id)
+  end
+
+  def first_two_members
+    [
+      { member: application_members[0], position: "primary" },
+      { member: application_members[1], position: "second" },
+    ]
+  end
+end

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -54,6 +54,12 @@ class MedicaidApplication < ApplicationRecord
     addresses.where(mailing: true).first || NullAddress.new
   end
 
+  def pdf
+    @pdf ||= Dhs1426Pdf.new(
+      medicaid_application: self,
+    ).completed_file
+  end
+
   private
 
   def unstable_housing?

--- a/app/models/medicaid_application_attributes.rb
+++ b/app/models/medicaid_application_attributes.rb
@@ -1,0 +1,15 @@
+class MedicaidApplicationAttributes
+  def initialize(medicaid_application:)
+    @medicaid_application = medicaid_application
+  end
+
+  def to_h
+    {
+      signature: medicaid_application.signature,
+    }.symbolize_keys
+  end
+
+  private
+
+  attr_reader :medicaid_application
+end

--- a/app/models/medicaid_application_member_attributes.rb
+++ b/app/models/medicaid_application_member_attributes.rb
@@ -1,0 +1,16 @@
+class MedicaidApplicationMemberAttributes
+  def initialize(member:, position:)
+    @member = member
+    @position = position
+  end
+
+  def to_h
+    {
+      "#{position}_member_full_name" => member.display_name,
+    }.symbolize_keys
+  end
+
+  private
+
+  attr_reader :member, :position
+end

--- a/app/views/admin/medicaid_applications/_collection.html.erb
+++ b/app/views/admin/medicaid_applications/_collection.html.erb
@@ -1,0 +1,98 @@
+<%#
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table aria-labelledby="<%= table_title %>">
+  <thead>
+    <tr>
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label
+        cell-label--<%= attr_type.html_class %>
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
+        scope="col"
+        role="columnheader"
+        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
+        <%= link_to(sanitized_order_params.merge(
+          collection_presenter.order_params_for(attr_name)
+        )) do %>
+        <%= t(
+          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+          default: attr_name.to_s,
+        ).titleize %>
+
+            <% if collection_presenter.ordered_by?(attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                <svg aria-hidden="true">
+                  <use xlink:href="#icon-up-caret" />
+                </svg>
+              </span>
+            <% end %>
+          <% end %>
+        </th>
+      <% end %>
+      <% [valid_action?(:edit, collection_presenter.resource_name),
+          valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
+        <th scope="col"></th>
+      <% end %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="js-table-row <%= resource.drive_status if resource.respond_to? :drive_status %>"
+          tabindex="0"
+          <% if valid_action? :show, collection_presenter.resource_name %>
+            <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+          <% end %>
+          >
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <a href="<%= polymorphic_path([namespace, resource]) -%>"
+               class="action-show"
+               >
+              <%= render_field attribute %>
+            </a>
+          </td>
+        <% end %>
+
+        <% if resource.is_a? MedicaidApplication -%>
+          <td><%= link_to("Download", pdf_admin_medicaid_application_path(resource)) %></td>
+        <% end -%>
+
+        <% if valid_action? :edit, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.edit"),
+            [:edit, namespace, resource],
+            class: "action-edit",
+          ) %></td>
+        <% end %>
+
+        <% if valid_action? :destroy, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.destroy"),
+            [namespace, resource],
+            class: "text-color-red",
+            method: :delete,
+            data: { confirm: t("administrate.actions.confirm") }
+          ) %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/medicaid_applications/index.html.erb
+++ b/app/views/admin/medicaid_applications/index.html.erb
@@ -1,0 +1,61 @@
+<%#
+# Index
+
+This view is the template for the index page.
+It is responsible for rendering the search bar, header and pagination.
+It renders the `_table` partial to display details about the resources.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Collection][1].
+  Contains helper methods to help display a table,
+  and knows which attributes should be displayed in the resource’s table.
+- `resources`:
+  An instance of `ActiveRecord::Relation` containing the resources
+  that match the user’s search criteria.
+  By default, these resources are passed to the table partial to be displayed.
+- `search_term`:
+  A string containing the term the user has searched for, if any.
+- `show_search_bar`:
+  A boolean that determines if the search bar should be shown.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<% content_for(:title) do %>
+  <%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <% if show_search_bar %>
+    <%= render(
+      "search",
+      search_term: search_term,
+      resource_name: display_resource_name(page.resource_name)
+    ) %>
+  <% end %>
+
+  <div>
+    <%= link_to(
+      "#{t("administrate.actions.new")} #{page.resource_name.titleize.downcase}",
+      [:new, namespace, page.resource_path],
+      class: "button",
+    ) if valid_action? :new %>
+  </div>
+</header>
+
+<section class="main-content__body main-content__body--flush">
+  <%= render(
+    "collection",
+    collection_presenter: page,
+    resources: resources,
+    table_title: "page-title"
+  ) %>
+
+  <%= paginate resources %>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,9 @@ Rails.application.routes.draw do
       post "resend_email", on: :member
       get "pdf", on: :member
     end
+    resources :medicaid_applications do
+      get "pdf", on: :member
+    end
     resources :exports, only: %i[index show]
     resources :members
     resources :driver_errors, only: %i[index show]

--- a/spec/features/admin_medicaid_applications_dashboard_spec.rb
+++ b/spec/features/admin_medicaid_applications_dashboard_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require_relative "../support/pdf_helper"
+
+RSpec.feature "Admin viewing medicaid applications dashboard", type: :feature do
+  include PdfHelper
+
+  before do
+    user = create(:admin_user)
+    login_as(user)
+  end
+
+  scenario "downloads the 1426 PDF application", javascript: true do
+    application = create(:medicaid_application,
+           members: [
+             create(:member, first_name: "Christa", last_name: "Tester"),
+           ])
+
+    visit admin_root_path
+
+    click_on "Medicaid Applications"
+
+    click_on "Download"
+
+    expect(current_path).to eq(
+      "/admin/medicaid_applications/#{application.id}/pdf",
+    )
+    temp_pdf = write_response_to_temp_file
+    results = filled_in_values(file: temp_pdf)
+    expect(results.values).to include("Christa Tester")
+  end
+end

--- a/spec/models/dhs1171_pdf_spec.rb
+++ b/spec/models/dhs1171_pdf_spec.rb
@@ -1,8 +1,11 @@
 require "rails_helper"
+require_relative "../support/pdf_helper"
 
 RSpec.describe Dhs1171Pdf do
-  describe "#save" do
-    it "saves the client info" do
+  include PdfHelper
+
+  describe "#completed_file" do
+    it "writes application info to file" do
       mailing_address = build(:mailing_address)
       residential_address = build(:address)
       member = create(:member, ssn: "012345678")
@@ -228,17 +231,5 @@ RSpec.describe Dhs1171Pdf do
 
       expect(file).to be_a_kind_of(Tempfile)
     end
-  end
-
-  def filled_in_values(file:)
-    filled_in_fields = pdftk.get_fields(file)
-
-    filled_in_fields.each_with_object({}) do |field, hash|
-      hash[field.name] = field.value
-    end
-  end
-
-  def pdftk
-    @_pdftk ||= PdfForms.new
   end
 end

--- a/spec/models/dhs1426_pdf_spec.rb
+++ b/spec/models/dhs1426_pdf_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+require_relative "../support/pdf_helper"
+
+RSpec.describe Dhs1426Pdf do
+  include PdfHelper
+
+  describe "#completed_file" do
+    it "writes application data to file" do
+      member = create(
+        :member,
+        first_name: "Christa",
+        last_name: "Tester",
+      )
+      medicaid_application = create(
+        :snap_application,
+        members: [member],
+      )
+      expected_client_data = {
+        primary_member_full_name: member.display_name,
+      }
+
+      file = Dhs1426Pdf.new(
+        medicaid_application: medicaid_application,
+      ).completed_file
+
+      result = filled_in_values(file: file.path)
+      expected_client_data.each do |field, expected_data|
+        expect(result[field.to_s].to_s).to eq expected_data.to_s
+      end
+    end
+
+    it "returns the tempfile" do
+      medicaid_application = create(:medicaid_application, :with_member)
+
+      file = Dhs1426Pdf.new(
+        medicaid_application: medicaid_application,
+      ).completed_file
+
+      expect(file).to be_a_kind_of(Tempfile)
+    end
+  end
+end

--- a/spec/models/medicaid_application_attributes_spec.rb
+++ b/spec/models/medicaid_application_attributes_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe MedicaidApplicationAttributes do
+  describe "#to_h" do
+    it "returns a hash of attributes" do
+      medicaid_application = create(
+        :medicaid_application,
+        signature: "Jane Hancock",
+      )
+
+      data = MedicaidApplicationAttributes.new(
+        medicaid_application: medicaid_application,
+      ).to_h
+
+      expect(data).to eq(
+        signature: "Jane Hancock",
+      )
+    end
+  end
+end

--- a/spec/models/medicaid_application_member_attributes_spec.rb
+++ b/spec/models/medicaid_application_member_attributes_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe MedicaidApplicationMemberAttributes do
+  describe "#to_h" do
+    it "returns the member attributes as a hash" do
+      member = create(
+        :member,
+        first_name: "First",
+        last_name: "Last",
+      )
+
+      result = MedicaidApplicationMemberAttributes.new(
+        member: member,
+        position: "primary",
+      ).to_h
+
+      expect(result).to eq(
+        primary_member_full_name: "First Last",
+      )
+    end
+  end
+end

--- a/spec/support/pdf_helper.rb
+++ b/spec/support/pdf_helper.rb
@@ -1,0 +1,19 @@
+module PdfHelper
+  def filled_in_values(file:)
+    filled_in_fields = pdftk.get_fields(file)
+
+    filled_in_fields.each_with_object({}) do |field, hash|
+      hash[field.name] = field.value
+    end
+  end
+
+  def pdftk
+    @_pdftk ||= PdfForms.new
+  end
+
+  def write_response_to_temp_file
+    temp_pdf = Tempfile.new("pdf")
+    temp_pdf << page.source.force_encoding("UTF-8")
+    temp_pdf
+  end
+end


### PR DESCRIPTION
Allows admins to download a 1426 PDF application in the admin dashboard.

Only fills out first name and last name of primary member, and signature.

https://www.pivotaltracker.com/story/show/152726754
[Finishes #152726754]

Signed-off-by: Christa Hartsock <christa@codeforamerica.org>

![screen shot 2017-11-13 at 11 18 46 am](https://user-images.githubusercontent.com/3675092/32744491-796ebb32-c864-11e7-8fef-40498e644389.png)
