### PR TITLE
More explicitly setting members in controllers

### DIFF
--- a/app/controllers/medicaid/contact_social_security_controller.rb
+++ b/app/controllers/medicaid/contact_social_security_controller.rb
@@ -1,5 +1,11 @@
 module Medicaid
   class ContactSocialSecurityController < Medicaid::ManyMemberStepsController
+    def step
+      @step ||= step_class.new(
+        members: members_requesting_health_insurance,
+      )
+    end
+
     private
 
     def skip?
@@ -12,6 +18,12 @@ module Medicaid
 
     def member_attrs
       %i[ssn birthday]
+    end
+
+    def members_requesting_health_insurance
+      current_application.
+        members.
+        where(requesting_health_insurance: true)
     end
   end
 end

--- a/app/controllers/medicaid/health_pregnancy_controller.rb
+++ b/app/controllers/medicaid/health_pregnancy_controller.rb
@@ -1,5 +1,11 @@
 module Medicaid
   class HealthPregnancyController < MedicaidStepsController
+    def edit
+      super
+
+      @step.members = current_application.members
+    end
+
     private
 
     def update_application

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -20,12 +20,6 @@ class StepsController < ApplicationController
   def edit
     attribute_keys = Step::Attributes.new(step_attrs).to_sym
     @step = step_class.new(existing_attributes.slice(*attribute_keys))
-
-    if attribute_keys.include?(:members)
-      @step.members = current_application&.members
-    end
-
-    before_rendering_edit_hook
   end
 
   def update
@@ -78,9 +72,6 @@ class StepsController < ApplicationController
   private
 
   delegate :step_class, to: :class
-
-  # This is an intentional noop
-  def before_rendering_edit_hook; end
 
   def existing_attributes
     HashWithIndifferentAccess.new(current_application&.attributes)

--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -7,9 +7,15 @@ class SuccessController < SnapStepsController
     after_submit_path
   end
 
+  def edit
+    super
+
+    export
+  end
+
   private
 
-  def before_rendering_edit_hook
+  def export
     return if !current_application.exportable?
 
     ExportFactory.create(

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -70,6 +70,10 @@ class MedicaidApplication < ApplicationRecord
     ).completed_file
   end
 
+  def members_count
+    members.count
+  end
+
   private
 
   def unstable_housing?

--- a/app/steps/medicaid/contact_social_security.rb
+++ b/app/steps/medicaid/contact_social_security.rb
@@ -1,14 +1,8 @@
 module Medicaid
   class ContactSocialSecurity < ManyMembersStep
-    step_attributes(:members)
-
     def validate_household_member(member)
       member.valid?
       member.errors[:ssn].blank?
-    end
-
-    def members_requesting_health_insurance
-      members.select(&:requesting_health_insurance)
     end
   end
 end

--- a/app/steps/medicaid/expenses_alimony.rb
+++ b/app/steps/medicaid/expenses_alimony.rb
@@ -2,7 +2,7 @@ module Medicaid
   class ExpensesAlimony < Step
     step_attributes(
       :anyone_pay_child_support_alimony_arrears,
-      :members,
+      :members_count,
     )
   end
 end

--- a/app/steps/medicaid/expenses_student_loan.rb
+++ b/app/steps/medicaid/expenses_student_loan.rb
@@ -2,7 +2,7 @@ module Medicaid
   class ExpensesStudentLoan < Step
     step_attributes(
       :anyone_pay_student_loan_interest,
-      :members,
+      :members_count,
     )
   end
 end

--- a/app/views/medicaid/contact_social_security/edit.html.erb
+++ b/app/views/medicaid/contact_social_security/edit.html.erb
@@ -12,7 +12,7 @@
       url: current_path,
       method: :put do |f| %>
 
-      <% @step.members_requesting_health_insurance.each do |member| %>
+      <% @step.members.each do |member| %>
         <fieldset class="form-group">
           <%= f.fields_for('members[]', member) do |ff| %>
             <div class="household-member-group" data-member-name="<%= member.display_name %>">

--- a/app/views/medicaid/expenses_alimony/edit.html.erb
+++ b/app/views/medicaid/expenses_alimony/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      <%= t "medicaid.expenses_alimony.edit.title", count: @step.members.count %>
+      <%= t "medicaid.expenses_alimony.edit.title", count: @step.members_count %>
     </div>
   </header>
 

--- a/app/views/medicaid/expenses_student_loan/edit.html.erb
+++ b/app/views/medicaid/expenses_student_loan/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t "medicaid.expenses_student_loan.edit.title",
-        count: @step.members.count %>
+        count: @step.members_count %>
     </div>
   </header>
 

--- a/spec/controllers/medicaid/contact_social_security_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_social_security_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Medicaid::ContactSocialSecurityController do
   end
 
   describe "#edit" do
-    context "client will not submitssn" do
+    context "client will not submit ssn" do
       it "redirects to next step" do
         medicaid_application = create(:medicaid_application, submit_ssn: false)
         session[:medicaid_application_id] = medicaid_application.id
@@ -29,6 +29,23 @@ RSpec.describe Medicaid::ContactSocialSecurityController do
         get :edit
 
         expect(response).to render_template(:edit)
+      end
+
+      it "assigns members requesting health insurance to step" do
+        member_one = create(:member, requesting_health_insurance: true)
+        member_two = create(:member, requesting_health_insurance: true)
+        member_three = create(:member, requesting_health_insurance: false)
+
+        medicaid_application = create(
+          :medicaid_application,
+          submit_ssn: true,
+          members: [member_one, member_two, member_three],
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(assigns[:step].members).to eq [member_one, member_two]
       end
     end
   end

--- a/spec/controllers/medicaid/health_pregnancy_controller_spec.rb
+++ b/spec/controllers/medicaid/health_pregnancy_controller_spec.rb
@@ -38,6 +38,16 @@ RSpec.describe Medicaid::HealthPregnancyController, type: :controller do
 
         expect(response).to render_template(:edit)
       end
+
+      it "assigns members to step" do
+        member = build(:member, sex: "female")
+        medicaid_application = create(:medicaid_application, members: [member])
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(assigns[:step].members).to eq [member]
+      end
     end
   end
 

--- a/spec/models/medicaid_application_spec.rb
+++ b/spec/models/medicaid_application_spec.rb
@@ -107,4 +107,15 @@ RSpec.describe MedicaidApplication do
       expect(app.no_expenses?).to eq(true)
     end
   end
+
+  describe "#members_count" do
+    it "returns the count of associated members" do
+      app = create(
+        :medicaid_application,
+        members: build_list(:member, 5),
+      )
+
+      expect(app.members_count).to eq 5
+    end
+  end
 end


### PR DESCRIPTION
 * Controllers that directly inherit from StepsController now have to
 explicitly call super and set it, instead of having it done for you
 based on if your attributes include members
 * Remove the edit hook in favor of calling `super`
 * ManyMembersStepController's children override edit anyways so they
 did not need to be changed as part of this commit.

 Feedback please!

[#152975776]