### PR TITLE
Display SSN errors consistently

### DIFF
--- a/app/views/medicaid/contact_social_security/edit.html.erb
+++ b/app/views/medicaid/contact_social_security/edit.html.erb
@@ -6,39 +6,50 @@
   </header>
 
   <div class="form-card__content">
-    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <% if single_member_household? %>
-        <%= f.fields_for('members[]', current_application.primary_member) do |ff| %>
-          <%= ff.mb_input_field :ssn,
-            "Social Security Number",
-            type: :tel,
-            options: { maxlength: 9 },
-            notes: ["If you don’t know it you can skip this"],
-            append_html: "<p class='text--secure'><i class='illustration illustration--safety'></i>Social security numbers help ensure you receive the correct benefits. MDHHS maintains strict security guidelines to protect the identities of our residents.</p>" %>
+    <%= form_for @step,
+      as: :step,
+      builder: MbFormBuilder,
+      url: current_path,
+      method: :put do |f| %>
 
-          <%= ff.mb_date_select :birthday, "What is your birthday?", { options: { start_year: 1900, end_year: Time.now.year, default: Date.new(1990,1,15), order: [:month, :day, :year] } } %>
-        <% end %>
-      <% else %>
-        <% @step.members_requesting_health_insurance.each do |member| %>
-          <fieldset class="form-group">
-            <%= f.fields_for('members[]', member) do |ff| %>
-              <div class="household-member-group" data-member-name="<%= member.display_name %>">
-                <p class="text--section-header"><%= member.display_name %></p>
-                <%= ff.mb_input_field :ssn,
-                  "Social Security Number",
-                  type: :tel,
-                  options: { maxlength: 9 },
-                  notes: ["If you don’t know it you can skip this"] %>
-                <%= ff.mb_date_select :birthday, "Date of birth", { options: { start_year: 1900, end_year: Time.now.year, default: Date.new(1990,1,15), order: [:month, :day, :year] } } %>
-              </div>
-            <% end %>
-          </fieldset>
-        <% end %>
-        <p class='text--secure'>
-          <i class='illustration illustration--safety'></i>
-          Social security numbers help ensure you receive the correct benefits. MDHHS maintains strict security guidelines to protect the identities of our residents.
-        </p>
-  <% end %>
+      <% @step.members_requesting_health_insurance.each do |member| %>
+        <fieldset class="form-group">
+          <%= f.fields_for('members[]', member) do |ff| %>
+            <div class="household-member-group" data-member-name="<%= member.display_name %>">
+
+              <% if !single_member_household? -%>
+                <p class="text--section-header">
+                  <%= member.display_name %>
+                </p>
+              <% end -%>
+
+              <%= ff.mb_input_field :ssn,
+                "Social Security Number",
+                type: :tel,
+                options: { maxlength: 9 },
+                notes: ["If you don’t know it you can skip this"] %>
+
+              <%= ff.mb_date_select :birthday,
+                "Date of birth",
+                options: {
+                  start_year: 1900,
+                  end_year: Time.now.year,
+                  default: Date.new(1990,1,15),
+                  order: [:month, :day, :year],
+                } %>
+
+            </div>
+          <% end %>
+        </fieldset>
+      <% end %>
+
+      <p class='text--secure'>
+        <i class='illustration illustration--safety'></i>
+        Social security numbers help ensure you receive the correct benefits.
+        MDHHS maintains strict security guidelines to protect the identities
+        of our residents.
+      </p>
+
       <%= render "medicaid/next_step" %>
     <% end %>
   </div>

--- a/spec/views/medicaid/contact_social_security/edit.html.erb_spec.rb
+++ b/spec/views/medicaid/contact_social_security/edit.html.erb_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+describe "medicaid/contact_social_security/edit.html.erb" do
+  before do
+    controller.singleton_class.class_eval do
+      def current_path
+        "/steps/medicaid/contact_social_security"
+      end
+
+      helper_method :current_path
+    end
+  end
+
+  context "one member has an invalid SSN" do
+    it "shows an error for that one member" do
+      controller.singleton_class.class_eval do
+        def single_member_household?
+          true
+        end
+
+        helper_method :single_member_household?
+      end
+
+      app = create(:medicaid_application, anyone_new_mom: true)
+      member = build(:member, ssn: "wrong", benefit_application: app)
+      member.save(validate: false)
+      member.valid?
+      step = Medicaid::ContactSocialSecurity.new(members: [member])
+      assign(:step, step)
+
+      render
+
+      expect(rendered).to include("Make sure to provide 9 digits")
+    end
+  end
+
+  context "two members have invalid SSN's" do
+    it "shows errors for each member" do
+      controller.singleton_class.class_eval do
+        def single_member_household?
+          false
+        end
+
+        helper_method :single_member_household?
+      end
+
+      app = create(:medicaid_application, anyone_new_mom: true)
+
+      member1 = build(:member, ssn: "wrong", benefit_application: app)
+      member1.save(validate: false)
+      member1.valid?
+
+      member2 = build(:member, ssn: "nope", benefit_application: app)
+      member2.save(validate: false)
+      member2.valid?
+
+      step = Medicaid::ContactSocialSecurity.new(members: [member1, member2])
+      assign(:step, step)
+
+      render
+      expect(rendered.scan("Make sure to provide 9 digits").size).to eq 2
+    end
+  end
+end


### PR DESCRIPTION
[Finishes #152623445]

This commit cleans up the contact SSN page and ensures that an error
displays at all times for instances where a social security number is
not formatted correctly.