### PR TITLE
Update release script to show diff of env var keys

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -26,7 +26,7 @@ fi
 
 echo "Checking for buildpack changes between staging and production."
 diff <(heroku buildpacks -r staging) <(heroku buildpacks -r production) && echo ""
-read -p "Are these the same (ignoring order)? " -n 1 -r
+read -p "Are these the same (ignoring order)? (y/N)" -n 1 -r
 echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]];then
   echo "Great!"
@@ -36,8 +36,11 @@ else
 fi
 
 echo "Diffing ENV variables between staging and production."
-diff <(heroku config -r staging) <(heroku config -r production) && echo ""
-read -p "Are these config variables the same (ignoring their value) (y/N) " -n 1 -r
+staging_env=$(heroku config -r staging --json | jq . -S | jq 'keys')
+production_env=$(heroku config -r production --json | jq . -S | jq 'keys')
+echo ${staging_env[@]} ${production_env[@]} | tr ' ' '\n' | sort | uniq -u
+echo "Any keys listed above exist on one env but not the other."
+read -p "Are you okay with these differences? (y/N)" -n 1 -r
 echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]; then
   echo "Great!"
@@ -52,7 +55,10 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
   heroku pipelines:promote -a michigan-benefits-staging
   heroku run bin/rails one_offs:run_all -a michigan-benefits-production
   heroku ps:restart -a michigan-benefits-production
+  echo "Success! Application deployed to Production!"
+  echo "Please do some testing on production! (use zip 12345 to send a fake fax)"
+else
+  echo "Okay, I won't deploy. Thank you for being thoughtful and careful!"
+  exit 1;
 fi
 
-echo "Success! Application deployed to Production!"
-echo "Please do some testing on production! (use zip 12345 to send a fake fax)"

--- a/bin/release
+++ b/bin/release
@@ -36,8 +36,8 @@ else
 fi
 
 echo "Diffing ENV variables between staging and production."
-staging_env=$(heroku config -r staging --json | jq . -S | jq 'keys')
-production_env=$(heroku config -r production --json | jq . -S | jq 'keys')
+staging_env=$(heroku config -r staging --json | jq -S 'keys')
+production_env=$(heroku config -r production --json | jq -S 'keys')
 echo ${staging_env[@]} ${production_env[@]} | tr ' ' '\n' | sort | uniq -u
 echo "Any keys listed above exist on one env but not the other."
 read -p "Are you okay with these differences? (y/N)" -n 1 -r

--- a/bin/setup
+++ b/bin/setup
@@ -54,6 +54,17 @@ chdir APP_ROOT do
     end
   end
 
+  step "Installing jq, a JSON CLI used by our release script" do
+    # use --version flag because running `chromedriver` will start
+    # chromedriver, which stops the script indefinitely if already installed.
+    if cli_installed?("jq")
+      puts "jq already installed."
+    else
+      system!("brew install jq")
+    end
+  end
+
+
   step "Installing bundler and gem dependencies" do
     system!("gem install bundler --conservative")
     system("bundle check") || system!("bundle install")


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/152831563

- Edits `bin/release` to show a diff of keys between stage and production.
- Does _not_ show values of env vars
- Uses `jq` CLI to separate out the keys, then bash to diff arrays of keys
- Adds `brew install jq` install to `bin/setup`
- Edits last step of `bin/release` which falsely said it was deploying if you answerered `"N"` to the final question.