### PR TITLE
BUGFIX: Show addresses correctly in 1426 PDF

### DIFF
--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -51,9 +51,7 @@ class MedicaidApplication < ApplicationRecord
   end
 
   def residential_address
-    return NullAddress.new if unstable_housing?
-    return mailing_address if mailing_address_same_as_residential_address?
-    addresses.where.not(mailing: true).first || NullAddress.new
+    addresses.where(mailing: false).first || NullAddress.new
   end
 
   def mailing_address

--- a/spec/controllers/mailing_address_controller_spec.rb
+++ b/spec/controllers/mailing_address_controller_spec.rb
@@ -74,11 +74,10 @@ RSpec.describe MailingAddressController, type: :controller do
 
   def address
     build(
-      :address,
+      :mailing_address,
       street_address: "123 Fake St",
       city: "Springfield",
       zip: "12345",
-      mailing: true,
     )
   end
 end

--- a/spec/controllers/medicaid/contact_home_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_home_address_controller_spec.rb
@@ -27,11 +27,10 @@ RSpec.describe Medicaid::ContactHomeAddressController, type: :controller do
           stable_housing: true,
         )
         create(
-          :address,
+          :residential_address,
           street_address: "I live here",
           city: "Hometown",
           zip: "54321",
-          mailing: false,
           benefit_application: medicaid_application,
         )
         session[:medicaid_application_id] = medicaid_application.id
@@ -148,7 +147,7 @@ RSpec.describe Medicaid::ContactHomeAddressController, type: :controller do
             :medicaid_application,
             stable_housing: true,
           )
