### PR TITLE
[PAIR] Do not ask for spouses if we already know spouse

### DIFF
--- a/app/controllers/medicaid/intro_marital_status_indicate_spouse_controller.rb
+++ b/app/controllers/medicaid/intro_marital_status_indicate_spouse_controller.rb
@@ -15,7 +15,8 @@ module Medicaid
 
     def skip?
       single_member_household? ||
-        current_application.nobody_married?
+        current_application.nobody_married? ||
+        current_member.spouse_id.present?
     end
 
     def first_married_member

--- a/app/controllers/medicaid/intro_marital_status_member_controller.rb
+++ b/app/controllers/medicaid/intro_marital_status_member_controller.rb
@@ -2,6 +2,11 @@ module Medicaid
   class IntroMaritalStatusMemberController < Medicaid::ManyMemberStepsController
     private
 
+    def update_application
+      step.members.each { |m| m.spouse_id = nil }
+      super
+    end
+
     def skip?
       single_member_household? || nobody_married?
     end

--- a/app/steps/medicaid/intro_marital_status_indicate_spouse.rb
+++ b/app/steps/medicaid/intro_marital_status_indicate_spouse.rb
@@ -13,9 +13,5 @@ module Medicaid
         errors.add(:spouse, "Make sure you select a person")
       end
     end
-
-    def member
-      @_member ||= Member.find(member_id)
-    end
   end
 end

--- a/spec/controllers/medicaid/intro_marital_status_indicate_spouse_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_marital_status_indicate_spouse_controller_spec.rb
@@ -67,8 +67,8 @@ RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouseController do
           medicaid_application = create(
             :medicaid_application,
             anyone_married: true,
+            members: build_list(:member, 2, married: true),
           )
-          build_list(:member, 2, benefit_application: medicaid_application)
           session[:medicaid_application_id] = medicaid_application.id
 
           get :edit

--- a/spec/controllers/medicaid/intro_marital_status_indicate_spouse_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_marital_status_indicate_spouse_controller_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouseController do
 
       session[:medicaid_application_id] = medicaid_application.id
 
+      get :edit, params: {}
+
       expect(subject.current_member).to eq married_member
     end
 
@@ -28,23 +30,6 @@ RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouseController do
       session[:medicaid_application_id] = medicaid_application.id
 
       get :edit, params: { member: jessie.id }
-
-      expect(subject.current_member).to eq jessie
-    end
-
-    it "finds member from posted form" do
-      medicaid_application = create(:medicaid_application, anyone_married: true)
-      _joel = create(:member, benefit_application: medicaid_application)
-      jessie = create(:member, benefit_application: medicaid_application)
-
-      session[:medicaid_application_id] = medicaid_application.id
-
-      put :update, params: {
-        step: {
-          member_id: jessie.id,
-          spouse_id: "0",
-        },
-      }
 
       expect(subject.current_member).to eq jessie
     end
@@ -102,6 +87,28 @@ RSpec.describe Medicaid::IntroMaritalStatusIndicateSpouseController do
           session[:medicaid_application_id] = medicaid_application.id
 
           get :edit
+
+          expect(response).to redirect_to(subject.next_path)
+        end
+      end
+
+      context "current member has spouse id" do
+        it "skips this page" do
+          member_one = build(
+            :member,
+            married: true,
+            spouse_id: 0,
+          )
+
+          medicaid_application = create(
+            :medicaid_application,
+            anyone_married: true,
+            members: [member_one, build(:member)],
+          )
+
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit, params: { member: member_one }
 
           expect(response).to redirect_to(subject.next_path)
         end

--- a/spec/controllers/medicaid/intro_marital_status_member_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_marital_status_member_controller_spec.rb
@@ -9,6 +9,40 @@ RSpec.describe Medicaid::IntroMaritalStatusMemberController do
     end
   end
 
+  describe "#update" do
+    context "application has spouses specified when revisiting page" do
+      it "clears spouses on all members" do
+        member_one = build(:member, spouse_id: 0)
+        member_two = build(:member, spouse_id: 1)
+
+        medicaid_application = create(
+          :medicaid_application,
+          members: [member_one, member_two],
+        )
+
+        session[:medicaid_application_id] = medicaid_application.id
+
+        put :update, params: {
+          step: {
+            members: {
+              member_one.id => { married: true },
+              member_two.id => { married: false },
+            }
+          }
+        }
+
+        member_one.reload
+        member_two.reload
+
+        expect(member_one.spouse_id).to be_nil
+        expect(member_one.married).to eq true
+        expect(member_two.spouse_id).to be_nil
+        expect(member_two.married).to eq false
+      end
+    end
+  end
+
+
   it_should_behave_like(
     "Medicaid multi-member controller",
     :anyone_married,

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -66,13 +66,6 @@ RSpec.feature "Medicaid app" do
 
     on_page "Introduction" do
       expect(page).to have_content(
-        "Tell us who Christa Tester is currently married to",
-      )
-      click_on "Next"
-    end
-
-    on_page "Introduction" do
-      expect(page).to have_content(
         "Tell us who Joel Tester is currently married to",
       )
       choose "Other - not listed"


### PR DESCRIPTION
 * If we know member1 is married to member2, we previously were asking
 this twice. Now we will skip the step and not ask the user.
 * We always clear all spouse information to account for scenario where spouse
 is selected and the applicant goes back.

 [#153069298]

Signed-off-by: Paras Sanghavi <paras@codeforamerica.org>