### PR TITLE
Fix last name bug

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -107,7 +107,7 @@ class Member < ApplicationRecord
   end
 
   def display_name
-    "#{first_name} #{last_name}".titleize
+    "#{first_name.upcase_first} #{last_name.upcase_first}"
   end
 
   def self.filing_taxes

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -246,4 +246,11 @@ RSpec.describe Member do
       expect(member.errors).to include(:other_income_types)
     end
   end
+
+  describe "#display_name" do
+    it "combines first name and last name" do
+      member = Member.new(first_name: "anneFace", last_name: "mcDog")
+      expect(member.display_name).to eq("AnneFace McDog")
+    end
+  end
 end


### PR DESCRIPTION
* Previously, a name with a capital letter in the middle would be split
into 2
* Now, we only upcase the first letter of the first and last names and
leave the rest alone.
* [Finishes #153189719]
https://www.pivotaltracker.com/story/show/153189719


Before:

![screen shot 2017-12-04 at 9 04 34 am](https://user-images.githubusercontent.com/601515/33565532-37a442d4-d8d2-11e7-9625-792a37168dc6.png)


After:

![screen shot 2017-12-04 at 9 04 13 am](https://user-images.githubusercontent.com/601515/33565518-3129381a-d8d2-11e7-8890-e11daad4ad91.png)