### PR TITLE
Allow 2-factor authentication for admins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
     - db/schema.rb
     - bin/stubs/*
     - bin/*
+    - config/initializers/*
 
 Naming/AccessorMethodName:
   Description: Check the naming of accessor methods for get_/set_.

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,9 @@ gem "capybara"
 gem "delayed_job_active_record"
 gem "delayed_job_web"
 gem "devise"
+gem "devise-otp",
+  git: "https://github.com/pynixwang/devise-otp",
+  ref: "a181217a2d436de7ebb9a278bcb326bbddefa514"
 gem "faraday"
 gem "good_migrations"
 gem "high_voltage"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,16 @@ GIT
   specs:
     sfax (0.1.0)
 
+GIT
+  remote: https://github.com/pynixwang/devise-otp
+  revision: a181217a2d436de7ebb9a278bcb326bbddefa514
+  ref: a181217a2d436de7ebb9a278bcb326bbddefa514
+  specs:
+    devise-otp (0.2.4)
+      devise (>= 3.1.0)
+      rails (>= 3.2.6)
+      rotp (>= 2.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -288,6 +298,7 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rotp (3.3.0)
     rspec-core (3.6.0)
       rspec-support (~> 3.6.0)
     rspec-expectations (3.6.0)
@@ -420,6 +431,7 @@ DEPENDENCIES
   delayed_job_active_record
   delayed_job_web
   devise
+  devise-otp!
   dotenv-rails
   factory_bot_rails
   faraday
@@ -465,4 +477,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.0

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,7 @@
 // = require jquery
 // = require jquery_ujs
 // = require handlebars
+// = require devise-otp
 // = require_tree .
 
 var textWell = (function () {

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -5,5 +5,6 @@ class AdminUser < ApplicationRecord
     :rememberable,
     :trackable,
     :validatable,
+    :otp_authenticatable,
   )
 end

--- a/app/views/admin/application/_navigation.html.erb
+++ b/app/views/admin/application/_navigation.html.erb
@@ -21,4 +21,9 @@ as defined by the routes in the `admin/` namespace
     method: :delete,
     class: "navigation__link navigation__link--sign-out",
   ) %>
+  <%= link_to(
+    "2FA Setup",
+    admin_user_otp_token_path,
+    class: "navigation__link navigation__link--sign-out",
+  ) %>
 </nav>

--- a/app/views/devise_otp/tokens/show.html.erb
+++ b/app/views/devise_otp/tokens/show.html.erb
@@ -1,0 +1,24 @@
+<h2><%= t "title", { scope: "devise.otp.tokens" } %></h2>
+<p><%= t "explain", { scope: "devise.otp.tokens" } %></p>
+
+<%= form_for resource, as: resource_name, url: [resource_name, :otp_token], html: { method: :put } do |f| %>
+  <%= devise_error_messages! %>
+
+  <h3><%= t "enable_request", { scope: "devise.otp.tokens" } %></h3>
+
+  <p>
+    <%= f.label :otp_enabled, t("status", { scope: "devise.otp.tokens" }) %>
+    <br />
+    <%= f.check_box :otp_enabled %>
+  </p>
+
+  <p>
+    <%= f.submit I18n.t("submit", {:scope => "devise.otp.tokens"}) %>
+    <%= link_to "Back to Admin", admin_root_path %>
+  </p>
+<% end %>
+
+<%- if resource.otp_enabled? %>
+  <%= render partial: "token_secret" if resource.otp_enabled? %>
+  <%= render partial: "trusted_devices" if trusted_devices_enabled? %>
+<% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,4 +12,34 @@ Devise.setup do |config|
   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
   config.reset_password_within = 6.hours
   config.sign_out_via = :delete
+
+  # ==> Devise OTP Extension
+  # Configure OTP extension for devise
+
+  # OTP is mandatory, users are going to be asked to
+  # enroll OTP the next time they sign in, before they can successfully complete the session establishment.
+  # This is the global value, can also be set on each user.
+  config.otp_mandatory = !Rails.env.test?
+
+  # Drift: a window which provides allowance for drift between a user's token device clock
+  # (and therefore their OTP tokens) and the authentication server's clock.
+  # Expressed in minutes centered at the current time. (Note: it's a number, *NOT* 3.minutes )
+  # config.otp_drift_window = 3
+
+  # Users that have logged in longer than this time ago, are going to be asked their password
+  # (and an OTP challenge, if enabled) before they can see or change their otp informations.
+  # config.otp_credentials_refresh = 15.minutes
+
+  # Users are given a list of one-time recovery tokens, for emergency access
+  # set to false to disable giving recovery tokens.
+  # config.otp_recovery_tokens = 10
+
+  # The user is allowed to set his browser as "trusted", no more OTP challenges will be
+  # asked for that browser, for a limited time.
+  # set to false to disable setting the browser as trusted
+  # config.otp_trust_persistence = 1.month
+
+  # The name of the token issuer, to be added to the provisioning
+  # url. Display will vary based on token application. (defaults to the Rails application class)
+  # config.otp_issuer = 'my_application'
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -2,6 +2,9 @@
 
 en:
   devise:
+    credentials:
+      admin_user:
+        signed_in: "Signed in successfully."
     confirmations:
       confirmed: "Your email address has been successfully confirmed."
       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."

--- a/config/locales/devise.otp.en.yml
+++ b/config/locales/devise.otp.en.yml
@@ -1,0 +1,65 @@
+en:
+  devise:
+    otp:
+      submit_token:
+        title: 'Check Token'
+        explain: "You're getting this because you enabled two-factors authentication on your account"
+        prompt: 'Please enter your two-factors authentication token:'
+        recovery_prompt: 'Please enter your recovery code:'
+        submit: 'Submit Token'
+        recovery_link: "I don't have my device, I want to use a recovery code"
+
+      credentials:
+        token_invalid: 'The token you provided was invalid.'
+        token_blank: 'You need to type in the token you generated with your device.'
+        need_to_refresh_credentials: 'We need to check your credentials before you can change these settings.'
+        valid_refresh: 'Thank you, your credentials were accepted.'
+        invalid_refresh: 'Sorry, you provided the wrong credentials.'
+
+      credentials_refresh:
+        title: 'Please enter your password again.'
+        explain: 'In order to ensure this is  safe, please enter your password again.'
+        go_on: 'Continue...'
+        identity: 'Identity:'
+        token: 'Your two-factor authentication token'
+
+      token_secret:
+        title: 'Your token secret'
+        explain: 'Take a photo of this QR code with your mobile'
+        manual_provisioning: 'Manual provisioning code'
+        reset_otp: 'Reset your Two Factors Authentication status'
+        reset_explain: 'This will reset your credentials, and disable two-factors authentication.'
+        reset_explain_warn: 'You will need to enroll your mobile device again.'
+
+      tokens:
+        title: 'Two-factors Authentication:'
+        explain: 'Two factors authentication adds adds an additional layer of security to your account. When logging in you will be asked for a code that you can generate on a physical device, like your phone.'
+        enable_request: 'Would you like to enable Two Factors Authenticator?'
+
+        status: 'Enable Two-Factors Authentication.'
+        submit: 'Continue...'
+
+        successfully_updated: 'Your two-factor authentication settings have been updated.'
+        successfully_reset_creds: 'Your two-factor credentials has been reset.'
+        successfully_set_persistence: 'Your device is now trusted.'
+        successfully_cleared_persistence: 'Your device has been removed from the list of trusted devices.'
+        successfully_reset_persistence: 'Your list of trusted devices has been cleared.'
+
+        need_to_refresh_credentials: 'We need to check your credentials before you can change these settings.'
+
+        recovery:
+          title: 'Your Emergency Recovery Codes'
+          explain: 'Take note or print these recovery codes. The will allow you to log back in in case your token device is lost, stolen, or unavailable.'
+          sequence: 'Sequence'
+          code: 'Recovery Code'
+          codes_list: 'Here is the list of your recovery codes'
+          download_codes: 'Download recovery codes'
+
+      trusted_devices:
+        title: 'Trusted Browsers'
+        explain: 'If you set your browser as trusted, you will not be asked to perform a 2-factors authentication when logging in from that browser, for a time of one month.'
+        device_trusted: 'Your browser is trusted.'
+        device_not_trusted: 'Your browser is not trusted.'
+        trust_remove: 'Remove this device from the list of trusted browsers'
+        trust_add: 'Trust this browser'
+        trust_clear: 'Clear the list of trusted browser'

--- a/db/migrate/20171114160332_devise_otp_add_to_admin_users.rb
+++ b/db/migrate/20171114160332_devise_otp_add_to_admin_users.rb
@@ -1,0 +1,32 @@
+class DeviseOtpAddToAdminUsers < ActiveRecord::Migration[5.1]
+  def up
+    safety_assured do
+      add_column :admin_users, :otp_auth_secret, :string
+      add_column :admin_users, :otp_recovery_secret, :string
+      add_column :admin_users, :otp_enabled, :boolean, default: false, null: false
+      add_column :admin_users, :otp_mandatory, :boolean, default: false, null: false
+      add_column :admin_users, :otp_enabled_on, :datetime
+      add_column :admin_users, :otp_failed_attempts, :integer, default: 0, null: false
+      add_column :admin_users, :otp_recovery_counter, :integer, default: 0, null: false
+      add_column :admin_users, :otp_persistence_seed, :string
+      add_column :admin_users, :otp_session_challenge, :string
+      add_column :admin_users, :otp_challenge_expires, :datetime
+
+      add_index :admin_users, :otp_session_challenge, unique: true
+      add_index :admin_users, :otp_challenge_expires
+    end
+  end
+
+  def down
+    remove_column :admin_users, :otp_auth_secret
+    remove_column :admin_users, :otp_recovery_secret
+    remove_column :admin_users, :otp_enabled
+    remove_column :admin_users, :otp_mandatory
+    remove_column :admin_users, :otp_enabled_on
+    remove_column :admin_users, :otp_session_challenge
+    remove_column :admin_users, :otp_challenge_expires
+    remove_column :admin_users, :otp_failed_attempts
+    remove_column :admin_users, :otp_recovery_counter
+    remove_column :admin_users, :otp_persistence_seed
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -36,12 +36,24 @@ ActiveRecord::Schema.define(version: 20171115005618) do
     t.string "encrypted_password", default: "", null: false
     t.datetime "last_sign_in_at"
     t.inet "last_sign_in_ip"
+    t.string "otp_auth_secret"
+    t.datetime "otp_challenge_expires"
+    t.boolean "otp_enabled", default: false, null: false
+    t.datetime "otp_enabled_on"
+    t.integer "otp_failed_attempts", default: 0, null: false
+    t.boolean "otp_mandatory", default: false, null: false
+    t.string "otp_persistence_seed"
+    t.integer "otp_recovery_counter", default: 0, null: false
+    t.string "otp_recovery_secret"
+    t.string "otp_session_challenge"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
     t.string "reset_password_token"
     t.integer "sign_in_count", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
+    t.index ["otp_challenge_expires"], name: "index_admin_users_on_otp_challenge_expires"
+    t.index ["otp_session_challenge"], name: "index_admin_users_on_otp_session_challenge", unique: true
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 

--- a/spec/features/admin_user_delayed_job_spec.rb
+++ b/spec/features/admin_user_delayed_job_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Admin user access Delayed Job web" do
   end
 
   context "admin signs in" do
-    scenario "ends up on Delayed Job Web page" do
+    scenario "sees successfull sign-in message" do
       create(:admin_user, email: "test@example.com", password: "password")
       visit "/delayed_job"
 
@@ -20,8 +20,7 @@ RSpec.feature "Admin user access Delayed Job web" do
       fill_in "Password", with: "password"
       click_on "Log in"
 
-      expect(page).to have_content "The list below shows an overview "\
-        "of the jobs in the delayed_job queue"
+      expect(page).to have_content("Signed in successfully")
     end
   end
 end

--- a/spec/features/admin_user_login_spec.rb
+++ b/spec/features/admin_user_login_spec.rb
@@ -5,12 +5,11 @@ RSpec.feature "Admin user login" do
     admin_user = create(:admin_user)
 
     visit admin_root_path
-    expect(current_path).to eq "/admin_users/sign_in"
-
     fill_in "Email", with: admin_user.email
     fill_in "Password", with: admin_user.password
     click_on "Log in"
 
-    expect(current_path).to eq admin_root_path
+    expect(current_path).to eq "/"
+    expect(page).to have_content("Signed in successfully")
   end
 end


### PR DESCRIPTION
[Finishes #152368004]

Using a fork of the `devise-otp` gem here:

  https://github.com/pynixwang/devise-otp

... we are able to integrate with Google Authenticator to add an added
layer of security for admins logging into the app.

After signing in, as usual, and heading to `/admin` you can see `2FA`
link in the left navigation where you can enable it and scan a QR code
with the Google Authenticator app:

* https://itunes.apple.com/us/app/google-authenticator/id388497605?mt=8
* https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2&hl=en

Once enabled, every subsequent sign-in will require that your 2FA code
is provided after the usual email and password step.