### PR TITLE
Remove hardcoded county from SNAP and Medicaid application

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -18,3 +18,6 @@ MAILGUN_SMTP_LOGIN=
 MAILGUN_SMTP_PASSWORD=
 MAILGUN_SMTP_PORT=587
 MAILGUN_SMTP_SERVER="smtp.mailgun.org"
+
+# Open Cage Data Geocoding
+OPEN_CAGE_DATA_API_KEY="aaaaaaaaaabbbbbbbbbbbbbb"

--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "devise-otp",
   git: "https://github.com/pynixwang/devise-otp",
   ref: "a181217a2d436de7ebb9a278bcb326bbddefa514"
 gem "faraday"
+gem "geocoder"
 gem "good_migrations"
 gem "high_voltage"
 gem "jquery-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,7 @@ GEM
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.18)
+    geocoder (1.4.4)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     good_migrations (0.0.2)
@@ -437,6 +438,7 @@ DEPENDENCIES
   dotenv-rails
   factory_bot_rails
   faraday
+  geocoder
   good_migrations
   high_voltage
   jquery-rails

--- a/app/controllers/mailing_address_controller.rb
+++ b/app/controllers/mailing_address_controller.rb
@@ -1,18 +1,4 @@
 class MailingAddressController < SnapStepsController
-  def update
-    @step = step_class.new(step_params)
-
-    if @step.valid?
-      current_application.update!(
-        snap_application_param => step_params[snap_application_param],
-      )
-      address.update(step_params.except(snap_application_param))
-      redirect_to(next_path)
-    else
-      render :edit
-    end
-  end
-
   private
 
   def existing_attributes
@@ -20,16 +6,32 @@ class MailingAddressController < SnapStepsController
     HashWithIndifferentAccess.new(attributes)
   end
 
+  def update_application
+    current_application.update!(application_params)
+    address.update!(address_params.merge(county: county))
+  end
+
   def address
     current_application.addresses.where(mailing: true).first ||
       current_application.addresses.new(mailing: true)
   end
 
-  def snap_application_param
-    :mailing_address_same_as_residential_address
+  def county
+    @county ||= CountyFinder.new(
+      street_address: address_params[:street_address],
+      city: address_params[:city],
+      zip: address_params[:zip],
+      state: address_params[:state],
+    ).run
   end
 
-  def step_params
-    super.merge(state: "MI", county: "Genesee")
+  def application_params
+    step_params.slice(:mailing_address_same_as_residential_address)
+  end
+
+  def address_params
+    step_params.
+      except(:mailing_address_same_as_residential_address).
+      merge(state: "MI")
   end
 end

--- a/app/controllers/medicaid/contact_home_address_controller.rb
+++ b/app/controllers/medicaid/contact_home_address_controller.rb
@@ -29,7 +29,7 @@ module Medicaid
     end
 
     def step_params
-      super.merge(state: "MI", county: "Genesee")
+      super.merge(state: "MI", county: CountyFinder.run())
     end
 
     def address

--- a/app/controllers/medicaid/contact_home_address_controller.rb
+++ b/app/controllers/medicaid/contact_home_address_controller.rb
@@ -22,14 +22,8 @@ module Medicaid
     end
 
     def update_application
-      current_application.update!(
-        same_address_key => step_params[same_address_key],
-      )
-      address.update!(step_params.except(same_address_key))
-    end
-
-    def step_params
-      super.merge(state: "MI", county: CountyFinder.run())
+      current_application.update!(application_params)
+      address.update!(address_params.merge(county: county))
     end
 
     def address
@@ -37,8 +31,23 @@ module Medicaid
         current_application.addresses.new(mailing: false)
     end
 
-    def same_address_key
-      :mailing_address_same_as_residential_address
+    def county
+      @county ||= CountyFinder.new(
+        street_address: address_params[:street_address],
+        city: address_params[:city],
+        zip: address_params[:zip],
+        state: address_params[:state],
+      ).run
+    end
+
+    def application_params
+      step_params.slice(:mailing_address_same_as_residential_address)
+    end
+
+    def address_params
+      step_params.
+        except(:mailing_address_same_as_residential_address).
+        merge(state: "MI")
     end
   end
 end

--- a/app/controllers/residential_address_controller.rb
+++ b/app/controllers/residential_address_controller.rb
@@ -7,7 +7,7 @@ class ResidentialAddressController < SnapStepsController
   end
 
   def address_params
-    step_params.slice(:city, :county, :state, :street_address, :zip)
+    step_params.slice(:city, :state, :street_address, :zip)
   end
 
   def existing_attributes

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -33,10 +33,6 @@ class StepsController < ApplicationController
     end
   end
 
