### PR TITLE
Update all members if "everyone a citizen"

### DIFF
--- a/app/controllers/medicaid/intro_citizen_controller.rb
+++ b/app/controllers/medicaid/intro_citizen_controller.rb
@@ -7,6 +7,10 @@ module Medicaid
 
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
+      elsif step_params[:everyone_a_citizen] == "true"
+        current_application.members.each do |member|
+          member.update!(citizen: true)
+        end
       end
     end
 

--- a/spec/controllers/medicaid/intro_citizen_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_citizen_controller_spec.rb
@@ -8,6 +8,28 @@ RSpec.describe Medicaid::IntroCitizenController, type: :controller do
   end
 
   describe "#update" do
+    context "multi member househoold" do
+      context "everyone a citizen" do
+        it "updates the members" do
+          members = create_list(:member, 2)
+
+          medicaid_application = create(
+            :medicaid_application,
+            members: members,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          put :update, params: { step: { everyone_a_citizen: true } }
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member).to be_citizen
+          end
+        end
+      end
+    end
+
     context "single member household" do
       context "is a citizen" do
         it "updates the member" do


### PR DESCRIPTION
* We were updating for a single member but not in a multi-member context
* For most questions, if the "anyone_" question is false, we do not want
to update any members because they all have an attribute as FALSE (or
nil). In the case of citizenship, the logic is reversed: when everyone is a
citizen we want to set an attribute ("citizen") to be TRUE.
* This bug became apparent when filling out the 1426 PDF for a
multi-member household where I'd said everyone was a citizen but members
were all being marked as not a citizen because they had a `nil` value in
the database for the `citizen` field