### PR TITLE
Add staging.rb

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,37 +1,5 @@
-require Rails.root.join("config/smtp")
+require File.expand_path('../shared_production', __FILE__)
 
 Rails.application.configure do
-  config.force_ssl = true
-
-  config.cache_classes = true
-  config.eager_load = true
-  config.consider_all_requests_local = false
-  config.action_controller.perform_caching = true
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
-  config.assets.js_compressor = :uglifier
-  config.assets.compile = false
-  config.log_level = :info
-  config.log_tags = [:request_id]
-  config.action_mailer.perform_caching = false
-
-  # Customize default host
-  config.action_mailer.default_url_options = {
-    host: ENV["HOSTNAME_FOR_URLS"],
-    protocol: "https",
-  }
-
-  config.action_mailer.smtp_settings = SMTP_SETTINGS
-  config.action_mailer.delivery_method = :smtp
-
-  config.i18n.fallbacks = true
-  config.active_support.deprecation = :notify
-  config.log_formatter = ::Logger::Formatter.new
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
-
-  config.active_record.dump_schema_after_migration = false
+  # any production-specific configs
 end

--- a/config/environments/shared_production.rb
+++ b/config/environments/shared_production.rb
@@ -1,0 +1,37 @@
+require Rails.root.join("config/smtp")
+
+Rails.application.configure do
+  config.force_ssl = true
+
+  config.cache_classes = true
+  config.eager_load = true
+  config.consider_all_requests_local = false
+  config.action_controller.perform_caching = true
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  config.assets.js_compressor = :uglifier
+  config.assets.compile = false
+  config.log_level = :info
+  config.log_tags = [:request_id]
+  config.action_mailer.perform_caching = false
+
+  # Customize default host
+  config.action_mailer.default_url_options = {
+    host: ENV["HOSTNAME_FOR_URLS"],
+    protocol: "https",
+  }
+
+  config.action_mailer.smtp_settings = SMTP_SETTINGS
+  config.action_mailer.delivery_method = :smtp
+
+  config.i18n.fallbacks = true
+  config.active_support.deprecation = :notify
+  config.log_formatter = ::Logger::Formatter.new
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  config.active_record.dump_schema_after_migration = false
+end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,37 +1,5 @@
-require Rails.root.join("config/smtp")
+require File.expand_path('../shared_production', __FILE__)
 
 Rails.application.configure do
-  config.force_ssl = true
-
-  config.cache_classes = true
-  config.eager_load = true
-  config.consider_all_requests_local = false
-  config.action_controller.perform_caching = true
-  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
-  config.assets.js_compressor = :uglifier
-  config.assets.compile = false
-  config.log_level = :info
-  config.log_tags = [:request_id]
-  config.action_mailer.perform_caching = false
-
-  # Customize default host
-  config.action_mailer.default_url_options = {
-    host: ENV["HOSTNAME_FOR_URLS"],
-    protocol: "https",
-  }
-
-  config.action_mailer.smtp_settings = SMTP_SETTINGS
-  config.action_mailer.delivery_method = :smtp
-
-  config.i18n.fallbacks = true
-  config.active_support.deprecation = :notify
-  config.log_formatter = ::Logger::Formatter.new
-
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
-    logger.formatter = config.log_formatter
-    config.logger = ActiveSupport::TaggedLogging.new(logger)
-  end
-
-  config.active_record.dump_schema_after_migration = false
+  # any staging-specific configs
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,0 +1,37 @@
+require Rails.root.join("config/smtp")
+
+Rails.application.configure do
+  config.force_ssl = true
+
+  config.cache_classes = true
+  config.eager_load = true
+  config.consider_all_requests_local = false
+  config.action_controller.perform_caching = true
+  config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
+  config.assets.js_compressor = :uglifier
+  config.assets.compile = false
+  config.log_level = :info
+  config.log_tags = [:request_id]
+  config.action_mailer.perform_caching = false
+
+  # Customize default host
+  config.action_mailer.default_url_options = {
+    host: ENV["HOSTNAME_FOR_URLS"],
+    protocol: "https",
+  }
+
+  config.action_mailer.smtp_settings = SMTP_SETTINGS
+  config.action_mailer.delivery_method = :smtp
+
+  config.i18n.fallbacks = true
+  config.active_support.deprecation = :notify
+  config.log_formatter = ::Logger::Formatter.new
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  config.active_record.dump_schema_after_migration = false
+end


### PR DESCRIPTION
This new file is a verbatim copy of production.rb.

This should make it possible to set `RAILS_ENV` and `RACK_ENV` to `staging` for our staging instance. Currently, the staging instance uses `production` for those environment variables.

This will then set the one-time password issuer to "MichiganBenefits.org - staging" for the staging instance.

https://www.pivotaltracker.com/story/show/152983494