### PR TITLE
Checkbox for medicare premium help

### DIFF
--- a/app/models/medicaid_application_attributes.rb
+++ b/app/models/medicaid_application_attributes.rb
@@ -74,6 +74,10 @@ class MedicaidApplicationAttributes
         anyone_has_insurance_type = members.any? ? "Yes" : nil
         names_with_insurance_type = members.map(&:first_name).join(", ")
 
+        if insurance_slug == :medicare
+          hash[:help_paying_medicare_premiums_yes] = anyone_has_insurance_type
+        end
+
         hash[:"insured_#{insurance_slug}_yes"] = anyone_has_insurance_type
         hash[:"insured_#{insurance_slug}_member_names"] =
           names_with_insurance_type

--- a/spec/models/dhs1426_pdf_spec.rb
+++ b/spec/models/dhs1426_pdf_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Dhs1426Pdf do
         pay_student_loan_interest: true,
         student_loan_interest_expenses: 70,
         insured: true,
-        insurance_type: "Medicaid",
+        insurance_type: "Medicare",
       )
 
       secondary_member = build(
@@ -162,10 +162,11 @@ RSpec.describe Dhs1426Pdf do
         flint_water_yes: "Yes",
         need_medical_expense_help_3_months_yes: "Yes",
         anyone_insured_yes: "Yes",
-        insured_medicaid_yes: "Yes",
-        insured_medicaid_member_names: "Christa",
+        insured_medicare_yes: "Yes",
+        insured_medicare_member_names: "Christa",
         insured_employer_yes: "Yes",
         insured_employer_member_names: "Roger",
+        help_paying_medicare_premiums_yes: "Yes",
       }
 
       expected_phone_data = {

--- a/spec/models/medicaid_application_attributes_spec.rb
+++ b/spec/models/medicaid_application_attributes_spec.rb
@@ -21,7 +21,29 @@ RSpec.describe MedicaidApplicationAttributes do
 
     describe "insurance types" do
       it_should_behave_like "insurance type", "medicaid", "Medicaid"
-      it_should_behave_like "insurance type", "medicare", "Medicare"
+
+      context "applicant is on medicare" do
+        it_should_behave_like "insurance type", "medicare", "Medicare"
+        it "should fill out yes for do you need help" do
+          member_with_medicare = build(
+            :member,
+            insurance_type: "Medicare",
+          )
+          medicaid_application = create(
+            :medicaid_application,
+            members: [member_with_medicare],
+          )
+
+          data = MedicaidApplicationAttributes.new(
+            medicaid_application: medicaid_application,
+          ).to_h
+
+          expect(data).to include(
+            help_paying_medicare_premiums_yes: "Yes",
+          )
+        end
+      end
+
       it_should_behave_like "insurance type", "chip", "CHIP/MIChild"
       it_should_behave_like "insurance type", "va", "VA health care programs"
       it_should_behave_like "insurance type",

--- a/spec/support/shared_examples/insurance_type.rb
+++ b/spec/support/shared_examples/insurance_type.rb
@@ -3,20 +3,20 @@ require "rails_helper"
 RSpec.shared_examples_for "insurance type" do |insurance_slug, insurance_name|
   context "one household member with #{insurance_name}" do
     it "sets insured_#{insurance_slug}_yes to 'Yes' and lists their name" do
-      member_with_medicaid = build(
+      member_with_insurance = build(
         :member,
         first_name: "Christa",
         last_name: "Person",
         insurance_type: insurance_name,
       )
-      member_without_medicaid = build(
+      member_without_insurance = build(
         :member,
         first_name: "Ben",
         last_name: "Person",
       )
       medicaid_application = create(
         :medicaid_application,
-        members: [member_with_medicaid, member_without_medicaid],
+        members: [member_with_insurance, member_without_insurance],
       )
 
       expected_data = {


### PR DESCRIPTION
 * if person has Medicare, then we should automatically check "Yes" on the
   1426 field, "Do you need help paying Medicare premiums?"

[Finishes #152727191]

https://www.pivotaltracker.com/story/show/152727191

Signed-off-by: Ben Golder <bgolder@codeforamerica.org>