-          create(:address,
+          create(:residential_address,
                  street_address: "456 Fake Street",
                  city: "Jackson",
                  zip: "55555",

--- a/spec/controllers/medicaid/contact_mailing_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_mailing_address_controller_spec.rb
@@ -86,15 +86,12 @@ RSpec.describe Medicaid::ContactMailingAddressController, type: :controller do
       end
 
       it "pre-populates the data properly if mailing address present" do
-        medicaid_application = create(
-          :medicaid_application,
-        )
+        medicaid_application = create(:medicaid_application)
         create(
-          :address,
-          street_address: "I live here",
+          :mailing_address,
+          street_address: "I receive mail here",
           city: "Hometown",
           zip: "54321",
-          mailing: true,
           benefit_application: medicaid_application,
         )
         session[:medicaid_application_id] = medicaid_application.id
@@ -102,7 +99,7 @@ RSpec.describe Medicaid::ContactMailingAddressController, type: :controller do
         get :edit
         step = assigns(:step)
 
-        expect(step.street_address).to eq("I live here")
+        expect(step.street_address).to eq("I receive mail here")
         expect(step.city).to eq("Hometown")
         expect(step.zip).to eq("54321")
       end
@@ -158,7 +155,7 @@ RSpec.describe Medicaid::ContactMailingAddressController, type: :controller do
             :medicaid_application,
             stable_housing: true,
           )
-          create(:address,
+          create(:residential_address,
                  street_address: "456 Fake Street",
                  city: "Jackson",
                  zip: "55555",

--- a/spec/controllers/residential_address_controller_spec.rb
+++ b/spec/controllers/residential_address_controller_spec.rb
@@ -89,11 +89,10 @@ RSpec.describe ResidentialAddressController, type: :controller do
 
   def address
     build(
-      :address,
+      :residential_address,
       street_address: "I live here",
       city: "Hometown",
       zip: "54321",
-      mailing: false,
     )
   end
 end

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -1,14 +1,19 @@
 FactoryBot.define do
-  factory :address do
+  factory :mailing_address, class: Address do
+    mailing true
     street_address "123 Main St."
     city "Flint"
     zip "12345"
     county "Genesee"
     state "MI"
-    mailing false
+  end
 
-    factory :mailing_address do
-      mailing true
-    end
+  factory :residential_address, class: Address do
+    mailing false
+    street_address "123 Main St."
+    city "Flint"
+    zip "12345"
+    county "Genesee"
+    state "MI"
   end
 end

--- a/spec/models/dhs1171_pdf_spec.rb
+++ b/spec/models/dhs1171_pdf_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Dhs1171Pdf do
   describe "#completed_file" do
     it "writes application info to file" do
       mailing_address = build(:mailing_address)
-      residential_address = build(:address)
+      residential_address = build(:residential_address)
       member = create(:member, ssn: "012345678")
       snap_application = create(
         :snap_application,

--- a/spec/models/medicaid_application_attributes_spec.rb
+++ b/spec/models/medicaid_application_attributes_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe MedicaidApplicationAttributes do
     it "returns a hash of attributes" do
       mailing_address = build(:mailing_address)
       residential_address = build(
-        :address,
+        :residential_address,
         street_address: "456 I Live Here Ave",
         city: "Other",
         zip: "54321",

--- a/spec/models/medicaid_application_spec.rb
+++ b/spec/models/medicaid_application_spec.rb
@@ -2,49 +2,24 @@ require "rails_helper"
 
 RSpec.describe MedicaidApplication do
   describe "#residential_address" do
-    context "mailing_address_same_as_residential_address is true" do
-      it "returns mailing address" do
-        app = create(:medicaid_application,
-                     stable_housing: true,
-                     mailing_address_same_as_residential_address: true)
-        create(:address, benefit_application: app)
-        mailing_address = create(:mailing_address, benefit_application: app)
+    context "residential address not present" do
+      it "returns NullAddress" do
+        app = create(:medicaid_application)
+        create(:mailing_address, benefit_application: app)
 
-        expect(app.residential_address).to eq mailing_address
-      end
-    end
-
-    context "mailing_address_same_as_residential_address is false" do
-      context "residential address not present" do
-        it "returns NullAddress" do
-          app = create(:medicaid_application,
-                       stable_housing: true,
-                       mailing_address_same_as_residential_address: false)
-          create(:mailing_address, benefit_application: app)
-
-          expect(app.residential_address).to be_a NullAddress
-        end
+        expect(app.residential_address).to be_a NullAddress
       end
 
       context "residential address present" do
-        context "housing is stable" do
-          it "returns residential address" do
-            app = create(:medicaid_application, stable_housing: true)
-            create(:mailing_address, benefit_application: app)
-            residential_address = create(:address, benefit_application: app)
+        it "returns residential address" do
+          app = create(:medicaid_application)
+          create(:mailing_address, benefit_application: app)
+          residential_address = create(
+            :residential_address,
+            benefit_application: app,
+          )
 
-            expect(app.residential_address).to eq residential_address
-          end
-        end
-
-        context "housing is not stable" do
-          it "returns NullAddress" do
-            app = create(:medicaid_application, stable_housing: false)
-            create(:mailing_address, benefit_application: app)
-            _residential_address = create(:address, benefit_application: app)
-
-            expect(app.residential_address.class).to eq NullAddress
-          end
+          expect(app.residential_address).to eq residential_address
         end
       end
     end
@@ -63,7 +38,7 @@ RSpec.describe MedicaidApplication do
     context "mailing address does not exist" do
       it "returns NullAddress" do
         app = create(:medicaid_application)
-        create(:address, benefit_application: app)
+        create(:residential_address, benefit_application: app)
 
         expect(app.mailing_address.class).to eq(NullAddress)
       end

--- a/spec/models/snap_application_attributes_spec.rb
+++ b/spec/models/snap_application_attributes_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe SnapApplicationAttributes do
   describe "#to_h" do
     it "returns a hash of attributes" do
       mailing_address = build(:mailing_address)
-      residential_address = build(:address)
+      residential_address = build(:residential_address)
       snap_application = create(
         :snap_application,
         :with_member,

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe SnapApplication do
       it "returns mailing address" do
         app = create(:snap_application,
                       mailing_address_same_as_residential_address: true)
-        create(:address, benefit_application: app)
+        create(:residential_address, benefit_application: app)
         mailing_address = create(:mailing_address, benefit_application: app)
 
         expect(app.residential_address).to eq mailing_address
@@ -122,7 +122,8 @@ RSpec.describe SnapApplication do
           it "returns residential address" do
             app = create(:snap_application)
             create(:mailing_address, benefit_application: app)
-            residential_address = create(:address, benefit_application: app)
+            residential_address =
+              create(:residential_address, benefit_application: app)
 
             expect(app.residential_address).to eq residential_address
           end
@@ -132,7 +133,8 @@ RSpec.describe SnapApplication do
           it "returns NullAddress" do
             app = create(:snap_application, stable_housing: false)
             create(:mailing_address, benefit_application: app)
-            _residential_address = create(:address, benefit_application: app)
+            _residential_address =
+              create(:residential_address, benefit_application: app)
 
             expect(app.residential_address.class).to eq NullAddress
           end
@@ -154,7 +156,7 @@ RSpec.describe SnapApplication do
     context "mailing address does not exist" do
       it "returns NullAddress" do
         app = create(:snap_application)
-        create(:address, benefit_application: app)
+        create(:residential_address, benefit_application: app)
 
         expect(app.mailing_address.class).to eq(NullAddress)
       end


### PR DESCRIPTION
* Explanation:

The PDF for the Medicaid application (1426) displays a home address and
a mailing address if that address is different.

Previously, we were not rendering these properly because our application
collects residential address and then mailing only IF they are
different, but our ruby logic returned mailing address and residential
address only IF they are different. This makes sense for how the SNAP
flow works, but resulted in not returning correct data for Medicaid.

To clarify the behavior in tests, we removed the `address` factory so
that only `residential_address` or `mailing_address` factories can be
used.

* [Finishes #152564632]

Signed-off-by: Jessie Young <jessie@cylinder.work>