### PR TITLE
Remove AWS GovCloud from Privacy Policy

### DIFF
--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -161,13 +161,7 @@
       When you enter your information on our site we encrypt the transmission
       of that information using transport layer security (TLS).
     </li>
-    <li>
-      We store your personal information on AWS GovCloud, which is a trusted
-      third party data storage service designed specifically for US government
-      agencies with sensitive information. For more information on see AWS
-      GovCloud security, see:
-      <a href="https://aws.amazon.com/govcloud-us/security">https://aws.amazon.com/govcloud-us/security</a>.
-    </li>
+  </ul>
   <p>
     Although we try our best to protect the privacy of your personal information,
     we cannot guarantee complete security. The transmission of information via
@@ -189,7 +183,7 @@
     Effective Date
   </h3>
   <p>
-    This version of the policy is effective July 10, 2017.
+    This version of the policy is effective November 22, 2017.
   </p>
 
   <h3>


### PR DESCRIPTION
Removes AWS GovCloud reference from our Privacy Policy, since we're not using it!

Also updates the effective date.

Here's what it looks like after the change:
![screen shot 2017-11-22 at 10 46 08 am](https://user-images.githubusercontent.com/3675092/33144775-fb04f476-cf72-11e7-9faa-779456703fee.png)

