### PR TITLE
[PAIR] Remove pre-prod env, speed up deploy instead

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,29 +1,6 @@
 #!/bin/bash
 set -e
 
-echo "Opening tracker to check for stories awaiting acceptance..."
-open "https://www.pivotaltracker.com/n/projects/2123705"
-
-read -p "Are there no stories in the accept/reject state? (y/N) " -n 1 -r
-echo    # (optional) move to a new line
-if [[ $REPLY =~ ^[Yy]$ ]];then
-  echo "Great!"
-else
-  echo "Please test and run acceptance for those stories first!"
-  exit 1
-fi
-
-echo "Diffing the code between staging and production..."
-bin/release-diff
-read -p "Looks ok? (y/N) " -n 1 -r
-echo    # (optional) move to a new line
-if [[ $REPLY =~ ^[Yy]$ ]];then
-  echo "Great!"
-else
-  echo "Have a closer look and you can do this again later!"
-  exit 1
-fi
-
 echo "Checking for buildpack changes between staging and production."
 diff <(heroku buildpacks -r staging) <(heroku buildpacks -r production) && echo ""
 read -p "Are these the same (ignoring order)? (y/N)" -n 1 -r
@@ -52,13 +29,10 @@ fi
 read -p "Ready to deploy to production? (y/N) " -n 1 -r
 echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]; then
-  heroku pipelines:promote -a michigan-benefits-pre-prod
-  heroku run bin/rails one_offs:run_all -a michigan-benefits-production
-  heroku ps:restart -a michigan-benefits-production
+  heroku pipelines:promote -a michigan-benefits-staging
   echo "Success! Application deployed to Production!"
-  echo "Please do some testing on production! (use zip 12345 to send a fake fax)"
+  echo "Please do some testing on production! (use zip 12345 to prevent actual submission)"
 else
   echo "Okay, I won't deploy. Thank you for being thoughtful and careful!"
   exit 1;
 fi
-

--- a/bin/release-diff
+++ b/bin/release-diff
@@ -1,6 +1,0 @@
-#!/bin/bash
-set -e
-
-staging_sha=$(heroku releases -r staging | grep "Deploy" | head -n 1 | tail -n 1 | cut -d " " -f 4)
-prod_sha=$(heroku releases -r production | grep "Deploy" | head -n 1 | tail -n 1 | cut -d " " -f 4)
-open "https://github.com/codeforamerica/michigan-benefits/compare/$prod_sha...$staging_sha"

--- a/bin/release_tasks
+++ b/bin/release_tasks
@@ -1,1 +1,2 @@
 bundle exec rake db:migrate
+bundle exec rake one_offs:run_all

--- a/circle.yml
+++ b/circle.yml
@@ -23,13 +23,6 @@ deployment:
     commands:
       - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
       - git push git@heroku.com:michigan-benefits-staging.git $CIRCLE_SHA1:refs/heads/master
-      - heroku run rake db:migrate --app michigan-benefits-staging
-  pre-production:
-    branch: production
-    commands:
-      - "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
-      - git push git@heroku.com:michigan-benefits-pre-prod.git $CIRCLE_SHA1:refs/heads/master
-      - heroku run rake db:migrate --app michigan-benefits-pre-prod
 
 general:
   branches:


### PR DESCRIPTION
[Finishes #153272916]

We decided to back out from the pre-prod approach, since we'll have the same issues, i.e. we can't prevent merges while deploying to pre-prod to solve the pain of preventing merge while deploying to prod.

Having a pre-prod branch was introducing a lot of complexity, seen yesterday when noticing a buildpack difference between pre-prod and staging.

Instead, we're removing steps from the release script to make it as quick as we feel responsible at the moment. The goal is to run this script whenever we see a clear acceptance queue in Tracker.

For visibility: @luigi @jessieay @bengolder

Signed-off-by: Paras Sanghavi <paras@codeforamerica.org>