### PR TITLE
Fix bug with steps using `members_count` attribute

### DIFF
--- a/app/controllers/medicaid_steps_controller.rb
+++ b/app/controllers/medicaid_steps_controller.rb
@@ -18,11 +18,11 @@ class MedicaidStepsController < StepsController
   end
 
   def single_member_household?
-    current_application.members.count == 1
+    current_application.members_count == 1
   end
 
   def multi_member_household?
-    current_application.members.count > 1
+    current_application.members_count > 1
   end
 
   def step_navigation

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -70,10 +70,6 @@ class MedicaidApplication < ApplicationRecord
     ).completed_file
   end
 
-  def members_count
-    members.count
-  end
-
   private
 
   def unstable_housing?

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -45,7 +45,7 @@ class Member < ApplicationRecord
     unemployment
   ].freeze
 
-  belongs_to :benefit_application, polymorphic: true
+  belongs_to :benefit_application, polymorphic: true, counter_cache: true
   has_one :spouse, class_name: "Member", foreign_key: "spouse_id"
 
   validates :employed_pay_interval,

--- a/app/models/snap_application_attributes.rb
+++ b/app/models/snap_application_attributes.rb
@@ -194,13 +194,13 @@ class SnapApplicationAttributes
 
   def more_than_six_members_yes
     bool_to_checkbox(
-      snap_application.members.length > Dhs1171Pdf::MAXIMUM_HOUSEHOLD_MEMBERS,
+      snap_application.members_count > Dhs1171Pdf::MAXIMUM_HOUSEHOLD_MEMBERS,
     )
   end
 
   def more_than_six_members_no
     bool_to_checkbox(
-      snap_application.members.length <=
+      snap_application.members_count <=
         Dhs1171Pdf::MAXIMUM_HOUSEHOLD_MEMBERS,
     )
   end

--- a/app/views/medicaid/amounts_expenses/edit.html.erb
+++ b/app/views/medicaid/amounts_expenses/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.amounts_expenses.edit.title",
-            count: @step.members_count,
+            count: current_application.members_count,
             name: current_member.display_name) %>
     </div>
   </header>

--- a/app/views/medicaid/amounts_expenses/edit.html.erb
+++ b/app/views/medicaid/amounts_expenses/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.amounts_expenses.edit.title",
-            count: current_application.members.count,
+            count: @step.members_count,
             name: current_member.display_name) %>
     </div>
   </header>

--- a/app/views/medicaid/contact_ss_dob/edit.html.erb
+++ b/app/views/medicaid/contact_ss_dob/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.contact_ss_dob.edit.title",
-            count: current_application.members.count) %>
+            count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">
       This information isn’t required at this time. But if you submit it now,

--- a/app/views/medicaid/expenses_alimony/edit.html.erb
+++ b/app/views/medicaid/expenses_alimony/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      <%= t "medicaid.expenses_alimony.edit.title", count: @step.members_count %>
+      <%= t("medicaid.expenses_alimony.edit.title", count: current_application.members_count) %>
     </div>
   </header>
 

--- a/app/views/medicaid/health_disability/edit.html.erb
+++ b/app/views/medicaid/health_disability/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.health_disability.edit.title",
-            count: current_application.members.count) %>
+            count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">
       This can include living in a nursing home or other medical facility or a

--- a/app/views/medicaid/health_flint_water_crisis/edit.html.erb
+++ b/app/views/medicaid/health_flint_water_crisis/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.health_flint_water_crisis.edit.title",
-            count: current_application.members.count) %>
+            count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">
       If you consumed water at a location that was serviced by the the Flint Water

--- a/app/views/medicaid/income_job/edit.html.erb
+++ b/app/views/medicaid/income_job/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.income_job.edit.title",
-        count: current_application.members.count) %>
+        count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">
       This includes full time, part time, temporary, and contract jobs.

--- a/app/views/medicaid/income_other_income/edit.html.erb
+++ b/app/views/medicaid/income_other_income/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.income_other_income.edit.title",
-        count: current_application.members.count) %>
+        count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">
       This includes unemployment, pensions, social security, retirement, etc.

--- a/app/views/medicaid/income_other_income_type/edit.html.erb
+++ b/app/views/medicaid/income_other_income_type/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.income_other_income_type.edit.title",
-            count: current_application.members.count,
+            count: current_application.members_count,
             name: current_member.display_name) %>
   </div>
     <p class="text--help text--centered">

--- a/app/views/medicaid/income_self_employment/edit.html.erb
+++ b/app/views/medicaid/income_self_employment/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.income_self_employment.edit.title",
-        count: current_application.members.count) %>
+        count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">
       You’re self employed if you own your own business or perform odd jobs.

--- a/app/views/medicaid/insurance_current/edit.html.erb
+++ b/app/views/medicaid/insurance_current/edit.html.erb
@@ -4,11 +4,11 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.insurance_current.edit.title",
-            count: current_application.members.count) %>
+            count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">
       <%= t("medicaid.insurance_current.edit.helper_text",
-            count: current_application.members.count) %>
+            count: current_application.members_count) %>
     </p>
   </header>
 

--- a/app/views/medicaid/intro_citizen/edit.html.erb
+++ b/app/views/medicaid/intro_citizen/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.intro_citizen.edit.title",
-         count: current_application.members.count) %>
+         count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">
       You don’t always have to be a citizen to receive benefits. If you are not

--- a/app/views/medicaid/intro_college/edit.html.erb
+++ b/app/views/medicaid/intro_college/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.intro_college.edit.title",
-            count: current_application.members.count) %>
+            count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">
       Students may be eligible for different health care coverage options than other adults.

--- a/app/views/medicaid/intro_marital_status/edit.html.erb
+++ b/app/views/medicaid/intro_marital_status/edit.html.erb
@@ -4,7 +4,7 @@
   <header class="form-card__header">
     <div class="form-card__title">
       <%= t("medicaid.intro_marital_status.edit.title",
-            count: current_application.members.count) %>
+            count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">
 

--- a/app/views/medicaid/tax_introduction/edit.html.erb
+++ b/app/views/medicaid/tax_introduction/edit.html.erb
@@ -14,7 +14,8 @@
   <div class="form-card__content">
     <ul class="list--bulleted">
       <li>
-        <%= t("medicaid.tax_introduction.edit.help_text", count: current_application.members.count) %>
+        <%= t("medicaid.tax_introduction.edit.help_text",
+              count: current_application.members_count) %>
       </li>
       <li>
         This information is important in determining the benefits you’re eligible for.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -78,9 +78,7 @@ en:
       edit:
         title:
           one: Do you pay child support, alimony, or arrears?
-          other:
-            Does anyone in your household pay child
-            support, alimony, or arrears?
+          other: Does anyone in your household pay child support, alimony, or arrears?
     expenses_student_loan:
       edit:
         title:

--- a/db/migrate/20171120220922_add_members_count_columns_to_snap_applications_and_medicaid_applications.rb
+++ b/db/migrate/20171120220922_add_members_count_columns_to_snap_applications_and_medicaid_applications.rb
@@ -1,0 +1,8 @@
+class AddMembersCountColumnsToSnapApplicationsAndMedicaidApplications < ActiveRecord::Migration[5.1]
+  def change
+    add_column :snap_applications, :members_count, :integer
+    add_column :medicaid_applications, :members_count, :integer
+    change_column_default :snap_applications, :members_count, from: nil, to: 0
+    change_column_default :medicaid_applications, :members_count, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171115191926) do
+ActiveRecord::Schema.define(version: 20171120220922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -143,6 +143,7 @@ ActiveRecord::Schema.define(version: 20171115191926) do
     t.boolean "income_social_security"
     t.boolean "income_unemployment"
     t.boolean "mailing_address_same_as_residential_address"
+    t.integer "members_count", default: 0
     t.boolean "michigan_resident", null: false
     t.boolean "need_medical_expense_help_3_months"
     t.string "office_location"
@@ -244,6 +245,7 @@ ActiveRecord::Schema.define(version: 20171115191926) do
     t.boolean "mailing_address_same_as_residential_address", default: true
     t.boolean "medical"
     t.string "medical_expenses", default: [], array: true
+    t.integer "members_count", default: 0
     t.boolean "money_or_accounts_income"
     t.integer "monthly_care_expenses"
     t.integer "monthly_court_ordered_expenses"

--- a/spec/controllers/household_add_member_controller_spec.rb
+++ b/spec/controllers/household_add_member_controller_spec.rb
@@ -27,6 +27,6 @@ RSpec.describe HouseholdAddMemberController do
 
   def member
     @_member ||=
-      create(:member, sex: "male", relationship: "Child", ssn: "123456789")
+      build(:member, sex: "male", relationship: "Child", ssn: "123456789")
   end
 end

--- a/spec/controllers/household_more_info_per_member_controller_spec.rb
+++ b/spec/controllers/household_more_info_per_member_controller_spec.rb
@@ -31,10 +31,10 @@ RSpec.describe HouseholdMoreInfoPerMemberController do
   end
 
   def member_one
-    @_member_one ||= create(:member, disabled: nil)
+    @_member_one ||= build(:member, disabled: nil)
   end
 
   def member_two
-    @_member_two ||= create(:member, in_college: false)
+    @_member_two ||= build(:member, in_college: false)
   end
 end

--- a/spec/controllers/income_details_per_member_controller_spec.rb
+++ b/spec/controllers/income_details_per_member_controller_spec.rb
@@ -49,6 +49,6 @@ RSpec.describe IncomeDetailsPerMemberController do
   end
 
   def member
-    @_member ||= create(:member, employment_status: "employed")
+    @_member ||= build(:member, employment_status: "employed")
   end
 end

--- a/spec/controllers/income_employment_status_controller_spec.rb
+++ b/spec/controllers/income_employment_status_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe IncomeEmploymentStatusController do
   let(:step) { assigns(:step) }
   let(:member) do
-    create(:member, sex: "male", relationship: "Child")
+    build(:member, sex: "male", relationship: "Child")
   end
   let(:invalid_params) do
     {
@@ -42,6 +42,6 @@ RSpec.describe IncomeEmploymentStatusController do
   end
 
   def member
-    @_member ||= create(:member, employment_status: "employed")
+    @_member ||= build(:member, employment_status: "employed")
   end
 end

--- a/spec/controllers/introduce_yourself_controller_spec.rb
+++ b/spec/controllers/introduce_yourself_controller_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe IntroduceYourselfController do
   end
 
   def member
-    create(:member, first_name: "bob", last_name: "booboo", birthday: birthday)
+    build(:member, first_name: "bob", last_name: "booboo", birthday: birthday)
   end
 
   def valid_params

--- a/spec/controllers/medicaid/amounts_income_controller_spec.rb
+++ b/spec/controllers/medicaid/amounts_income_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Medicaid::AmountsIncomeController do
     context "a single member in the household" do
       context "current member does not have income" do
         it "redirects to next step" do
-          member = create(:member, employed: false)
+          member = build(:member, employed: false)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -39,7 +39,7 @@ RSpec.describe Medicaid::AmountsIncomeController do
 
       context "household, and a client, has income" do
         it "renders edit" do
-          member = create(:member, employed: true, employed_number_of_jobs: 2)
+          member = build(:member, employed: true, employed_number_of_jobs: 2)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -60,7 +60,7 @@ RSpec.describe Medicaid::AmountsIncomeController do
   describe "#update" do
     context "client has multiple jobs" do
       it "saves the income for each job" do
-        member = create(:member, employed: true, employed_number_of_jobs: 2)
+        member = build(:member, employed: true, employed_number_of_jobs: 2)
         medicaid_application = create(
           :medicaid_application,
           members: [member],

--- a/spec/controllers/medicaid/contact_social_security_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_social_security_controller_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Medicaid::ContactSocialSecurityController do
       end
 
       it "assigns members requesting health insurance to step" do
-        member_one = create(:member, requesting_health_insurance: true)
-        member_two = create(:member, requesting_health_insurance: true)
-        member_three = create(:member, requesting_health_insurance: false)
+        member_one = build(:member, requesting_health_insurance: true)
+        member_two = build(:member, requesting_health_insurance: true)
+        member_three = build(:member, requesting_health_insurance: false)
 
         medicaid_application = create(
           :medicaid_application,

--- a/spec/controllers/medicaid/expenses_alimony_controller_spec.rb
+++ b/spec/controllers/medicaid/expenses_alimony_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Medicaid::ExpensesAlimonyController, type: :controller do
     context "single member household" do
       context "anyone pays child support alimony or arrears" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application, members: [member]
@@ -33,7 +33,7 @@ RSpec.describe Medicaid::ExpensesAlimonyController, type: :controller do
 
       context "nobody pays child support alimony or arrears" do
         it "does not update the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application, members: [member]

--- a/spec/controllers/medicaid/expenses_student_loan_controller_spec.rb
+++ b/spec/controllers/medicaid/expenses_student_loan_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Medicaid::ExpensesStudentLoanController, type: :controller do
     context "single member household" do
       context "pays student loan interest" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,
@@ -35,7 +35,7 @@ RSpec.describe Medicaid::ExpensesStudentLoanController, type: :controller do
 
       context "does not pay student loan interest" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,

--- a/spec/controllers/medicaid/health_disability_controller_spec.rb
+++ b/spec/controllers/medicaid/health_disability_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Medicaid::HealthDisabilityController, type: :controller do
     context "single member household" do
       context "is disabled" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,
@@ -29,7 +29,7 @@ RSpec.describe Medicaid::HealthDisabilityController, type: :controller do
 
       context "is not disabled" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,

--- a/spec/controllers/medicaid/health_pregnancy_controller_spec.rb
+++ b/spec/controllers/medicaid/health_pregnancy_controller_spec.rb
@@ -55,8 +55,8 @@ RSpec.describe Medicaid::HealthPregnancyController, type: :controller do
     context "multi member household, one female membrer" do
       context "someone is pregnant" do
         it "updates the member" do
-          female_member = create(:member, sex: "female")
-          male_member = create(:member, sex: "male")
+          female_member = build(:member, sex: "female")
+          male_member = build(:member, sex: "male")
 
           medicaid_application = create(
             :medicaid_application,
@@ -78,7 +78,7 @@ RSpec.describe Medicaid::HealthPregnancyController, type: :controller do
     context "single member household" do
       context "someone is pregnant" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,
@@ -96,7 +96,7 @@ RSpec.describe Medicaid::HealthPregnancyController, type: :controller do
 
       context "nobody pregnant" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,

--- a/spec/controllers/medicaid/health_pregnancy_member_controller_spec.rb
+++ b/spec/controllers/medicaid/health_pregnancy_member_controller_spec.rb
@@ -52,12 +52,7 @@ RSpec.describe Medicaid::HealthPregnancyMemberController, type: :controller do
         medicaid_application = create(
           :medicaid_application,
           anyone_new_mom: true,
-        )
-        create_list(
-          :member,
-          2,
-          sex: "female",
-          benefit_application: medicaid_application,
+          members: build_list(:member, 2, sex: "female"),
         )
         session[:medicaid_application_id] = medicaid_application.id
 

--- a/spec/controllers/medicaid/income_job_controller_spec.rb
+++ b/spec/controllers/medicaid/income_job_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Medicaid::IncomeJobController do
     context "medicaid app has a single member" do
       context "someone in the household has a job" do
         it "updates the employment status of the primary member" do
-          member = create(:member)
+          member = build(:member)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -31,7 +31,7 @@ RSpec.describe Medicaid::IncomeJobController do
 
       context "nobody in the household has a job" do
         it "does not update the employment status of the primary member" do
-          member = create(:member)
+          member = build(:member)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -50,10 +50,10 @@ RSpec.describe Medicaid::IncomeJobController do
 
     context "medicaid app has multiple members" do
       it "does not update the employment status of the primary member" do
-        member = create(:member)
+        member = build(:member)
         medicaid_application = create(
           :medicaid_application,
-          members: [member, create(:member)],
+          members: [member, build(:member)],
         )
 
         session[:medicaid_application_id] = medicaid_application.id

--- a/spec/controllers/medicaid/income_job_number_continued_controller_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_continued_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Medicaid::IncomeJobNumberContinuedController do
         medicaid_application = create(
           :medicaid_application,
           anyone_employed: true,
-          members: create_list(:member, 2),
+          members: build_list(:member, 2),
         )
 
         session[:medicaid_application_id] = medicaid_application.id
@@ -27,7 +27,7 @@ RSpec.describe Medicaid::IncomeJobNumberContinuedController do
     context "medicaid app has a single member" do
       context "client is has 4+ jobs" do
         it "renders edit" do
-          member = create(:member, employed_number_of_jobs: 5)
+          member = build(:member, employed_number_of_jobs: 5)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -44,7 +44,7 @@ RSpec.describe Medicaid::IncomeJobNumberContinuedController do
 
       context "client has fewer than 4 jobs" do
         it "redirects to the next page" do
-          member = create(:member, employed_number_of_jobs: 3)
+          member = build(:member, employed_number_of_jobs: 3)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -77,7 +77,7 @@ RSpec.describe Medicaid::IncomeJobNumberContinuedController do
 
   describe "#update" do
     it "updates the job number count for the primary member" do
-      member = create(:member)
+      member = build(:member)
       medicaid_application = create(:medicaid_application, members: [member])
 
       session[:medicaid_application_id] = medicaid_application.id

--- a/spec/controllers/medicaid/income_job_number_controller_spec.rb
+++ b/spec/controllers/medicaid/income_job_number_controller_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Medicaid::IncomeJobNumberController do
         medicaid_application = create(
           :medicaid_application,
           anyone_employed: true,
-          members: create_list(:member, 2),
+          members: build_list(:member, 2),
         )
 
         session[:medicaid_application_id] = medicaid_application.id
@@ -29,7 +29,7 @@ RSpec.describe Medicaid::IncomeJobNumberController do
     context "medicaid app has a single member" do
       context "client has 4 or more jobs" do
         it "sets the job number to 4" do
-          member = create(:member, employed_number_of_jobs: 5)
+          member = build(:member, employed_number_of_jobs: 5)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -79,7 +79,7 @@ RSpec.describe Medicaid::IncomeJobNumberController do
 
   describe "#update" do
     it "updates the job number count for the primary member" do
-      member = create(:member)
+      member = build(:member)
       medicaid_application = create(:medicaid_application, members: [member])
 
       session[:medicaid_application_id] = medicaid_application.id

--- a/spec/controllers/medicaid/income_other_income_controller_spec.rb
+++ b/spec/controllers/medicaid/income_other_income_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Medicaid::IncomeOtherIncomeController do
     context "medicaid app has a single member" do
       context "someone in the household has other income" do
         it "updates the other_income attr of the primary member" do
-          member = create(:member)
+          member = build(:member)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -30,7 +30,7 @@ RSpec.describe Medicaid::IncomeOtherIncomeController do
 
       context "nobody in the household has a job" do
         it "does not update the employment status of the primary member" do
-          member = create(:member)
+          member = build(:member)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -47,10 +47,10 @@ RSpec.describe Medicaid::IncomeOtherIncomeController do
 
     context "medicaid app has multiple members" do
       it "does not update the employment status of the primary member" do
-        member = create(:member)
+        member = build(:member)
         medicaid_application = create(
           :medicaid_application,
-          members: [member, create(:member)],
+          members: [member, build(:member)],
         )
 
         session[:medicaid_application_id] = medicaid_application.id

--- a/spec/controllers/medicaid/income_other_income_type_controller_spec.rb
+++ b/spec/controllers/medicaid/income_other_income_type_controller_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Medicaid::IncomeOtherIncomeTypeController do
         medicaid_application = create(
           :medicaid_application,
           anyone_other_income: false,
-          members: [create(:member, other_income: false)],
+          members: [build(:member, other_income: false)],
         )
         session[:medicaid_application_id] = medicaid_application.id
 
@@ -87,7 +87,7 @@ RSpec.describe Medicaid::IncomeOtherIncomeTypeController do
         medicaid_application = create(
           :medicaid_application,
           anyone_other_income: true,
-          members: [create(:member, other_income: true)],
+          members: [build(:member, other_income: true)],
         )
         session[:medicaid_application_id] = medicaid_application.id
 

--- a/spec/controllers/medicaid/income_self_employment_controller_spec.rb
+++ b/spec/controllers/medicaid/income_self_employment_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Medicaid::IncomeSelfEmploymentController do
     context "medicaid app has a single member" do
       context "someone in the household is self employed" do
         it "updates the self_employment attr of the primary member" do
-          member = create(:member)
+          member = build(:member)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -30,7 +30,7 @@ RSpec.describe Medicaid::IncomeSelfEmploymentController do
 
       context "nobody in the household has a job" do
         it "does not update the employment status of the primary member" do
-          member = create(:member)
+          member = build(:member)
           medicaid_application = create(
             :medicaid_application,
             members: [member],
@@ -47,10 +47,10 @@ RSpec.describe Medicaid::IncomeSelfEmploymentController do
 
     context "medicaid app has multiple members" do
       it "does not update the employment status of the primary member" do
-        member = create(:member)
+        member = build(:member)
         medicaid_application = create(
           :medicaid_application,
-          members: [member, create(:member)],
+          members: [member, build(:member)],
         )
 
         session[:medicaid_application_id] = medicaid_application.id

--- a/spec/controllers/medicaid/insurance_current_controller_spec.rb
+++ b/spec/controllers/medicaid/insurance_current_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Medicaid::InsuranceCurrentController do
     context "single member household" do
       context "anyone is insured" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,
@@ -23,7 +23,7 @@ RSpec.describe Medicaid::InsuranceCurrentController do
 
       context "nobody insured" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,

--- a/spec/controllers/medicaid/insurance_current_type_controller_spec.rb
+++ b/spec/controllers/medicaid/insurance_current_type_controller_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Medicaid::InsuranceCurrentTypeController do
       it "does not redirect" do
         medicaid_application = create(:medicaid_application,
                                       anyone_insured: true,
-                                      members: [create(:member)])
+                                      members: [build(:member)])
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
@@ -68,7 +68,7 @@ RSpec.describe Medicaid::InsuranceCurrentTypeController do
       it "redirects to next step" do
         medicaid_application = create(:medicaid_application,
                                       anyone_insured: false,
-                                      members: [create(:member)])
+                                      members: [build(:member)])
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit

--- a/spec/controllers/medicaid/insurance_needed_controller_spec.rb
+++ b/spec/controllers/medicaid/insurance_needed_controller_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe Medicaid::InsuranceNeededController do
       it "redirects to the next page" do
         medicaid_application = create(
           :medicaid_application,
-          members: [create(:member)],
+          members: [build(:member)],
         )
+
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
@@ -28,7 +29,7 @@ RSpec.describe Medicaid::InsuranceNeededController do
       it "renders edit" do
         medicaid_application = create(
           :medicaid_application,
-          members: create_list(:member, 2),
+          members: build_list(:member, 2),
         )
         session[:medicaid_application_id] = medicaid_application.id
 

--- a/spec/controllers/medicaid/intro_caretaker_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_caretaker_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Medicaid::IntroCaretakerController do
       it "redirects to the next page" do
         medicaid_application = create(
           :medicaid_application,
-            members: [create(:member)],
+            members: [build(:member)],
         )
         session[:medicaid_application_id] = medicaid_application.id
 
@@ -26,7 +26,7 @@ RSpec.describe Medicaid::IntroCaretakerController do
       it "renders edit" do
         medicaid_application = create(
           :medicaid_application,
-            members: create_list(:member, 2),
+            members: build_list(:member, 2),
         )
         session[:medicaid_application_id] = medicaid_application.id
 

--- a/spec/controllers/medicaid/intro_citizen_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_citizen_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Medicaid::IntroCitizenController, type: :controller do
     context "multi member househoold" do
       context "everyone a citizen" do
         it "updates the members" do
-          members = create_list(:member, 2)
+          members = build_list(:member, 2)
 
           medicaid_application = create(
             :medicaid_application,
@@ -33,7 +33,7 @@ RSpec.describe Medicaid::IntroCitizenController, type: :controller do
     context "single member household" do
       context "is a citizen" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,
@@ -51,7 +51,7 @@ RSpec.describe Medicaid::IntroCitizenController, type: :controller do
 
       context "is not a citizen" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,

--- a/spec/controllers/medicaid/intro_citizen_member_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_citizen_member_controller_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Medicaid::IntroCitizenMemberController, type: :controller do
             :medicaid_application,
             everyone_a_citizen: false,
           )
-          create_list(:member, 2, benefit_application: medicaid_application)
+          build_list(:member, 2, benefit_application: medicaid_application)
           session[:medicaid_application_id] = medicaid_application.id
 
           get :edit
@@ -41,7 +41,7 @@ RSpec.describe Medicaid::IntroCitizenMemberController, type: :controller do
       context "single member household" do
         context "member is a citizen" do
           it "skips this page" do
-            member = create(:member, citizen: true)
+            member = build(:member, citizen: true)
             medicaid_application = create(
               :medicaid_application,
               members: [member],
@@ -57,7 +57,7 @@ RSpec.describe Medicaid::IntroCitizenMemberController, type: :controller do
 
         context "not a citizen" do
           it "skips this page" do
-            member = create(:member, citizen: false)
+            member = build(:member, citizen: false)
             medicaid_application = create(
               :medicaid_application,
               members: [member],

--- a/spec/controllers/medicaid/intro_college_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_college_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Medicaid::IntroCollegeController do
     context "single member household" do
       context "anyone in college" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,
@@ -23,7 +23,7 @@ RSpec.describe Medicaid::IntroCollegeController do
 
       context "nobody in college" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,

--- a/spec/controllers/medicaid/intro_marital_status_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_marital_status_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Medicaid::IntroMaritalStatusController do
     context "single member household" do
       context "anyone married" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,
@@ -23,7 +23,7 @@ RSpec.describe Medicaid::IntroMaritalStatusController do
 
       context "nobody married" do
         it "updates the member" do
-          member = create(:member)
+          member = build(:member)
 
           medicaid_application = create(
             :medicaid_application,

--- a/spec/controllers/medicaid/intro_marital_status_indicate_spouse_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_marital_status_indicate_spouse_controller_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouseController do
       it "skips this page" do
         medicaid_application = create(
           :medicaid_application,
-          members: [create(:member)],
+          members: [build(:member)],
           anyone_married: true,
         )
 
@@ -83,7 +83,7 @@ RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouseController do
             :medicaid_application,
             anyone_married: true,
           )
-          create_list(:member, 2, benefit_application: medicaid_application)
+          build_list(:member, 2, benefit_application: medicaid_application)
           session[:medicaid_application_id] = medicaid_application.id
 
           get :edit
@@ -98,7 +98,7 @@ RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouseController do
             :medicaid_application,
             anyone_married: false,
           )
-          create_list(:member, 2, benefit_application: medicaid_application)
+          build_list(:member, 2, benefit_application: medicaid_application)
           session[:medicaid_application_id] = medicaid_application.id
 
           get :edit

--- a/spec/controllers/medicaid/tax_claimed_as_dependent_controller_spec.rb
+++ b/spec/controllers/medicaid/tax_claimed_as_dependent_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Medicaid::TaxClaimedAsDependentController do
   describe "#update" do
     context "claimed as dependent" do
       it "updates the primary member" do
-        member = create(:member)
+        member = build(:member)
 
         medicaid_application = create(
           :medicaid_application,
@@ -30,7 +30,7 @@ RSpec.describe Medicaid::TaxClaimedAsDependentController do
 
     context "not claimed as dependent" do
       it "updates the primary member" do
-        member = create(:member)
+        member = build(:member)
 
         medicaid_application = create(
           :medicaid_application,
@@ -52,7 +52,7 @@ RSpec.describe Medicaid::TaxClaimedAsDependentController do
       it "skips this page" do
         medicaid_application = create(
           :medicaid_application,
-          members: [create(:member)],
+          members: [build(:member)],
           filing_federal_taxes_next_year: true,
         )
         session[:medicaid_application_id] = medicaid_application.id
@@ -67,7 +67,7 @@ RSpec.describe Medicaid::TaxClaimedAsDependentController do
       it "renders edit" do
         medicaid_application = create(
           :medicaid_application,
-          members: [create(:member)],
+          members: [build(:member)],
           filing_federal_taxes_next_year: false,
         )
         session[:medicaid_application_id] = medicaid_application.id

--- a/spec/controllers/medicaid/tax_filing_with_household_members_controller_spec.rb
+++ b/spec/controllers/medicaid/tax_filing_with_household_members_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersController do
       it "updates the application" do
         medicaid_application = create(
           :medicaid_application,
-          members: create_list(:member, 2),
+          members: build_list(:member, 2),
         )
         session[:medicaid_application_id] = medicaid_application.id
 
@@ -34,7 +34,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersController do
       it "updates the application" do
         medicaid_application = create(
           :medicaid_application,
-          members: create_list(:member, 2),
+          members: build_list(:member, 2),
         )
         session[:medicaid_application_id] = medicaid_application.id
 
@@ -56,7 +56,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersController do
       it "skips this page" do
         medicaid_application = create(
           :medicaid_application,
-          members: [create(:member)],
+          members: [build(:member)],
           filing_federal_taxes_next_year: true,
         )
         session[:medicaid_application_id] = medicaid_application.id
@@ -72,7 +72,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersController do
         it "skips this page" do
           medicaid_application = create(
             :medicaid_application,
-            members: create_list(:member, 2),
+            members: build_list(:member, 2),
             filing_federal_taxes_next_year: false,
           )
           session[:medicaid_application_id] = medicaid_application.id
@@ -87,7 +87,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersController do
         it "renders edit" do
           medicaid_application = create(
             :medicaid_application,
-            members: create_list(:member, 2),
+            members: build_list(:member, 2),
             filing_federal_taxes_next_year: true,
           )
           session[:medicaid_application_id] = medicaid_application.id

--- a/spec/controllers/medicaid/tax_filing_with_household_members_member_controller_spec.rb
+++ b/spec/controllers/medicaid/tax_filing_with_household_members_member_controller_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersMemberController do
       it "skips this page" do
         medicaid_application = create(
           :medicaid_application,
-          members: [create(:member)],
+          members: [build(:member)],
           filing_federal_taxes_next_year: true,
         )
         session[:medicaid_application_id] = medicaid_application.id
@@ -30,7 +30,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersMemberController do
         it "skips this page" do
           medicaid_application = create(
             :medicaid_application,
-            members: create_list(:member, 2),
+            members: build_list(:member, 2),
             filing_federal_taxes_next_year: false,
           )
           session[:medicaid_application_id] = medicaid_application.id
@@ -46,7 +46,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersMemberController do
           it "renders edit" do
             medicaid_application = create(
               :medicaid_application,
-              members: create_list(:member, 2),
+              members: build_list(:member, 2),
               filing_federal_taxes_next_year: true,
               filing_taxes_with_household_members: true,
             )
@@ -62,7 +62,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersMemberController do
           it "skips this page" do
             medicaid_application = create(
               :medicaid_application,
-              members: create_list(:member, 2),
+              members: build_list(:member, 2),
               filing_federal_taxes_next_year: true,
               filing_taxes_with_household_members: false,
             )

--- a/spec/controllers/medicaid/tax_filing_with_household_members_relationship_controller_spec.rb
+++ b/spec/controllers/medicaid/tax_filing_with_household_members_relationship_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersRelationshipController do
           it "skips this page" do
             medicaid_application = create(
               :medicaid_application,
-              members: create_list(:member, 2),
+              members: build_list(:member, 2),
               filing_federal_taxes_next_year: false,
             )
             session[:medicaid_application_id] = medicaid_application.id
@@ -123,7 +123,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersRelationshipController do
           it "skips this page" do
             medicaid_application = create(
               :medicaid_application,
-              members: create_list(:member, 2),
+              members: build_list(:member, 2),
               filing_federal_taxes_next_year: true,
               filing_taxes_with_household_members: false,
             )
@@ -140,7 +140,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersRelationshipController do
         it "skips this page" do
           medicaid_application = create(
             :medicaid_application,
-            members: [create(:member)],
+            members: [build(:member)],
             filing_federal_taxes_next_year: true,
             filing_taxes_with_household_members: true,
           )

--- a/spec/controllers/medicaid/tax_overview_controller_spec.rb
+++ b/spec/controllers/medicaid/tax_overview_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Medicaid::TaxOverviewController do
   describe "#skip" do
     it "is false if has any dependents" do
       medicaid_application = create(:medicaid_application)
-      create(:member, benefit_application: medicaid_application)
+      build(:member, benefit_application: medicaid_application)
       create(
         :member,
         claimed_as_dependent: true,
@@ -17,7 +17,7 @@ RSpec.describe Medicaid::TaxOverviewController do
 
     it "is true if single member household" do
       medicaid_application = create(:medicaid_application)
-      create(:member, benefit_application: medicaid_application)
+      build(:member, benefit_application: medicaid_application)
       session[:medicaid_application_id] = medicaid_application.id
 
       expect(subject.skip?).to eq true
@@ -30,7 +30,7 @@ RSpec.describe Medicaid::TaxOverviewController do
           filing_federal_taxes_next_year: true,
           filing_taxes_with_household_members: true,
         )
-        create_list(:member, 2, benefit_application: medicaid_application)
+        build_list(:member, 2, benefit_application: medicaid_application)
         session[:medicaid_application_id] = medicaid_application.id
 
         expect(subject.skip?).to eq false
@@ -42,7 +42,7 @@ RSpec.describe Medicaid::TaxOverviewController do
           filing_federal_taxes_next_year: false,
           filing_taxes_with_household_members: true,
         )
-        create_list(:member, 2, benefit_application: medicaid_application)
+        build_list(:member, 2, benefit_application: medicaid_application)
         session[:medicaid_application_id] = medicaid_application.id
 
         expect(subject.skip?).to eq true
@@ -54,7 +54,7 @@ RSpec.describe Medicaid::TaxOverviewController do
           filing_federal_taxes_next_year: true,
           filing_taxes_with_household_members: false,
         )
-        create_list(:member, 2, benefit_application: medicaid_application)
+        build_list(:member, 2, benefit_application: medicaid_application)
         session[:medicaid_application_id] = medicaid_application.id
 
         expect(subject.skip?).to eq true
@@ -62,7 +62,7 @@ RSpec.describe Medicaid::TaxOverviewController do
 
       it "is true if not filing federal taxes next year" do
         medicaid_application = create(:medicaid_application)
-        create_list(:member, 2, benefit_application: medicaid_application)
+        build_list(:member, 2, benefit_application: medicaid_application)
         session[:medicaid_application_id] = medicaid_application.id
       end
     end

--- a/spec/controllers/personal_detail_controller_spec.rb
+++ b/spec/controllers/personal_detail_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe PersonalDetailController do
   end
 
   def member
-    create(:member,
+    build(:member,
            sex: "male",
            marital_status: "Married",
            ssn: "123456789")

--- a/spec/factories/member.rb
+++ b/spec/factories/member.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     sex "female"
     marital_status "Widowed"
     birthday { DateTime.parse("August 18, 1990") }
-    benefit_application { create(:snap_application) }
 
     trait :female do
       sex "female"

--- a/spec/features/admin_dashboard_members_spec.rb
+++ b/spec/features/admin_dashboard_members_spec.rb
@@ -15,8 +15,19 @@ RSpec.feature "Admins can view members" do
   end
 
   scenario "Members are listed" do
-    john = create(:member, first_name: "john", last_name: "doe")
-    joe  = create(:member, first_name: "joe", last_name: "schmoe")
+    benefit_application = build(:medicaid_application)
+    john = create(
+      :member,
+      first_name: "john",
+      last_name: "doe",
+      benefit_application: benefit_application,
+    )
+    joe = create(
+      :member,
+      first_name: "joe",
+      last_name: "schmoe",
+      benefit_application: benefit_application,
+    )
 
     visit admin_members_path
 

--- a/spec/features/admin_medicaid_applications_dashboard_spec.rb
+++ b/spec/features/admin_medicaid_applications_dashboard_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "Admin viewing medicaid applications dashboard", type: :feature do
   scenario "downloads the 1426 PDF application", javascript: true do
     application = create(
       :medicaid_application,
-      members: [create(:member, first_name: "Christa", last_name: "Tester")],
+      members: [build(:member, first_name: "Christa", last_name: "Tester")],
     )
 
     visit admin_root_path

--- a/spec/models/dhs1171_pdf_spec.rb
+++ b/spec/models/dhs1171_pdf_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dhs1171Pdf do
     it "writes application info to file" do
       mailing_address = build(:mailing_address)
       residential_address = build(:residential_address)
-      member = create(:member, ssn: "012345678")
+      member = build(:member, ssn: "012345678")
       snap_application = create(
         :snap_application,
         addresses: [mailing_address, residential_address],
@@ -69,8 +69,8 @@ RSpec.describe Dhs1171Pdf do
 
     context "multiple household members" do
       it "returns attributes for each member" do
-        first_member = create(:member, ssn: "555555555")
-        second_member = create(:member, ssn: "444444444")
+        first_member = build(:member, ssn: "555555555")
+        second_member = build(:member, ssn: "444444444")
         snap_application =
           create(:snap_application, members: [first_member, second_member])
 
@@ -113,9 +113,9 @@ RSpec.describe Dhs1171Pdf do
 
     context "employed and self employed household members" do
       it "returns attributes for each member" do
-        employed_member = create(:member, employment_status: "employed")
+        employed_member = build(:member, employment_status: "employed")
         self_employed_member =
-          create(:member, employment_status: "self_employed")
+          build(:member, employment_status: "self_employed")
         snap_application = create(
           :snap_application,
           members: [self_employed_member, employed_member],
@@ -172,7 +172,7 @@ RSpec.describe Dhs1171Pdf do
     end
 
     it "appends pages if there are more than 6 household members" do
-      members = create_list(:member, 8)
+      members = build_list(:member, 8)
       snap_application = create(:snap_application, members: members)
       original_length = PDF::Reader.new(Dhs1171Pdf::SOURCE_PDF).page_count
 
@@ -183,7 +183,7 @@ RSpec.describe Dhs1171Pdf do
     end
 
     it "appends pages if there are more than 2 employed members" do
-      members = create_list(:member, 3, employment_status: "employed")
+      members = build_list(:member, 3, employment_status: "employed")
       snap_application = create(:snap_application, members: members)
       original_length = PDF::Reader.new(Dhs1171Pdf::SOURCE_PDF).page_count
 
@@ -194,7 +194,7 @@ RSpec.describe Dhs1171Pdf do
     end
 
     it "appends pages if there are more than 2 self-employed members" do
-      members = create_list(:member, 3, employment_status: "self_employed")
+      members = build_list(:member, 3, employment_status: "self_employed")
       snap_application = create(:snap_application, members: members)
       original_length = PDF::Reader.new(Dhs1171Pdf::SOURCE_PDF).page_count
 

--- a/spec/models/dhs1426_pdf_spec.rb
+++ b/spec/models/dhs1426_pdf_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Dhs1426Pdf do
 
   describe "#completed_file" do
     it "writes application data to file" do
-      primary_member = create(
+      primary_member = build(
         :member,
         first_name: "Christa",
         last_name: "Tester",
@@ -15,7 +15,6 @@ RSpec.describe Dhs1426Pdf do
         married: true,
         caretaker_or_parent: true,
         in_college: true,
-        spouse: create(:member, first_name: "Candy", last_name: "Crush"),
         ssn: "111223333",
         new_mom: true,
         requesting_health_insurance: true,
@@ -40,12 +39,13 @@ RSpec.describe Dhs1426Pdf do
         pay_student_loan_interest: true,
         student_loan_interest_expenses: 70,
       )
-      secondary_member = create(
+      secondary_member = build(
         :member,
         first_name: "Roger",
         last_name: "Rabbit",
         birthday: Date.new(1980, 1, 20),
         sex: "male",
+        spouse: primary_member,
         married: false,
         caretaker_or_parent: false,
         in_college: false,
@@ -75,7 +75,7 @@ RSpec.describe Dhs1426Pdf do
         primary_member_sex_female: "Yes",
         primary_member_married_yes: "Yes",
         primary_member_married_no: nil,
-        primary_member_spouse_name: "Candy Crush",
+        primary_member_spouse_name: nil,
         primary_member_caretaker_yes: "Yes",
         primary_member_caretaker_no: nil,
         primary_member_in_college_yes: "Yes",
@@ -102,7 +102,7 @@ RSpec.describe Dhs1426Pdf do
         second_member_sex_female: nil,
         second_member_married_yes: nil,
         second_member_married_no: "Yes",
-        second_member_spouse_name: nil,
+        second_member_spouse_name: "Christa Tester",
         second_member_caretaker_yes: nil,
         second_member_caretaker_no: "Yes",
         second_member_in_college_yes: nil,
@@ -272,7 +272,7 @@ RSpec.describe Dhs1426Pdf do
     end
 
     it "appends pages if there are more than 2 household members" do
-      members = create_list(:member, 4)
+      members = build_list(:member, 4)
       medicaid_application = create(:medicaid_application, members: members)
       original_length = PDF::Reader.new(Dhs1426Pdf::SOURCE_PDF).page_count
 
@@ -285,10 +285,10 @@ RSpec.describe Dhs1426Pdf do
 
     it "prepends the additional member page fields with numbers" do
       members = [
-        create(:member, first_name: "Primera"),
-        create(:member, first_name: "Segunda"),
-        create(:member, first_name: "Tercera"),
-        create(:member, first_name: "Cuarta"),
+        build(:member, first_name: "Primera"),
+        build(:member, first_name: "Segunda"),
+        build(:member, first_name: "Tercera"),
+        build(:member, first_name: "Cuarta"),
       ]
       medicaid_application = create(:medicaid_application, members: members)
       file = Dhs1426Pdf.new(medicaid_application: medicaid_application).

--- a/spec/models/employed_member_attributes_spec.rb
+++ b/spec/models/employed_member_attributes_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe EmployedMemberAttributes do
   describe "#to_h" do
     it "returns the correct attributes prepended with the position" do
-      member = create(
+      member = build(
         :member,
         employment_status: "employed",
         first_name: "Foo",

--- a/spec/models/medicaid_application_member_attributes_spec.rb
+++ b/spec/models/medicaid_application_member_attributes_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe MedicaidApplicationMemberAttributes do
   describe "#to_h" do
     it "returns the member attributes as a hash" do
-      member = create(
+      member = build(
         :member,
         first_name: "First",
         last_name: "Last",
@@ -12,7 +12,7 @@ RSpec.describe MedicaidApplicationMemberAttributes do
         married: true,
         caretaker_or_parent: true,
         in_college: true,
-        spouse: create(:member, first_name: "Candy", last_name: "Crush"),
+        spouse: build(:member, first_name: "Candy", last_name: "Crush"),
         ssn: "111223333",
         new_mom: true,
         requesting_health_insurance: true,
@@ -95,7 +95,7 @@ RSpec.describe MedicaidApplicationMemberAttributes do
 
     context "nil birthday" do
       it "it does not return keys for age-related questions" do
-        member = create(:member, birthday: nil)
+        member = build(:member, birthday: nil)
 
         result = MedicaidApplicationMemberAttributes.new(
           member: member,

--- a/spec/models/medicaid_application_spec.rb
+++ b/spec/models/medicaid_application_spec.rb
@@ -3,8 +3,8 @@ require "rails_helper"
 RSpec.describe MedicaidApplication do
   describe "#members" do
     it "returns them created_at ascending order" do
-      old_member = create(:member, created_at: 1.year.ago)
-      new_member = create(:member, created_at: 1.day.ago)
+      old_member = build(:member, created_at: 1.year.ago)
+      new_member = build(:member, created_at: 1.day.ago)
       medicaid_app = create(
         :medicaid_application,
         members: [old_member, new_member],

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -4,10 +4,15 @@ RSpec.describe Member do
   describe "scopes" do
     describe ".filing_taxes" do
       it "returns members filing taxes as Single or Joint" do
-        _no_relationship = create(:member, tax_relationship: nil)
-        _dependent = create(:member, tax_relationship: "Dependent")
-        filing1 = create(:member, tax_relationship: "Single")
-        filing2 = create(:member, tax_relationship: "Joint")
+        no_relationship = build(:member, tax_relationship: nil)
+        dependent = build(:member, tax_relationship: "Dependent")
+        filing1 = build(:member, tax_relationship: "Single")
+        filing2 = build(:member, tax_relationship: "Joint")
+
+        create(
+          :snap_application,
+          members: [no_relationship, dependent, filing1, filing2],
+        )
 
         expect(Member.filing_taxes).to eq [filing1, filing2]
       end
@@ -15,10 +20,14 @@ RSpec.describe Member do
 
     describe ".dependents" do
       it "returns members that are dependents of primary applicant" do
-        _no_relationship = create(:member, tax_relationship: nil)
-        dependent = create(:member, tax_relationship: "Dependent")
-        _filing1 = create(:member, tax_relationship: "Single")
-        _filing2 = create(:member, tax_relationship: "Joint")
+        no_relationship = build(:member, tax_relationship: nil)
+        dependent = build(:member, tax_relationship: "Dependent")
+        filing1 = build(:member, tax_relationship: "Single")
+        filing2 = build(:member, tax_relationship: "Joint")
+        create(
+          :snap_application,
+          members: [no_relationship, dependent, filing1, filing2],
+        )
 
         expect(Member.dependents).to eq [dependent]
       end
@@ -26,10 +35,14 @@ RSpec.describe Member do
 
     describe ".no_tax_relationship" do
       it "returns members NOT filing taxes with primary applicant" do
-        no_relationship = create(:member, tax_relationship: nil)
-        _dependent = create(:member, tax_relationship: "Dependent")
-        _filing1 = create(:member, tax_relationship: "Single")
-        _filing2 = create(:member, tax_relationship: "Joint")
+        no_relationship = build(:member, tax_relationship: nil)
+        dependent = build(:member, tax_relationship: "Dependent")
+        filing1 = build(:member, tax_relationship: "Single")
+        filing2 = build(:member, tax_relationship: "Joint")
+        create(
+          :snap_application,
+          members: [no_relationship, dependent, filing1, filing2],
+        )
 
         expect(Member.no_tax_relationship).to eq [no_relationship]
       end
@@ -37,9 +50,12 @@ RSpec.describe Member do
 
     describe ".first_insurance_holder" do
       it "returns the first member that is insured" do
-        create(:member, insured: false, requesting_health_insurance: true)
-        create(:member, insured: true, requesting_health_insurance: false)
-        joel = create(:member, insured: true, requesting_health_insurance: true)
+        first =
+          build(:member, insured: false, requesting_health_insurance: true)
+        second =
+          build(:member, insured: true, requesting_health_insurance: false)
+        joel = build(:member, insured: true, requesting_health_insurance: true)
+        create(:snap_application, members: [first, second, joel])
 
         expect(Member.insured).to eq [joel]
       end
@@ -47,9 +63,10 @@ RSpec.describe Member do
 
     describe ".after" do
       it "returns the next member _after_ the provided member" do
-        joel = create(:member)
-        jessie = create(:member)
-        christa = create(:member)
+        joel = build(:member)
+        jessie = build(:member)
+        christa = build(:member)
+        create(:snap_application, members: [joel, jessie, christa])
 
         expect(Member.after(joel)).to eq [jessie, christa]
         expect(Member.after(jessie)).to eq [christa]

--- a/spec/models/self_employed_member_attributes_spec.rb
+++ b/spec/models/self_employed_member_attributes_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe SelfEmployedMemberAttributes do
   describe "#to_h" do
     it "returns the correct attributes prepended with the position" do
-      member = create(
+      member = build(
         :member,
         employment_status: "self_employed",
         first_name: "Boo",

--- a/spec/models/snap_application_member_attributes_spec.rb
+++ b/spec/models/snap_application_member_attributes_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe SnapApplicationMemberAttributes do
   describe "#to_h" do
     it "returns the member attributes as a hash" do
-      member = create(
+      member = build(
         :member,
         first_name: "First",
         last_name: "Last",
@@ -56,7 +56,7 @@ RSpec.describe SnapApplicationMemberAttributes do
 
     context "nil SSN" do
       it "does not error" do
-        member = create(
+        member = build(
           :member,
           ssn: nil,
         )

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe SnapApplication do
 
     context "members present" do
       it "adds members' monthly income" do
-        member = create(:member)
+        member = build(:member)
         app = create(:snap_application, members: [member])
         allow(member).to receive(:monthly_income).and_return(100)
 

--- a/spec/steps/income_details_per_member_spec.rb
+++ b/spec/steps/income_details_per_member_spec.rb
@@ -3,12 +3,12 @@ require "rails_helper"
 RSpec.describe IncomeDetailsPerMember do
   describe "Validations" do
     it "validates employer name on employed members" do
-      working = create(
+      working = build(
         :member,
         employment_status: "employed",
         employed_employer_name: nil,
       )
-      self_employed = create(
+      self_employed = build(
         :member,
         employment_status: "self_employed",
         employed_employer_name: nil,

--- a/spec/steps/medicaid/amounts_income_spec.rb
+++ b/spec/steps/medicaid/amounts_income_spec.rb
@@ -3,7 +3,11 @@ require "rails_helper"
 RSpec.describe Medicaid::AmountsIncome do
   context "has 2 jobs" do
     it "validates that there is income for 2 jobs" do
-      member = create(:member, employed_number_of_jobs: 2)
+      member = create(
+        :member,
+        employed_number_of_jobs: 2,
+        benefit_application: build(:medicaid_application),
+      )
 
       step = Medicaid::AmountsIncome.new(
         member_id: member.id,
@@ -18,7 +22,11 @@ RSpec.describe Medicaid::AmountsIncome do
 
   context "fills out only one job's info" do
     it "invalidates the object because 1 income amount is missing" do
-      member = create(:member, employed_number_of_jobs: 2)
+      member = create(
+        :member,
+        employed_number_of_jobs: 2,
+        benefit_application: build(:medicaid_application),
+      )
 
       step = Medicaid::AmountsIncome.new(
         member_id: member.id,
@@ -34,7 +42,11 @@ RSpec.describe Medicaid::AmountsIncome do
 
   context "empty strings" do
     it "is invalid" do
-      member = create(:member, employed_number_of_jobs: 2)
+      member = create(
+        :member,
+        employed_number_of_jobs: 2,
+        benefit_application: build(:medicaid_application),
+      )
 
       step = Medicaid::AmountsIncome.new(
         member_id: member.id,
@@ -50,7 +62,11 @@ RSpec.describe Medicaid::AmountsIncome do
 
   context "member receives unemployment" do
     it "is valid if the amount is provided" do
-      member = create(:member, other_income_types: %w(unemployment))
+      member = create(
+        :member,
+        other_income_types: %w(unemployment),
+        benefit_application: build(:medicaid_application),
+      )
 
       step = Medicaid::AmountsIncome.new(
         member_id: member.id,
@@ -61,7 +77,11 @@ RSpec.describe Medicaid::AmountsIncome do
     end
 
     it "is invalid if the amount is not provided" do
-      member = create(:member, other_income_types: %w(unemployment))
+      member = create(
+        :member,
+        other_income_types: %w(unemployment),
+        benefit_application: build(:medicaid_application),
+      )
 
       step = Medicaid::AmountsIncome.new(
         member_id: member.id,
@@ -74,7 +94,11 @@ RSpec.describe Medicaid::AmountsIncome do
 
   context "member is self-employed" do
     it "is valid if the amount is provided" do
-      member = create(:member, self_employed: true)
+      member = create(
+        :member,
+        self_employed: true,
+        benefit_application: build(:medicaid_application),
+      )
 
       step = Medicaid::AmountsIncome.new(
         member_id: member.id,
@@ -85,7 +109,11 @@ RSpec.describe Medicaid::AmountsIncome do
     end
 
     it "is invalid if self-employment income is not provided" do
-      member = create(:member, self_employed: true)
+      member = create(
+        :member,
+        self_employed: true,
+        benefit_application: build(:medicaid_application),
+      )
 
       step = Medicaid::AmountsIncome.new(
         member_id: member.id,

--- a/spec/steps/medicaid/income_other_income_member_spec.rb
+++ b/spec/steps/medicaid/income_other_income_member_spec.rb
@@ -4,8 +4,17 @@ RSpec.describe Medicaid::IncomeOtherIncomeMember do
   describe "Validations" do
     context "at least one household member has other income" do
       it "is valid" do
-        member = create(:member, other_income: true)
-        member_not_other_income = create(:member, other_income: nil)
+        benefit_application = build(:medicaid_application)
+        member = build(
+          :member,
+          other_income: true,
+          benefit_application: benefit_application,
+        )
+        member_not_other_income = build(
+          :member,
+          other_income: nil,
+          benefit_application: benefit_application,
+        )
 
         step = Medicaid::IncomeOtherIncomeMember.new(
           members: [member, member_not_other_income],
@@ -17,7 +26,12 @@ RSpec.describe Medicaid::IncomeOtherIncomeMember do
 
     context "no household member has other income" do
       it "is invalid" do
-        members = create_list(:member, 2, other_income: nil)
+        members = create_list(
+          :member,
+          2,
+          other_income: nil,
+          benefit_application: build(:medicaid_application),
+        )
 
         step = Medicaid::IncomeOtherIncomeMember.new(members: members)
 

--- a/spec/steps/medicaid/income_other_income_type_spec.rb
+++ b/spec/steps/medicaid/income_other_income_type_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe Medicaid::IncomeOtherIncomeType do
   describe "Validations" do
     context "the household member has other income" do
       it "is valid" do
-        member = create(:member, other_income: true)
+        benefit_application = build(:medicaid_application)
+        member = create(
+          :member,
+          other_income: true,
+          benefit_application: benefit_application,
+        )
 
         step = Medicaid::IncomeOtherIncomeType.new(
           member_id: member.id,
@@ -17,10 +22,12 @@ RSpec.describe Medicaid::IncomeOtherIncomeType do
 
     context "a member with other income is missing an other income type" do
       it "is invalid" do
+        benefit_application = build(:medicaid_application)
         member = create(
           :member,
           other_income: true,
           other_income_types: [],
+          benefit_application: benefit_application,
         )
 
         step = Medicaid::IncomeOtherIncomeType.new(

--- a/spec/steps/medicaid/income_self_employment_member_spec.rb
+++ b/spec/steps/medicaid/income_self_employment_member_spec.rb
@@ -4,8 +4,17 @@ RSpec.describe Medicaid::IncomeSelfEmploymentMember do
   describe "Validations" do
     context "at least one household member is self employed" do
       it "is valid" do
-        member = create(:member, self_employed: true)
-        member_not_self_employed = create(:member, self_employed: nil)
+        benefit_application = build(:medicaid_application)
+        member = create(
+          :member,
+          self_employed: true,
+          benefit_application: benefit_application,
+        )
+        member_not_self_employed = create(
+          :member,
+          self_employed: nil,
+          benefit_application: benefit_application,
+        )
 
         step = Medicaid::IncomeSelfEmploymentMember.new(
           members: [member, member_not_self_employed],
@@ -17,7 +26,12 @@ RSpec.describe Medicaid::IncomeSelfEmploymentMember do
 
     context "no household member is self employed" do
       it "is invalid" do
-        members = create_list(:member, 2, self_employed: nil)
+        members = create_list(
+          :member,
+          2,
+          self_employed: nil,
+          benefit_application: build(:medicaid_application),
+        )
 
         step = Medicaid::IncomeSelfEmploymentMember.new(members: members)
 

--- a/spec/steps/medicaid/insurance_current_member_spec.rb
+++ b/spec/steps/medicaid/insurance_current_member_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Medicaid::InsuranceCurrentMember do
   describe "Validations" do
     context "at least one household member is insured" do
       it "is valid" do
-        member = create(:member,
+        member = build(:member,
                         requesting_health_insurance: true,
                         insured: true)
-        member_not_insured = create(:member,
+        member_not_insured = build(:member,
                                     requesting_health_insurance: true,
                                     insured: false)
 
@@ -21,7 +21,7 @@ RSpec.describe Medicaid::InsuranceCurrentMember do
 
     context "no household member is insured" do
       it "is invalid" do
-        members = create_list(:member, 2,
+        members = build_list(:member, 2,
                               requesting_health_insurance: true,
                               insured: false)
 

--- a/spec/steps/medicaid/insurance_current_type_spec.rb
+++ b/spec/steps/medicaid/insurance_current_type_spec.rb
@@ -4,9 +4,13 @@ RSpec.describe Medicaid::InsuranceCurrentType do
   describe "Validations" do
     context "the household member has an insurance type" do
       it "is valid" do
-        member = create(:member,
-                        insured: true,
-                        requesting_health_insurance: true)
+        benefit_application = build(:medicaid_application)
+        member = create(
+          :member,
+          insured: true,
+          requesting_health_insurance: true,
+          benefit_application: benefit_application,
+        )
 
         step = Medicaid::InsuranceCurrentType.new(
           member_id: member.id,
@@ -19,9 +23,13 @@ RSpec.describe Medicaid::InsuranceCurrentType do
 
     context "an insured household member is missing an insurance type" do
       it "is invalid" do
-        insured_member_without_type = create(:member,
-                                             insured: true,
-                                             requesting_health_insurance: true)
+        benefit_application = build(:medicaid_application)
+        insured_member_without_type = create(
+          :member,
+          insured: true,
+          requesting_health_insurance: true,
+          benefit_application: benefit_application,
+        )
 
         step = Medicaid::InsuranceCurrentType.new(
           member_id: insured_member_without_type.id,

--- a/spec/steps/medicaid/insurance_needed_spec.rb
+++ b/spec/steps/medicaid/insurance_needed_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Medicaid::InsuranceNeeded do
   describe "Validations" do
     context "at least one household member needs insurance" do
       it "is valid" do
-        member = create(:member, requesting_health_insurance: true)
+        member = build(:member, requesting_health_insurance: true)
         member_not_requesting =
-          create(:member, requesting_health_insurance: false)
+          build(:member, requesting_health_insurance: false)
 
         step = Medicaid::InsuranceNeeded.new(
           members: [member, member_not_requesting],
@@ -18,7 +18,7 @@ RSpec.describe Medicaid::InsuranceNeeded do
 
     context "no household members need insurance" do
       it "is invalid" do
-        members = create_list(:member, 2, requesting_health_insurance: false)
+        members = build_list(:member, 2, requesting_health_insurance: false)
 
         step = Medicaid::InsuranceNeeded.new(members: members)
 

--- a/spec/steps/medicaid/intro_caretaker_member_spec.rb
+++ b/spec/steps/medicaid/intro_caretaker_member_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Medicaid::IntroCaretakerMember do
   describe "Validations" do
     context "at least one household member is a caretaker or parent" do
       it "is valid" do
-        member = create(:member, caretaker_or_parent: true)
+        member = build(:member, caretaker_or_parent: true)
         member_not_caretaker_or_parent =
-          create(:member, caretaker_or_parent: false)
+          build(:member, caretaker_or_parent: false)
 
         step = Medicaid::IntroCaretakerMember.new(
           members: [member, member_not_caretaker_or_parent],
@@ -18,7 +18,7 @@ RSpec.describe Medicaid::IntroCaretakerMember do
 
     context "no household member is a caretaker or parent" do
       it "is invalid" do
-        members = create_list(:member, 2, caretaker_or_parent: false)
+        members = build_list(:member, 2, caretaker_or_parent: false)
 
         step = Medicaid::IntroCaretakerMember.new(members: members)
 

--- a/spec/steps/medicaid/intro_college_member_spec.rb
+++ b/spec/steps/medicaid/intro_college_member_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Medicaid::IntroCollegeMember do
   describe "Validations" do
     context "at least one household member is a student" do
       it "is valid" do
-        member = create(:member, in_college: true)
+        member = build(:member, in_college: true)
         member_not_in_college =
-          create(:member, in_college: false)
+          build(:member, in_college: false)
 
         step = Medicaid::IntroCollegeMember.new(
           members: [member, member_not_in_college],
@@ -18,7 +18,7 @@ RSpec.describe Medicaid::IntroCollegeMember do
 
     context "no household member is a student" do
       it "is invalid" do
-        members = create_list(:member, 2, in_college: false)
+        members = build_list(:member, 2, in_college: false)
 
         step = Medicaid::IntroCollegeMember.new(members: members)
 

--- a/spec/steps/medicaid/intro_marital_status_indicate_spouse_spec.rb
+++ b/spec/steps/medicaid/intro_marital_status_indicate_spouse_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouse do
   describe "Validations" do
     context "other member is selected" do
       it "is valid" do
-        member = create(:member, married: true)
+        benefit_application = build(:medicaid_application)
+        member = create(
+          :member,
+          married: true,
+          benefit_application: benefit_application,
+        )
 
         step = Medicaid::IntroMaritalStatusIndicateSpouse.new(
           member_id: member.id,
@@ -17,8 +22,17 @@ RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouse do
 
     context "member is selected" do
       it "is valid" do
-        member = create(:member, married: true)
-        spouse_member = create(:member, married: true)
+        benefit_application = build(:medicaid_application)
+        member = create(
+          :member,
+          married: true,
+          benefit_application: benefit_application,
+        )
+        spouse_member = create(
+          :member,
+          married: true,
+          benefit_application: benefit_application,
+        )
 
         step = Medicaid::IntroMaritalStatusIndicateSpouse.new(
           member_id: member.id,
@@ -31,7 +45,12 @@ RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouse do
 
     context "nobody is selected" do
       it "is invalid" do
-        member = create(:member, married: true)
+        benefit_application = build(:medicaid_application)
+        member = create(
+          :member,
+          married: true,
+          benefit_application: benefit_application,
+        )
 
         step = Medicaid::IntroMaritalStatusIndicateSpouse.new(
           member_id: member.id,

--- a/spec/steps/medicaid/intro_marital_status_member_spec.rb
+++ b/spec/steps/medicaid/intro_marital_status_member_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Medicaid::IntroMaritalStatusMember do
   describe "Validations" do
     context "at least one household member is married" do
       it "is valid" do
-        member = create(:member, married: true)
+        member = build(:member, married: true)
         member_not_married =
-          create(:member, married: false)
+          build(:member, married: false)
 
         step = Medicaid::IntroMaritalStatusMember.new(
           members: [member, member_not_married],
@@ -18,7 +18,7 @@ RSpec.describe Medicaid::IntroMaritalStatusMember do
 
     context "no household member is married" do
       it "is invalid" do
-        members = create_list(:member, 2, married: false)
+        members = build_list(:member, 2, married: false)
 
         step = Medicaid::IntroMaritalStatusMember.new(members: members)
 

--- a/spec/support/shared_examples/medicaid_multi_member_step_controller.rb
+++ b/spec/support/shared_examples/medicaid_multi_member_step_controller.rb
@@ -7,7 +7,7 @@ RSpec.shared_examples_for "Medicaid multi-member controller" do |medicaid_attr|
         it "skips this page" do
           medicaid_application = create(
             :medicaid_application,
-            members: create_list(:member, 2),
+            members: build_list(:member, 2),
             medicaid_attr => false,
           )
           session[:medicaid_application_id] = medicaid_application.id
@@ -22,7 +22,7 @@ RSpec.shared_examples_for "Medicaid multi-member controller" do |medicaid_attr|
         it "renders :edit" do
           medicaid_application = create(
             :medicaid_application,
-            members: create_list(:member, 2),
+            members: build_list(:member, 2),
             medicaid_attr => true,
           )
           session[:medicaid_application_id] = medicaid_application.id
@@ -39,7 +39,7 @@ RSpec.shared_examples_for "Medicaid multi-member controller" do |medicaid_attr|
         it "skips this page" do
           medicaid_application = create(
             :medicaid_application,
-            members: [create(:member)],
+            members: [build(:member)],
             medicaid_attr => true,
           )
           session[:medicaid_application_id] = medicaid_application.id
@@ -54,7 +54,7 @@ RSpec.shared_examples_for "Medicaid multi-member controller" do |medicaid_attr|
         it "skips the page" do
           medicaid_application = create(
             :medicaid_application,
-            members: [create(:member)],
+            members: [build(:member)],
             medicaid_attr => false,
           )
           session[:medicaid_application_id] = medicaid_application.id

--- a/spec/views/medicaid/income_other_income_type/edit.html.erb_spec.rb
+++ b/spec/views/medicaid/income_other_income_type/edit.html.erb_spec.rb
@@ -21,7 +21,12 @@ describe "medicaid/income_other_income_type/edit.html.erb" do
 
   context "has not selected another income type" do
     it "shows an error message" do
-      member = create(:member, other_income: true)
+      member = create(
+        :member,
+        other_income: true,
+        benefit_application: build(:medicaid_application),
+      )
+
       step = Medicaid::IncomeOtherIncomeType.new(
         other_income_types: [],
         member_id: member.id,


### PR DESCRIPTION
* [Fixes #153018504]
* The i18n copy was not showing up properly on these pages because
`members_count` was an attribute on steps but by default steps are
initialized with attributes of the `current_application` and
`members_count` was a method rather than an attribute.
* To fix this, I made `members_count` an attribute on the
`medicaid_applications` table. It is a counter cache column so we no
longer need to do a SQL join query each time we ask for `members.count` in
the view, which does a join on `medicaid_application.members` and
returns the count. Now, it just gets the data from a column in the
database.
* Note that we will need to run rails console and `reset_counters` for
all Medicaid and Snap apps once this is deployed. https://apidock.com/rails/ActiveRecord/CounterCache/reset_counters