### PR TITLE
Add "Welcome" breather/intro page

### DIFF
--- a/app/controllers/medicaid/welcome_controller.rb
+++ b/app/controllers/medicaid/welcome_controller.rb
@@ -1,0 +1,17 @@
+module Medicaid
+  class WelcomeController < MedicaidStepsController
+    def step_class
+      NullStep
+    end
+
+    private
+
+    def current_or_new_medicaid_application
+      current_application || MedicaidApplication.new
+    end
+
+    def ensure_application_present
+      true
+    end
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,6 +1,8 @@
 class StaticPagesController < ApplicationController
   before_action :clear_session
 
+  helper_method :step_path
+
   def index; end
 
   def union; end
@@ -8,6 +10,10 @@ class StaticPagesController < ApplicationController
   def clio; end
 
   def dual_index; end
+
+  def step_path(*args)
+    super.gsub("%2F", "/")
+  end
 
   private
 

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -2,6 +2,7 @@ module Medicaid
   class StepNavigation
     ALL = {
       "Introduction" => [
+        Medicaid::WelcomeController,
         Medicaid::IntroLocationController,
         Medicaid::IntroLocationHelpController,
         Medicaid::IntroNameController,

--- a/app/views/medicaid/welcome/edit.html.erb
+++ b/app/views/medicaid/welcome/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :header_title, "Introduction" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="illustration illustration--hello"></div>
+    <div class="pre-title">We're here to help.</div>
+    <div class="form-card__title">Welcome to the Medicaid application</div>
+  </header>
+
+  <footer class="form-card__button_right">
+    <%= link_to next_path, class: "button button--nav  button--cta button--full-width" do %>
+      Next
+    <% end %>
+  </footer>
+</div>

--- a/app/views/static_pages/dual_index.html.erb
+++ b/app/views/static_pages/dual_index.html.erb
@@ -18,7 +18,7 @@ end %>
       Apply for FAP
     <% end %>
 
-    <%= link_to "steps/medicaid/intro-location", class: "button button--cta button--fully-width" do %>
+    <%= link_to step_path(Medicaid::StepNavigation.first), class: "button button--cta button--fully-width" do %>
       Apply for Medicaid
     <% end %>
   </div>

--- a/spec/features/medicaid_address_flow_spec.rb
+++ b/spec/features/medicaid_address_flow_spec.rb
@@ -9,7 +9,8 @@ RSpec.feature "medicaid address flows" do
     end
 
     on_pages "Introduction" do
-      expect(page).to have_content("Medicaid Application")
+      expect(page).to have_content("Welcome to the Medicaid application")
+      click_on "Next"
 
       click_on "Yes"
 
@@ -41,7 +42,8 @@ RSpec.feature "medicaid address flows" do
     end
 
     on_pages "Introduction" do
-      expect(page).to have_content("Medicaid Application")
+      expect(page).to have_content("Welcome to the Medicaid application")
+      click_on "Next"
 
       click_on "Yes"
 
@@ -83,6 +85,9 @@ RSpec.feature "medicaid address flows" do
     end
 
     on_pages "Introduction" do
+      expect(page).to have_content("Welcome to the Medicaid application")
+      click_on "Next"
+
       expect(page).to have_content(
         "Before we get started, do you currently reside in Michigan?",
       )

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -9,6 +9,9 @@ RSpec.feature "Medicaid app" do
     end
 
     on_pages "Introduction" do
+      expect(page).to have_content("Welcome to the Medicaid application")
+      click_on "Next"
+
       click_on "Yes"
 
       fill_in "What is your first name?", with: "Jessie"

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -9,7 +9,8 @@ RSpec.feature "Medicaid app" do
     end
 
     on_pages "Introduction" do
-      expect(page).to have_content("Medicaid Application")
+      expect(page).to have_content("Welcome to the Medicaid application")
+      click_on "Next"
 
       click_on "Yes"
 

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -8,33 +8,26 @@ RSpec.feature "Medicaid app" do
       click_on "Apply for Medicaid"
     end
 
-    on_page "Introduction" do
-      click_on "Yes"
-    end
+    on_pages "Introduction" do
+      expect(page).to have_content("Welcome to the Medicaid application")
+      click_on "Next"
 
-    on_page "Introduction" do
+      click_on "Yes"
+
       fill_in "What is your first name?", with: "Jessie"
       fill_in "What is your last name?", with: "Tester"
       select_radio(question: "What is your gender?", answer: "Female")
       click_on "Next"
-    end
 
-    on_page "Introduction" do
       click_on "Add a member"
-    end
 
-    on_page "Introduction" do
       fill_in "What is their first name?", with: "Christa"
       fill_in "What is their last name?", with: "Tester"
       select_radio(question: "What is their gender?", answer: "Female")
       click_on "Next"
-    end
 
-    on_page "Introduction" do
       click_on "Add a member"
-    end
 
-    on_page "Introduction" do
       fill_in "What is their first name?", with: "Joel"
       fill_in "What is their last name?", with: "Tester"
       select_radio(question: "What is their gender?", answer: "Male")


### PR DESCRIPTION
[Finishes #152654927]

Before a client starts filling out the application we provide them with a quick "Hi!".

This commit adds that page _and_:

    * Changes the hard-coded link path in dual-index homepage to use the
      step_path helper (which is fixed to not URLencode `/`s).
    * Multiple members feature spec updated to match 2 other features. IE:
      one `on_pages` assertion instead of many `on_page`.
