### PR TITLE
Validate that at least one other income type given

### DIFF
--- a/app/views/medicaid/income_other_income_type/edit.html.erb
+++ b/app/views/medicaid/income_other_income_type/edit.html.erb
@@ -15,6 +15,9 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.hidden_field :member_id, value: current_member.id %>
+
+      <%= f.mb_form_errors :other_income_types %>
+
       <%= f.mb_checkbox_set(
         [
           { method: :unemployment, label: "Unemployment" },

--- a/spec/views/medicaid/income_other_income_type/edit.html.erb_spec.rb
+++ b/spec/views/medicaid/income_other_income_type/edit.html.erb_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+describe "medicaid/income_other_income_type/edit.html.erb" do
+  before do
+    controller.singleton_class.class_eval do
+      def current_path
+        "/steps/medicaid/income-other-income-type"
+      end
+
+      def current_member
+        Member.last
+      end
+
+      def current_application
+        current_member.benefit_application
+      end
+
+      helper_method :current_path, :current_application, :current_member
+    end
+  end
+
+  context "has not selected another income type" do
+    it "shows an error message" do
+      member = create(:member, other_income: true)
+      step = Medicaid::IncomeOtherIncomeType.new(
+        other_income_types: [],
+        member_id: member.id,
+      ).tap(&:valid?)
+
+      assign(:step, step)
+
+      render
+
+      expect(rendered).to include(
+        "Please select at least one other income type",
+      )
+    end
+  end
+end


### PR DESCRIPTION
[Finishes #152702632]

The `Other Income Type` page was not displaying the validation error. This
commit fixes that.