### PR TITLE
Add 'Sign Out' link for Admin dashboard

### DIFF
--- a/app/views/admin/application/_navigation.html.erb
+++ b/app/views/admin/application/_navigation.html.erb
@@ -1,0 +1,24 @@
+<%#
+# Navigation
+
+This partial is used to display the navigation in Administrate.
+By default, the navigation contains navigation links
+for all resources in the admin dashboard,
+as defined by the routes in the `admin/` namespace
+%>
+
+<nav class="navigation" role="navigation">
+  <% Administrate::Namespace.new(namespace).resources.each do |resource| %>
+    <%= link_to(
+      display_resource_name(resource),
+      [namespace, resource.path],
+      class: "navigation__link navigation__link--#{nav_link_state(resource)}",
+    ) %>
+  <% end %>
+  <%= link_to(
+    "Sign Out",
+    destroy_admin_user_session_path,
+    method: :delete,
+    class: "navigation__link navigation__link--sign-out",
+  ) %>
+</nav>

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -58,4 +58,14 @@ RSpec.feature "Submit application with minimal information" do
     expect(page).to have_content("Updated At 04/04/2017 at 10:30PM EDT")
     expect(page).to have_content("Signed At 04/04/2017 at 11:30PM EDT")
   end
+
+  scenario "logging out", javascript: true do
+    visit admin_root_path
+
+    click_link "Sign Out"
+
+    visit admin_root_path
+
+    expect(page).to have_content("Log in")
+  end
 end


### PR DESCRIPTION
Accepting some stories about Admin User authentication was difficult, because we don't have an easy way to sign out. To address this, I added a "Sign Out" link to the admin dashboard that destroys the user session upon clicking.

https://www.pivotaltracker.com/story/show/152826538
[Finishes #152826538]

![screen shot 2017-11-13 at 1 41 12 pm](https://user-images.githubusercontent.com/3675092/32750734-6f68b188-c878-11e7-938b-9bd1718f39fd.png)

![screen shot 2017-11-13 at 1 41 17 pm](https://user-images.githubusercontent.com/3675092/32750714-5c2f0e50-c878-11e7-86a9-5d70e308982d.png)

