### PR TITLE
Bug: pregnancy in multi-member household w/single female

### DIFF
--- a/app/controllers/medicaid/health_pregnancy_controller.rb
+++ b/app/controllers/medicaid/health_pregnancy_controller.rb
@@ -7,7 +7,15 @@ module Medicaid
 
       if single_member_household?
         current_application.primary_member.update!(member_attrs)
+      elsif female_members.count == 1
+        female_members.each do |member|
+          member.update!(member_attrs)
+        end
       end
+    end
+
+    def female_members
+      current_application.members.select(&:female?)
     end
 
     def skip?
@@ -15,9 +23,7 @@ module Medicaid
     end
 
     def all_males?
-      current_application.members.all? do |member|
-        member.sex == "male"
-      end
+      current_application.members.all?(&:male?)
     end
 
     def member_attrs

--- a/spec/controllers/medicaid/health_pregnancy_controller_spec.rb
+++ b/spec/controllers/medicaid/health_pregnancy_controller_spec.rb
@@ -42,6 +42,29 @@ RSpec.describe Medicaid::HealthPregnancyController, type: :controller do
   end
 
   describe "#update" do
+    context "multi member household, one female membrer" do
+      context "someone is pregnant" do
+        it "updates the member" do
+          female_member = create(:member, sex: "female")
+          male_member = create(:member, sex: "male")
+
+          medicaid_application = create(
+            :medicaid_application,
+            members: [male_member, female_member],
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          put :update, params: { step: { anyone_new_mom: true } }
+
+          female_member.reload
+          male_member.reload
+
+          expect(female_member).to be_new_mom
+          expect(male_member).not_to be_new_mom
+        end
+      end
+    end
+
     context "single member household" do
       context "someone is pregnant" do
         it "updates the member" do


### PR DESCRIPTION
* Usually, we update a single member if the answer to yes/no question is
"yes".
* Pregnancy is an edge case where if there is a multi-member household
but only one member is a female, we can update the `new_mom` attribute
of that single woman after the yes/no question about pregnancy.
* This will fix a bug found via the 1426 form when "new mom" field was
not checked for a dual household with one female. The female was not
marked as a new mom in the database even though the `anyone_new_mom` was
set to true on the Medicaid app.