### PR TITLE
Skip amounts conditionally

### DIFF
--- a/app/controllers/medicaid/amounts_expenses_controller.rb
+++ b/app/controllers/medicaid/amounts_expenses_controller.rb
@@ -43,21 +43,7 @@ module Medicaid
     end
 
     def skip?
-      no_self_employment? &&
-        no_child_support_alimony_arrears? &&
-        no_student_loan_interest?
-    end
-
-    def no_self_employment?
-      !current_application&.anyone_self_employed?
-    end
-
-    def no_child_support_alimony_arrears?
-      !current_application&.anyone_pay_child_support_alimony_arrears?
-    end
-
-    def no_student_loan_interest?
-      !current_application&.anyone_pay_student_loan_interest?
+      current_application.no_expenses?
     end
   end
 end

--- a/app/controllers/medicaid/amounts_overview_controller.rb
+++ b/app/controllers/medicaid/amounts_overview_controller.rb
@@ -1,4 +1,31 @@
 module Medicaid
   class AmountsOverviewController < MedicaidStepsController
+    private
+
+    def skip?
+      no_income? && no_expenses?
+    end
+
+    def no_income?
+      current_application.no_one_with_income?
+    end
+
+    def no_expenses?
+      no_self_employment? &&
+        no_child_support_alimony_arrears? &&
+        no_student_loan_interest?
+    end
+
+    def no_self_employment?
+      !current_application&.anyone_self_employed?
+    end
+
+    def no_child_support_alimony_arrears?
+      !current_application&.anyone_pay_child_support_alimony_arrears?
+    end
+
+    def no_student_loan_interest?
+      !current_application&.anyone_pay_student_loan_interest?
+    end
   end
 end

--- a/app/controllers/medicaid/amounts_overview_controller.rb
+++ b/app/controllers/medicaid/amounts_overview_controller.rb
@@ -3,29 +3,8 @@ module Medicaid
     private
 
     def skip?
-      no_income? && no_expenses?
-    end
-
-    def no_income?
-      current_application.no_one_with_income?
-    end
-
-    def no_expenses?
-      no_self_employment? &&
-        no_child_support_alimony_arrears? &&
-        no_student_loan_interest?
-    end
-
-    def no_self_employment?
-      !current_application&.anyone_self_employed?
-    end
-
-    def no_child_support_alimony_arrears?
-      !current_application&.anyone_pay_child_support_alimony_arrears?
-    end
-
-    def no_student_loan_interest?
-      !current_application&.anyone_pay_student_loan_interest?
+      current_application.no_one_with_income? &&
+        current_application.no_expenses?
     end
   end
 end

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -28,6 +28,12 @@ class MedicaidApplication < ApplicationRecord
       anyone_other_income?
   end
 
+  def no_expenses?
+    no_self_employment? &&
+      no_child_support_alimony_arrears? &&
+      no_student_loan_interest?
+  end
+
   def nobody_married?
     !anyone_married?
   end
@@ -64,5 +70,17 @@ class MedicaidApplication < ApplicationRecord
 
   def unstable_housing?
     !stable_housing?
+  end
+
+  def no_self_employment?
+    !anyone_self_employed?
+  end
+
+  def no_child_support_alimony_arrears?
+    !anyone_pay_child_support_alimony_arrears?
+  end
+
+  def no_student_loan_interest?
+    !anyone_pay_student_loan_interest?
   end
 end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -107,12 +107,6 @@ class Member < ApplicationRecord
     !receiving_income?
   end
 
-  def receiving_income?
-    employed? ||
-      self_employed? ||
-      receives_unemployment_income?
-  end
-
   def primary_member?
     benefit_application.primary_member.id == id
   end
@@ -152,6 +146,12 @@ class Member < ApplicationRecord
   end
 
   private
+
+  def receiving_income?
+    employed? ||
+      self_employed? ||
+      receives_unemployment_income?
+  end
 
   def age
     today = Date.today

--- a/spec/controllers/medicaid/amounts_overview_controller_spec.rb
+++ b/spec/controllers/medicaid/amounts_overview_controller_spec.rb
@@ -4,15 +4,14 @@ require "rails_helper"
 
 RSpec.describe Medicaid::AmountsOverviewController do
   describe "#skip?" do
-    before do
-      medicaid_application = create(:medicaid_application)
-      session[:medicaid_application_id] = medicaid_application.id
-    end
-
     context "receives an income, and has expenses" do
       it "does not skip" do
-        allow(subject).to receive(:no_income?).and_return(false)
-        allow(subject).to receive(:no_expenses?).and_return(false)
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_employed: true,
+          anyone_pay_child_support_alimony_arrears: true,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
 
@@ -22,8 +21,14 @@ RSpec.describe Medicaid::AmountsOverviewController do
 
     context "receives an income, and has no expenses" do
       it "does not skip" do
