### PR TITLE
Set OTP issuer name based on Rails environment

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -41,5 +41,6 @@ Devise.setup do |config|
 
   # The name of the token issuer, to be added to the provisioning
   # url. Display will vary based on token application. (defaults to the Rails application class)
-  # config.otp_issuer = 'my_application'
+  otp_env = Rails.env.production? ? "" : " - #{Rails.env}"
+  config.otp_issuer = "MichiganBenefits.org" + otp_env
 end


### PR DESCRIPTION
Fixes a bug where 2FA codes were overwriting each other when on multiple environments (i.e. staging and production).

[Fixes #152983494]
https://www.pivotaltracker.com/story/show/152983494