### PR TITLE
MIBridges web driver capabilities on/off via ENV

### DIFF
--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -22,9 +22,13 @@ class SuccessController < SnapStepsController
       snap_application: current_application,
     )
 
-    DriveApplicationJob.perform_later(
-      snap_application: current_application,
-    )
+    if web_driving_enabled?
+      DriveApplicationJob.perform_later(snap_application: current_application)
+    end
+  end
+
+  def web_driving_enabled?
+    ENV.fetch("DRIVER_ENABLED", "false") == "true"
   end
 
   def update_application


### PR DESCRIPTION
`heroku config:set DRIVER_ENABLED=[true|false]` to turn on or off

For now having the noise of a not fully functional web driver is not
worth having it turned on. We should be able to flip a switch to enable
it.