### PR TITLE
Bugfix: PDF with documents

### DIFF
--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -52,10 +52,6 @@ class MedicaidApplication < ApplicationRecord
     primary_member.display_name
   end
 
-  def birthday
-    primary_member.formatted_birthday
-  end
-
   def primary_member
     members.order(:id).first || NullMember.new
   end

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -135,10 +135,6 @@ class SnapApplication < ApplicationRecord
     primary_member.display_name
   end
 
-  def birthday
-    primary_member.formatted_birthday
-  end
-
   def primary_member
     members.order(:id).first || NullMember.new
   end

--- a/app/models/verification_document.rb
+++ b/app/models/verification_document.rb
@@ -31,7 +31,15 @@ class VerificationDocument
 
   def header
     output = "Name:                  #{benefit_application.display_name}\n"
-    output += "Date of Birth:        #{benefit_application.birthday}\n"
+    output += "Date of Birth:        #{birthday}\n"
     output
+  end
+
+  def birthday
+    if benefit_application.primary_member.birthday.present?
+      benefit_application.primary_member.formatted_birthday
+    else
+      ""
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171120220922) do
+ActiveRecord::Schema.define(version: 20171121231237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,7 +125,6 @@ ActiveRecord::Schema.define(version: 20171120220922) do
     t.boolean "anyone_pay_child_support_alimony_arrears"
     t.boolean "anyone_pay_student_loan_interest"
     t.boolean "anyone_self_employed", default: false
-    t.datetime "birthday"
     t.boolean "consent_to_terms"
     t.datetime "created_at", null: false
     t.string "email"

--- a/spec/models/verification_document_spec.rb
+++ b/spec/models/verification_document_spec.rb
@@ -58,6 +58,31 @@ describe VerificationDocument do
       end
     end
 
+    context "primary member has a nil birthday" do
+      it "does not error" do
+        medicaid_application = create(
+          :medicaid_application,
+          members: [build(:member, birthday: nil)],
+        )
+        document_url = "http://example.com/test.jpg"
+        remote_document = double(
+          :remote_document,
+          tempfile: temp_image_file,
+          pdf?: false,
+        )
+        allow(remote_document).to receive(:download).and_return(remote_document)
+        allow(RemoteDocument).to receive(:new).and_return(remote_document)
+
+        document = VerificationDocument.new(
+          url: document_url,
+          benefit_application: medicaid_application,
+        )
+
+        expect(document.file).to be_a(Tempfile)
+        expect(pdf?(document.file.path)).to eq true
+      end
+    end
+
     def temp_image_file
       Tempfile.new(["image", ".jpg"]).tap do |f|
         f.write(File.read("spec/fixtures/image.jpg"))


### PR DESCRIPTION
* We were getting an error on staging related to a `nil` birthday.
Medicaid applicants will not always have a birthday, so we have to check
for birthday before calling `strftime` on it.
* [Finishes #152564700] (again)
* Also removes unused `birthday` field on `medicaid_applications` table