### PR TITLE
Fix admin dashboard error on Exports page

### DIFF
--- a/app/dashboards/export_dashboard.rb
+++ b/app/dashboards/export_dashboard.rb
@@ -2,7 +2,7 @@ require "administrate/base_dashboard"
 
 class ExportDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
-    snap_application: Field::BelongsTo,
+    benefit_application: Field::Polymorphic,
     id: Field::Number,
     destination: Field::String,
     metadata: Field::String,
@@ -17,12 +17,12 @@ class ExportDashboard < Administrate::BaseDashboard
     completed_at
     destination
     metadata
-    snap_application
+    benefit_application
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = %i[
     id
-    snap_application
+    benefit_application
     destination
     metadata
     force

--- a/app/dashboards/member_dashboard.rb
+++ b/app/dashboards/member_dashboard.rb
@@ -9,7 +9,7 @@ class MemberDashboard < Administrate::BaseDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     id: Field::Number,
-    snap_application: Field::Polymorphic,
+    benefit_application: Field::Polymorphic,
     created_at: Field::DateTime,
     updated_at: Field::DateTime,
     marital_status: Field::String,
@@ -44,13 +44,13 @@ class MemberDashboard < Administrate::BaseDashboard
     first_name
     last_name
     created_at
-    snap_application
+    benefit_application
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-    snap_application
+    benefit_application
     id
     created_at
     updated_at

--- a/spec/features/admin_dashboard_exports_spec.rb
+++ b/spec/features/admin_dashboard_exports_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.feature "Admins can view exports" do
+  before do
+    user = create(:admin_user)
+    login_as(user)
+  end
+
+  scenario "Exports are listed" do
+    medicaid_application = build(:medicaid_application)
+    snap_application = build(:snap_application)
+    medicaid_export = create(:export, benefit_application: medicaid_application)
+    snap_export = create(:export, benefit_application: snap_application)
+
+    visit admin_exports_path
+
+    within "[data-url='#{admin_export_path(medicaid_export)}']" do
+      expect(page).to have_content(
+        "MedicaidApplication ##{medicaid_application.id}",
+      )
+    end
+
+    within "[data-url='#{admin_export_path(snap_export)}']" do
+      expect(page).to have_content(
+        "Snap Application ##{snap_application.id}",
+      )
+    end
+  end
+end


### PR DESCRIPTION
* From sentry:
```
ActionView::Template::Error: Association named 'snap_application' was not found on Export; perhaps you misspelled it?
Culprit
----------------
app/views/admin/snap_applications/_collection.html.erb in _app_views_admin_snap_applications__collection_html_erb___966721738635953996_62738060 at line 57
```

* This is pre-work for #152982028