### PR TITLE
Ask for tax filing status for tax household members

### DIFF
--- a/app/controllers/medicaid/tax_claimed_as_dependent_controller.rb
+++ b/app/controllers/medicaid/tax_claimed_as_dependent_controller.rb
@@ -7,11 +7,7 @@ module Medicaid
     end
 
     def update_application
-      current_application.primary_member.update!(member_attrs)
-    end
-
-    def member_attrs
-      { claimed_as_dependent: step_params[:claimed_as_dependent] }
+      current_application.primary_member.update!(step_params)
     end
   end
 end

--- a/app/controllers/medicaid/tax_filing_with_household_members_relationship_controller.rb
+++ b/app/controllers/medicaid/tax_filing_with_household_members_relationship_controller.rb
@@ -2,18 +2,6 @@ module Medicaid
   class TaxFilingWithHouseholdMembersRelationshipController <
     ManyMemberStepsController
 
-    def update
-      assign_household_member_attributes
-
-      if step.valid?
-        assign_primary_member_attributes
-        update_application
-        redirect_to(next_path)
-      else
-        render :edit
-      end
-    end
-
     private
 
     def step
@@ -34,12 +22,14 @@ module Medicaid
       end
     end
 
-    def assign_primary_member_attributes
-      primary_member = current_application.primary_member
-      primary_member.assign_attributes(
-        tax_relationship: primary_member_tax_relationship,
-      )
-      @step.members.push(primary_member)
+    def update_application
+      super
+
+      current_application.
+        primary_member.
+        update!(
+          tax_relationship: primary_member_tax_relationship,
+        )
     end
 
     def not_filing_federal_taxes_next_year

--- a/app/controllers/medicaid/tax_filing_with_household_members_relationship_controller.rb
+++ b/app/controllers/medicaid/tax_filing_with_household_members_relationship_controller.rb
@@ -1,0 +1,62 @@
+module Medicaid
+  class TaxFilingWithHouseholdMembersRelationshipController <
+    ManyMemberStepsController
+
+    def update
+      assign_household_member_attributes
+
+      if step.valid?
+        assign_primary_member_attributes
+        update_application
+        redirect_to(next_path)
+      else
+        render :edit
+      end
+    end
+
+    private
+
+    def step
+      @step ||= step_class.new(members: tax_household_members)
+    end
+
+    def skip?
+      single_member_household? ||
+        not_filing_federal_taxes_next_year ||
+        not_filing_taxes_with_household_members
+    end
+
+    def primary_member_tax_relationship
+      if step.members.map(&:tax_relationship).include?("Joint")
+        "Joint"
+      else
+        "Single"
+      end
+    end
+
+    def assign_primary_member_attributes
+      primary_member = current_application.primary_member
+      primary_member.assign_attributes(
+        tax_relationship: primary_member_tax_relationship,
+      )
+      @step.members.push(primary_member)
+    end
+
+    def not_filing_federal_taxes_next_year
+      !current_application.filing_federal_taxes_next_year?
+    end
+
+    def not_filing_taxes_with_household_members
+      !current_application.filing_taxes_with_household_members?
+    end
+
+    def tax_household_members
+      current_application.non_applicant_members.
+        select(&:filing_taxes_with_primary_member)
+    end
+
+    def member_attrs
+      %i[tax_relationship]
+    end
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -30,6 +30,12 @@ class Member < ApplicationRecord
     "Separated",
   ].freeze
 
+  TAX_RELATIONSHIPS = %w[
+    Single
+    Joint
+    Dependent
+  ].freeze
+
   belongs_to :benefit_application, polymorphic: true
   has_one :spouse, class_name: "Member", foreign_key: "spouse_id"
 
@@ -47,6 +53,10 @@ class Member < ApplicationRecord
 
   validates :sex,
     inclusion: { in: SEXES },
+    allow_nil: true
+
+  validates :tax_relationship,
+    inclusion: { in: TAX_RELATIONSHIPS },
     allow_nil: true
 
   attribute :ssn

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -38,6 +38,7 @@ module Medicaid
         Medicaid::TaxClaimedAsDependentController,
         Medicaid::TaxFilingWithHouseholdMembersController,
         Medicaid::TaxFilingWithHouseholdMembersMemberController,
