### PR TITLE
Add focus styles

### DIFF
--- a/app/assets/stylesheets/atoms/_buttons.scss
+++ b/app/assets/stylesheets/atoms/_buttons.scss
@@ -23,7 +23,7 @@
     background-color: shade($button-color, 15%);
   }
   &:focus {
-    outline: 2px solid tint($button-color, 50%);
+    outline: $form-focus;
   }
 }
 
@@ -41,7 +41,6 @@
   border-color: $button-cta-border-color;
   border-bottom-color: shade($button-cta-color, 15%);
 
-  &:focus,
   &:hover {
     background-color: tint($button-cta-color, 20%);
     color: #FFFFFF;

--- a/app/assets/stylesheets/atoms/_form-elements.scss
+++ b/app/assets/stylesheets/atoms/_form-elements.scss
@@ -1,3 +1,7 @@
+:focus {
+  outline: 3px solid $form-color-border-focus;
+}
+
 fieldset {
   border: 0;
   padding: 0;
@@ -150,7 +154,7 @@ label {
   margin-bottom: .5em;
 
   &:focus {
-    border-color: $color-teal;
+    border-color: $form-color-border-focus;
   }
 }
 

--- a/app/assets/stylesheets/atoms/_variables.scss
+++ b/app/assets/stylesheets/atoms/_variables.scss
@@ -83,7 +83,8 @@ $width-form-searchbar:  30em;
 
 // Form Colors
 $form-color-border: $color-dark-grey;
-$form-color-border-focus:  $color-dark-sky;
+$form-color-border-focus:  $color-orange;
+$form-focus: 3px solid $form-color-border-focus;
 
 
 // Border Colors


### PR DESCRIPTION
* Add focus styles to allow for clear "keyboard-only" navigation
* https://trello.com/c/tsKFB0F4/126-add-consistent-obvious-focus-pseudo-selector-style-for-all-interactive-elements-buttons-links-inputs-radios-etc

![keyboard-only](https://user-images.githubusercontent.com/7483074/32854591-4ecbf20c-c9fc-11e7-88a7-a61d3d120800.gif)