-  def update_application
-    current_application.update!(step_params)
-  end
-
   def self.to_param
     controller_path.dasherize
   end
@@ -73,9 +69,21 @@ class StepsController < ApplicationController
 
   delegate :step_class, to: :class
 
+  # Redefine me
+
+  def update_application
+    current_application.update!(step_params)
+  end
+
   def existing_attributes
     HashWithIndifferentAccess.new(current_application&.attributes)
   end
+
+  def skip?
+    false
+  end
+
+  # Probably don't redefine me
 
   def step_params
     params.fetch(:step, {}).permit(*step_attrs)
@@ -95,10 +103,6 @@ class StepsController < ApplicationController
     elsif skip?
       redirect_to next_path
     end
-  end
-
-  def skip?
-    false
   end
 
   def previous_path(params = nil)

--- a/app/services/county_finder.rb
+++ b/app/services/county_finder.rb
@@ -1,0 +1,18 @@
+class CountyFinder
+  def initialize(address)
+    @address = address
+  end
+
+  def run
+
+    full_address = [
+      @address.street_address,
+      @address.city,
+      @address.state,
+      @address.zip,
+    ].join(" ")
+    results = Geocoder.search(full_address, countrycode: "us")
+
+    results.first&.county
+  end
+end

--- a/app/services/county_finder.rb
+++ b/app/services/county_finder.rb
@@ -1,16 +1,18 @@
 class CountyFinder
-  def initialize(address)
-    @address = address
+  def initialize(street_address:, city:, zip:, state:)
+    @street_address = street_address
+    @city = city
+    @state = state
+    @zip = zip
   end
 
   def run
-
     full_address = [
-      @address.street_address,
-      @address.city,
-      @address.state,
-      @address.zip,
-    ].join(" ")
+      @street_address,
+      @city,
+      @state,
+      @zip,
+    ].compact.join(" ")
     results = Geocoder.search(full_address, countrycode: "us")
 
     results.first&.county