-        allow(subject).to receive(:no_income?).and_return(false)
-        allow(subject).to receive(:no_expenses?).and_return(true)
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_employed: true,
+          anyone_self_employed: false,
+          anyone_pay_child_support_alimony_arrears: false,
+          anyone_pay_student_loan_interest: false,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
 
@@ -33,8 +38,14 @@ RSpec.describe Medicaid::AmountsOverviewController do
 
     context "has expenses, and no income" do
       it "does not skip" do
-        allow(subject).to receive(:no_expenses?).and_return(false)
-        allow(subject).to receive(:no_income?).and_return(true)
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_employed: false,
+          anyone_self_employed: false,
+          anyone_other_income: false,
+          anyone_pay_child_support_alimony_arrears: true,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
 
@@ -44,8 +55,15 @@ RSpec.describe Medicaid::AmountsOverviewController do
 
     context "no income, no expenses" do
       it "skips to the next page" do
-        allow(subject).to receive(:no_expenses?).and_return(true)
-        allow(subject).to receive(:no_income?).and_return(true)
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_employed: false,
+          anyone_self_employed: false,
+          anyone_other_income: false,
+          anyone_pay_child_support_alimony_arrears: false,
+          anyone_pay_student_loan_interest: false,
+        )
+        session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
 

--- a/spec/controllers/medicaid/amounts_overview_controller_spec.rb
+++ b/spec/controllers/medicaid/amounts_overview_controller_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Medicaid::AmountsOverviewController do
+  describe "#skip?" do
+    before do
+      medicaid_application = create(:medicaid_application)
+      session[:medicaid_application_id] = medicaid_application.id
+    end
+
+    context "receives an income, and has expenses" do
+      it "does not skip" do
+        allow(subject).to receive(:no_income?).and_return(false)
+        allow(subject).to receive(:no_expenses?).and_return(false)
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context "receives an income, and has no expenses" do
+      it "does not skip" do
+        allow(subject).to receive(:no_income?).and_return(false)
+        allow(subject).to receive(:no_expenses?).and_return(true)
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context "has expenses, and no income" do
+      it "does not skip" do
+        allow(subject).to receive(:no_expenses?).and_return(false)
+        allow(subject).to receive(:no_income?).and_return(true)
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+
+    context "no income, no expenses" do
+      it "skips to the next page" do
+        allow(subject).to receive(:no_expenses?).and_return(true)
+        allow(subject).to receive(:no_income?).and_return(true)
+
+        get :edit
+
+        expect(response).to redirect_to(subject.next_path)
+      end
+    end
+  end
+end

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -87,11 +87,6 @@ RSpec.feature "Medicaid app" do
 
       expect(page).to have_content("Do you pay student loan interest?")
       click_on "No"
-
-      expect(page).to have_content(
-        "Okay, thanks! Now describe your income and expenses.",
-      )
-      click_on "Next"
     end
 
     on_pages "Contact Information & Followup" do

--- a/spec/models/medicaid_application_spec.rb
+++ b/spec/models/medicaid_application_spec.rb
@@ -69,4 +69,50 @@ RSpec.describe MedicaidApplication do
       end
     end
   end
+
+  describe "#no_expenses?" do
+    it "returns false if anyone is self employed" do
+      app = create(
+        :medicaid_application,
+        anyone_self_employed: true,
+        anyone_pay_child_support_alimony_arrears: false,
+        anyone_pay_student_loan_interest: false,
+      )
+
+      expect(app.no_expenses?).to eq(false)
+    end
+
+    it "returns false if anyone pays child support" do
+      app = create(
+        :medicaid_application,
+        anyone_self_employed: false,
+        anyone_pay_child_support_alimony_arrears: true,
+        anyone_pay_student_loan_interest: false,
+      )
+
+      expect(app.no_expenses?).to eq(false)
+    end
+
+    it "returns false if anyone pays student loan interest" do
+      app = create(
+        :medicaid_application,
+        anyone_employed: false,
+        anyone_pay_child_support_alimony_arrears: false,
+        anyone_pay_student_loan_interest: true,
+      )
+
+      expect(app.no_expenses?).to eq(false)
+    end
+
+    it "returns true if no expenses" do
+      app = create(
+        :medicaid_application,
+        anyone_self_employed: false,
+        anyone_pay_child_support_alimony_arrears: false,
+        anyone_pay_student_loan_interest: false,
+      )
+
+      expect(app.no_expenses?).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
Conditionally skip expenses in the AmountsExpenses step

Refactored queries used for skip logic into the medicaid_application

@jayroh We decided not to break this out into a SkipHelper, instead we put it on the model, which solved the code duplication problem. Happy to discuss adding a skiphelper if you think it would help what we have here! Both @bengolder and I are happy with this commit but we'll let you approve the merge.