### PR TITLE
Remove leftover hardcoded county

### DIFF
--- a/app/controllers/medicaid/contact_mailing_address_controller.rb
+++ b/app/controllers/medicaid/contact_mailing_address_controller.rb
@@ -7,7 +7,7 @@ module Medicaid
     end
 
     def update_application
-      address.update!(step_params.merge(state: "MI", county: "Genesee"))
+      address.update!(address_params.merge(county: county))
     end
 
     def skip?
@@ -43,6 +43,19 @@ module Medicaid
     def address
       current_application.addresses.where(mailing: true).first ||
         current_application.addresses.new(mailing: true)
+    end
+
+    def address_params
+      step_params.merge(state: "MI")
+    end
+
+    def county
+      @county ||= CountyFinder.new(
+        street_address: address_params[:street_address],
+        city: address_params[:city],
+        zip: address_params[:zip],
+        state: address_params[:state],
+      ).run
     end
   end
 end

--- a/app/controllers/residential_address_controller.rb
+++ b/app/controllers/residential_address_controller.rb
@@ -13,7 +13,7 @@ class ResidentialAddressController < SnapStepsController
   end
 
   def application_params
-    { stable_housing: stable_housing }
+    { stable_housing: !unstable_housing }
   end
 
   def existing_attributes
@@ -27,8 +27,8 @@ class ResidentialAddressController < SnapStepsController
       current_application.addresses.new(mailing: false)
   end
 
-  def stable_housing
-    !step_params[:unstable_housing]
+  def unstable_housing
+    step_params[:unstable_housing] == "1"
   end
 
   def county

--- a/app/steps/medicaid/contact_mailing_address.rb
+++ b/app/steps/medicaid/contact_mailing_address.rb
@@ -4,7 +4,6 @@ module Medicaid
       :street_address,
       :street_address_2,
       :city,
-      :state,
       :zip,
     )
 

--- a/spec/controllers/residential_address_controller_spec.rb
+++ b/spec/controllers/residential_address_controller_spec.rb
@@ -48,6 +48,24 @@ RSpec.describe ResidentialAddressController, type: :controller do
         expect(current_app.reload.stable_housing).to eq false
       end
 
+      context "with stable housing" do
+        it "sets stable housing to true" do
+          valid_params = {
+            street_address: "321 Real St",
+            street_address_2: "Apt 4",
+            city: "Shelbyville",
+            zip: "54321",
+            unstable_housing: "0",
+          }
+
+          put :update, params: { step: valid_params }
+
+          residential_address.reload
+
+          expect(current_app.reload.stable_housing).to eq true
+        end
+      end
+
       it "sets the county based on address" do
         valid_params = {
           street_address: "321 Main St",


### PR DESCRIPTION
Also fixes a bug where people with residential addresses were being marked as Homeless in the SNAP flow.

[Finishes #152981944]

Signed-off-by: Jessie Young <jessie@cylinder.work>