--- a/app/steps/mailing_address.rb
+++ b/app/steps/mailing_address.rb
@@ -2,7 +2,6 @@ class MailingAddress < Step
   step_attributes(
     :city,
     :mailing_address_same_as_residential_address,
-    :state,
     :street_address,
     :street_address_2,
     :zip,
@@ -16,9 +15,6 @@ class MailingAddress < Step
 
   validates :zip,
     length: { is: 5, message: "Make sure your ZIP code is 5 digits long" }
-
-  validates :state,
-    inclusion: { in: %w(MI), message: "Make sure the county is MI" }
 
   validates(
     :mailing_address_same_as_residential_address,

--- a/app/steps/mailing_address.rb
+++ b/app/steps/mailing_address.rb
@@ -1,7 +1,6 @@
 class MailingAddress < Step
   step_attributes(
     :city,
-    :county,
     :mailing_address_same_as_residential_address,
     :state,
     :street_address,
@@ -17,9 +16,6 @@ class MailingAddress < Step
 
   validates :zip,
     length: { is: 5, message: "Make sure your ZIP code is 5 digits long" }
-
-  validates :county,
-    inclusion: { in: %w(Genesee), message: "Make sure the county is Genesee" }
 
   validates :state,
     inclusion: { in: %w(MI), message: "Make sure the county is MI" }

--- a/app/steps/medicaid/contact_home_address.rb
+++ b/app/steps/medicaid/contact_home_address.rb
@@ -4,8 +4,6 @@ module Medicaid
       :street_address,
       :street_address_2,
       :city,
-      :county,
-      :state,
       :zip,
       :mailing_address_same_as_residential_address,
     )

--- a/app/steps/medicaid/contact_mailing_address.rb
+++ b/app/steps/medicaid/contact_mailing_address.rb
@@ -4,7 +4,6 @@ module Medicaid
       :street_address,
       :street_address_2,
       :city,
-      :county,
       :state,
       :zip,
     )

--- a/app/steps/residential_address.rb
+++ b/app/steps/residential_address.rb
@@ -1,7 +1,6 @@
 class ResidentialAddress < Step
   step_attributes(
     :city,
-    :county,
     :state,
     :street_address,
     :street_address_2,
@@ -28,9 +27,6 @@ class ResidentialAddress < Step
         message: "Make sure your ZIP code is 5 digits long",
       }
   end
-
-  validates :county,
-    inclusion: { in: %w(Genesee), message: "Make sure the county is Genesee" }
 
   validates :state,
     inclusion: { in: %w(MI), message: "Make sure the state is MI" }

--- a/app/steps/residential_address.rb
+++ b/app/steps/residential_address.rb
@@ -1,7 +1,6 @@
 class ResidentialAddress < Step
   step_attributes(
     :city,
-    :state,
     :street_address,
     :street_address_2,
     :unstable_housing,
@@ -27,9 +26,6 @@ class ResidentialAddress < Step
         message: "Make sure your ZIP code is 5 digits long",
       }
   end
-
-  validates :state,
-    inclusion: { in: %w(MI), message: "Make sure the state is MI" }
 
   private
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,22 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  lookup: :opencagedata,            # name of geocoding service (symbol)
+  # ip_lookup: :freegeoip,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  use_https: true,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV["OPEN_CAGE_DATA_API_KEY"],               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+  # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+)

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,7 +7,7 @@ Geocoder.configure(
   use_https: true,           # use HTTPS for lookup requests? (if supported)
   # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
   # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
-  api_key: ENV["OPEN_CAGE_DATA_API_KEY"],               # API key for geocoding service
+  api_key: Rails.application.secrets.opencagedata_api_key,               # API key for geocoding service
   # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
   # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -25,6 +25,7 @@ from_environment: &deployable_settings
   aws_secret: <%= ENV.fetch("AWS_SECRET_ACCESS_KEY", ENV["BUCKETEER_AWS_SECRET_ACCESS_KEY"]) %>
   aws_bucket: <%= ENV.fetch("AWS_BUCKET", ENV["BUCKETEER_BUCKET_NAME"]) %>
   aws_region: <%= ENV.fetch("AWS_REGION", ENV["BUCKETEER_REGION"]) %>
+  opencagedata_api_key: <%= ENV.fetch("OPEN_CAGE_DATA_API_KEY", ENV["OPEN_CAGE_DATA_API_KEY"]) %>
 
 development:
   <<: *deployable_settings
@@ -45,6 +46,7 @@ test:
   twilio_phone_number: '8007771234'
   twilio_account_sid: 'bbbb1111'
   twilio_auth_token: 'aaaa0000'
+  opencagedata_api_key: 'aaaaaaaaaabbbbbbbbbbbbbb'
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/db/migrate/20171127231016_remove_not_null_constraint_on_address.rb
+++ b/db/migrate/20171127231016_remove_not_null_constraint_on_address.rb
@@ -1,0 +1,5 @@
+class RemoveNotNullConstraintOnAddress < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :addresses, :county, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171121231237) do
+ActiveRecord::Schema.define(version: 20171127231016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 20171121231237) do
     t.bigint "benefit_application_id", null: false
     t.string "benefit_application_type", null: false
     t.string "city", null: false
-    t.string "county", null: false
+    t.string "county"
     t.datetime "created_at", null: false
     t.boolean "mailing", default: true, null: false
     t.string "state", null: false

--- a/spec/controllers/medicaid/contact_home_address_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_home_address_controller_spec.rb
@@ -193,7 +193,6 @@ RSpec.describe Medicaid::ContactHomeAddressController, type: :controller do
         expect(residential_address.county).to eq("Wayne")
       end
 
-
       it "sets the state to 'MI'" do
         params = {
           street_address: "321 Real St",

--- a/spec/factories/address.rb
+++ b/spec/factories/address.rb
@@ -4,7 +4,6 @@ FactoryBot.define do
     street_address "123 Main St."
     city "Flint"
     zip "12345"
-    county "Genesee"
     state "MI"
   end
 
@@ -13,7 +12,6 @@ FactoryBot.define do
     street_address "123 Main St."
     city "Flint"
     zip "12345"
-    county "Genesee"
     state "MI"
   end
 end

--- a/spec/models/snap_application_attributes_spec.rb
+++ b/spec/models/snap_application_attributes_spec.rb
@@ -3,12 +3,15 @@ require "rails_helper"
 RSpec.describe SnapApplicationAttributes do
   describe "#to_h" do
     it "returns a hash of attributes" do
-      mailing_address = build(:mailing_address, street_address_2: "Apt B")
-      residential_address = build(:residential_address)
+      mailing_address = build(
+        :mailing_address,
+        street_address_2: "Apt B",
+        county: "Genessee",
+      )
       snap_application = create(
         :snap_application,
         :with_member,
-        addresses: [mailing_address, residential_address],
+        addresses: [mailing_address],
         financial_accounts: [:four_oh_one_k],
         phone_number: "2222222222",
         rent_expense: 100,
@@ -25,7 +28,7 @@ RSpec.describe SnapApplicationAttributes do
         applying_for_food_assistance: "Yes",
         email: "test@example.com",
         mailing_address_city: "Flint",
-        mailing_address_county: "Genesee",
+        mailing_address_county: "Genessee",
         mailing_address_state: "MI",
         mailing_address_street_address: "123 Main St., Apt B",
         mailing_address_zip: "12345",

--- a/spec/services/county_finder_spec.rb
+++ b/spec/services/county_finder_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe CountyFinder do
+
+  it "should find the county based on street and city" do
+    address = Address.new(
+      street_address: "2405 West Vernor Highway",
+      city: "Detroit",
+      state: "MI",
+      zip: "48216"
+    )
+
+    expect(Geocoder).to receive(:search).with(
+      "2405 West Vernor Highway Detroit MI 48216",
+      countrycode: "us",
+    ).and_return([double('result', county: "Wayne County")])
+
+    expect(CountyFinder.new(address).run).to eq "Wayne County"
+  end
+
+  it "should return nil if no results can be found" do
+    address = Address.new(
+      street_address: "2405 West Vernor Highway",
+      city: "Detroit",
+      state: "MI",
+      zip: "48216"
+    )
+
+    expect(Geocoder).to receive(:search).with(
+      "2405 West Vernor Highway Detroit MI 48216",
+      countrycode: "us",
+    ).and_return([])
+
+    expect(CountyFinder.new(address).run).to eq nil
+  end
+end

--- a/spec/services/county_finder_spec.rb
+++ b/spec/services/county_finder_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe CountyFinder do
     expect(Geocoder).to receive(:search).with(
       "2405 West Vernor Highway Detroit MI 48216",
       countrycode: "us",
-    ).and_return([double('result', county: "Wayne County")])
+    ).and_return([double("result", county: "Wayne County")])
 
     expect(CountyFinder.new(
       street_address: "2405 West Vernor Highway",

--- a/spec/services/county_finder_spec.rb
+++ b/spec/services/county_finder_spec.rb
@@ -1,36 +1,31 @@
 require "rails_helper"
 
 RSpec.describe CountyFinder do
-
   it "should find the county based on street and city" do
-    address = Address.new(
-      street_address: "2405 West Vernor Highway",
-      city: "Detroit",
-      state: "MI",
-      zip: "48216"
-    )
-
     expect(Geocoder).to receive(:search).with(
       "2405 West Vernor Highway Detroit MI 48216",
       countrycode: "us",
     ).and_return([double('result', county: "Wayne County")])
 
-    expect(CountyFinder.new(address).run).to eq "Wayne County"
-  end
-
-  it "should return nil if no results can be found" do
-    address = Address.new(
+    expect(CountyFinder.new(
       street_address: "2405 West Vernor Highway",
       city: "Detroit",
       state: "MI",
-      zip: "48216"
-    )
+      zip: "48216",
+    ).run).to eq "Wayne County"
+  end
 
+  it "should return nil if no results can be found" do
     expect(Geocoder).to receive(:search).with(
       "2405 West Vernor Highway Detroit MI 48216",
       countrycode: "us",
     ).and_return([])
 
-    expect(CountyFinder.new(address).run).to eq nil
+    expect(CountyFinder.new(
+      street_address: "2405 West Vernor Highway",
+      city: "Detroit",
+      state: "MI",
+      zip: "48216",
+    ).run).to eq nil
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,17 @@ RSpec.configure do |config|
 
   config.run_all_when_everything_filtered = true
 
+  config.before(:each) do
+    stub_request(:get, /api.opencagedata.com/).
+      to_return(status: 200, body: {
+        results: [],
+        status: {
+          code: 200,
+          message: "OK",
+        },
+      }.to_json, headers: {})
+  end
+
   if ENV["CI"]
     config.before(:example, :focus) do |example|
       raise(

--- a/spec/steps/residential_address_spec.rb
+++ b/spec/steps/residential_address_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe ResidentialAddress do
         street_address: nil,
         city: nil,
         zip: nil,
-        county: "Genesee",
-        state: "MI",
         unstable_housing: "1",
       )
 
@@ -22,8 +20,6 @@ RSpec.describe ResidentialAddress do
         street_address: "123 Main St.",
         city: "Flint",
         zip: "12345",
-        county: "Genesee",
-        state: "MI",
         unstable_housing: "0",
       )
 
@@ -31,8 +27,6 @@ RSpec.describe ResidentialAddress do
         street_address: nil,
         city: nil,
         zip: nil,
-        county: "Genesee",
-        state: "MI",
         unstable_housing: "0",
       )
 
@@ -40,8 +34,6 @@ RSpec.describe ResidentialAddress do
         street_address: "",
         city: "",
         zip: "",
-        county: "Genesee",
-        state: "MI",
         unstable_housing: "0",
       )
 


### PR DESCRIPTION
Creates CountyFinder service object that talks to one of two geocoding services that returns county information (opencagedata), then writes that county information to the PDF.

Info on Opencagedata usage [here](https://github.com/alexreisner/geocoder#opencagedata-opencagedata), login info in LastPass

Continues to route application PDFs based on zipcode.

https://www.pivotaltracker.com/story/show/152981944