+        Medicaid::TaxFilingWithHouseholdMembersRelationshipController,
       ],
       "Income" => [
         Medicaid::IncomeIntroductionController,

--- a/app/steps/medicaid/tax_filing_with_household_members_relationship.rb
+++ b/app/steps/medicaid/tax_filing_with_household_members_relationship.rb
@@ -1,0 +1,26 @@
+module Medicaid
+  class TaxFilingWithHouseholdMembersRelationship < ManyMembersStep
+    step_attributes(:members)
+
+    validate :only_one_joint_filer
+
+    private
+
+    def only_one_joint_filer
+      return true if members.map(&:tax_relationship).count("Joint") <= 1
+      errors.add(
+        :duplicate_joint_filers,
+        "Make sure you only select one joint filer",
+      )
+    end
+
+    def validate_household_member(_member)
+      if _member.tax_relationship.empty?
+        _member.errors.add(
+          :tax_relationship,
+          "Make sure you select one option",
+        )
+      end
+    end
+  end
+end

--- a/app/views/medicaid/tax_filing_with_household_members_relationship/edit.html.erb
+++ b/app/views/medicaid/tax_filing_with_household_members_relationship/edit.html.erb
@@ -1,0 +1,29 @@
+<% content_for :header_title, "Quick Tax Questions" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Tell us your tax relationships with each person that you file taxes with.
+    </div>
+  </header>
+
+
+  <div class="form-card__content">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+        <%= f.mb_form_errors :duplicate_joint_filers %>
+        <fieldset class="form-group">
+        <% @step.members.each do |member| %>
+          <%= f.fields_for("members[]", member) do |ff| %>
+            <%= ff.mb_select :tax_relationship,
+              member.display_name,
+              ['Joint', 'Dependent'],
+              include_blank: "Choose one" %>
+          <% end %>
+        <% end %>
+      </fieldset>
+
+      <%= render "medicaid/next_step" %>
+    <% end %>
+  </div>
+
+</div>

--- a/db/migrate/20171115182700_add_tax_relationship_to_member.rb
+++ b/db/migrate/20171115182700_add_tax_relationship_to_member.rb
@@ -1,0 +1,5 @@
+class AddTaxRelationshipToMember < ActiveRecord::Migration[5.1]
+  def change
+    add_column :members, :tax_relationship, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -209,6 +209,7 @@ ActiveRecord::Schema.define(version: 20171115191926) do
     t.string "sex"
     t.integer "spouse_id"
     t.integer "student_loan_interest_expenses"
+    t.string "tax_relationship"
     t.integer "unemployment_income"
     t.datetime "updated_at", null: false
   end

--- a/spec/controllers/medicaid/tax_filing_with_household_members_member_controller_spec.rb
+++ b/spec/controllers/medicaid/tax_filing_with_household_members_member_controller_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe Medicaid::TaxFilingWithHouseholdMembersMemberController do
   describe "#next_path" do
-    it "is the income intro path" do
+    it "is the tax filing   members relationship path" do
       expect(subject.next_path).to eq(
-        "/steps/medicaid/income-introduction",
+        "/steps/medicaid/tax-filing-with-household-members-relationship",
       )
     end
   end

--- a/spec/controllers/medicaid/tax_filing_with_household_members_relationship_controller_spec.rb
+++ b/spec/controllers/medicaid/tax_filing_with_household_members_relationship_controller_spec.rb
@@ -1,0 +1,158 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::TaxFilingWithHouseholdMembersRelationshipController do
+  describe "#next_path" do
+    it "is the income introduction path" do
+      expect(subject.next_path).to eq(
+        "/steps/medicaid/income-introduction",
+      )
+    end
+  end
+
+  describe "#update" do
+    context "a household member selected 'Joint' as tax relationship" do
+      it "updates primary member's tax relationship to 'Joint'" do
+        primary_member = build(:member)
+        secondary_member = build(:member,
+          filing_taxes_with_primary_member: true)
+        medicaid_application = create(
+          :medicaid_application,
+          members: [
+            primary_member,
+            secondary_member,
+          ],
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        put(
+          :update,
+          params: {
+            step: {
+              members: {
+                secondary_member.id => {
+                  tax_relationship: "Joint",
+                },
+              },
+            },
+          },
+        )
+        primary_member.reload
+        secondary_member.reload
+
+        expect(primary_member.tax_relationship).to eq("Joint")
+        expect(secondary_member.tax_relationship).to eq("Joint")
+      end
+    end
+
+    context "a household member selected 'Dependent' as tax relationship" do
+      it "updates primary member's tax relationship to 'Single'" do
+        primary_member = build(:member)
+        secondary_member = build(:member,
+          filing_taxes_with_primary_member: true)
+        medicaid_application = create(
+          :medicaid_application,
+          members: [
+            primary_member,
+            secondary_member,
+          ],
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        put(
+          :update,
+          params: {
+            step: {
+              members: {
+                secondary_member.id => {
+                  tax_relationship: "Dependent",
+                },
+              },
+            },
+          },
+        )
+        primary_member.reload
+        secondary_member.reload
+
+        expect(primary_member.tax_relationship).to eq("Single")
+        expect(secondary_member.tax_relationship).to eq("Dependent")
+      end
+    end
+
+    describe "#edit" do
+      context "multi-member household" do
+        it "limits step members to non-primary members in tax household" do
+          primary_member = build(:member)
+          non_household_member = build(:member,
+            filing_taxes_with_primary_member: false)
+          household_member = build(:member,
+            filing_taxes_with_primary_member: true)
+          medicaid_application = create(
+            :medicaid_application,
+            members: [
+              primary_member,
+              non_household_member,
+              household_member,
+            ],
+            filing_federal_taxes_next_year: true,
+            filing_taxes_with_household_members: true,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to render_template(:edit)
+          expect(assigns(:step).members).to eq([
+            household_member,
+          ])
+        end
+
+        context "not filing federal taxes next year" do
+          it "skips this page" do
+            medicaid_application = create(
+              :medicaid_application,
+              members: create_list(:member, 2),
+              filing_federal_taxes_next_year: false,
+            )
+            session[:medicaid_application_id] = medicaid_application.id
+
+            get :edit
+
+            expect(response).to redirect_to(subject.next_path)
+          end
+        end
+
+        context "filing federal taxes next year, without household members" do
+          it "skips this page" do
+            medicaid_application = create(
+              :medicaid_application,
+              members: create_list(:member, 2),
+              filing_federal_taxes_next_year: true,
+              filing_taxes_with_household_members: false,
+            )
+            session[:medicaid_application_id] = medicaid_application.id
+
+            get :edit
+
+            expect(response).to redirect_to(subject.next_path)
+          end
+        end
+      end
+
+      context "single member household" do
+        it "skips this page" do
+          medicaid_application = create(
+            :medicaid_application,
+            members: [create(:member)],
+            filing_federal_taxes_next_year: true,
+            filing_taxes_with_household_members: true,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          expect(response).to redirect_to(subject.next_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -239,6 +239,17 @@ RSpec.feature "Medicaid app" do
       )
       check "Joel Tester"
       click_on "Next"
+
+      expect(page).to have_content(
+        "Tell us your tax relationships with each person that "\
+        "you file taxes with.",
+      )
+
+      click_on "Next"
+      expect(page).to have_content("Make sure you select one option")
+
+      select "Joint"
+      click_on "Next"
     end
 
     on_page "Income & Expenses" do

--- a/spec/steps/medicaid/tax_filing_with_household_members_relationship_spec.rb
+++ b/spec/steps/medicaid/tax_filing_with_household_members_relationship_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::TaxFilingWithHouseholdMembersRelationship do
+  describe "Validations" do
+    context "each member has a specified tax relationship" do
+      it "is valid" do
+        member_one = build(:member,
+          tax_relationship: "Single")
+        member_two = build(:member,
+          tax_relationship: "Dependent")
+
+        step = described_class.new(
+          members: [member_one, member_two],
+        )
+
+        expect(step).to be_valid
+      end
+    end
+
+    context "one member does not specify a tax relationship" do
+      it "is invalid" do
+        member_one = build(:member,
+          tax_relationship: "Single")
+        member_two = build(:member,
+          tax_relationship: "")
+
+        step = described_class.new(
+          members: [member_one, member_two],
+        )
+
+        expect(step).not_to be_valid
+      end
+    end
+
+    context "only one member has 'joint' tax relationship" do
+      it "is valid" do
+        member_one = build(:member,
+          tax_relationship: "Joint")
+        member_two = build(:member,
+          tax_relationship: "Dependent")
+
+        step = described_class.new(
+          members: [member_one, member_two],
+        )
+
+        expect(step).to be_valid
+      end
+    end
+
+    context "more than one member has 'joint' tax relationship" do
+      it "is invalid" do
+        member_one = build(:member,
+          tax_relationship: "Joint")
+        member_two = build(:member,
+          tax_relationship: "Joint")
+
+        step = described_class.new(
+          members: [member_one, member_two],
+        )
+
+        expect(step).not_to be_valid
+      end
+    end
+  end
+end


### PR DESCRIPTION
Updates primary member's tax relationship (filing status, effectively) to "Single"
if noone in household is filing jointly, and "Joint" if one other member of household
has indicated they are filing jointly.

Also introduces pattern of redefining step members in the controller, so that the controller
is scoped to only consider applicable members (in this case, tax household members).

https://www.pivotaltracker.com/story/show/152561623
[Finishes #152561623]

Signed-off-by: Paras Sanghavi <paras@codeforamerica.org>

![screen shot 2017-11-15 at 5 57 37 pm](https://user-images.githubusercontent.com/3675092/32869952-86e28e58-ca2e-11e7-8810-2fff0787772f.png)

![screen shot 2017-11-15 at 5 57 44 pm](https://user-images.githubusercontent.com/3675092/32869964-8dddb610-ca2e-11e7-964a-1751179bb9f7.png)

![screen shot 2017-11-15 at 5 57 49 pm](https://user-images.githubusercontent.com/3675092/32869967-9154160e-ca2e-11e7-9de1-3f1c57143586.png)
