### PR TITLE
Declare staging environments

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -10,6 +10,10 @@ test:
   <<: *default
   database: michigan_prototype_test
 
+staging:
+  adapter: postgresql
+  url: <%= ENV["DATABASE_URL"] %>
+
 production:
   adapter: postgresql
   url: <%= ENV["DATABASE_URL"] %>

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -53,3 +53,7 @@ test:
 production:
   <<: *deployable_settings
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
+staging:
+  <<: *deployable_settings
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
Needed to set a `RAILS_ENV=staging` on our staging Heroku instance.