### PR TITLE
SnapApplication webdriving fixes

### DIFF
--- a/lib/mi_bridges/driver/housing_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_bills_page.rb
@@ -24,7 +24,7 @@ module MiBridges
       end
 
       def section_name
-        "star#{first_name_section(primary_member).capitalize}sHousingBills"
+        "star#{first_name_section(primary_member)}sHousingBills"
       end
     end
   end

--- a/lib/mi_bridges/driver/services/submit_relationship.rb
+++ b/lib/mi_bridges/driver/services/submit_relationship.rb
@@ -56,7 +56,7 @@ module MiBridges
             "Child" => "is the Mother of",
             "Parent" => "is the Daughter of",
             "Sibling" => "is the Sister of",
-            "Spouse" => "is the Spouse of",
+            "Spouse" => "is the Wife of",
           }
         end
 

--- a/lib/mi_bridges/driver/submit_page.rb
+++ b/lib/mi_bridges/driver/submit_page.rb
@@ -1,9 +1,17 @@
 
 module MiBridges
   class Driver
-    class SubmitPage < DebuggerPage
+    class SubmitPage < BasePage
       def self.title
         "Before You Submit the Application"
+      end
+
+      def setup; end
+
+      def fill_in_required_fields; end
+
+      def continue
+        close unless ENV["PRE_DEPLOY_TEST"] == "true"
       end
     end
   end

--- a/lib/mi_bridges/driver/utility_bills_page.rb
+++ b/lib/mi_bridges/driver/utility_bills_page.rb
@@ -35,7 +35,7 @@ module MiBridges
       private
 
       def section_name
-        "star#{first_name_section(primary_member).capitalize}sUtilityBills"
+        "star#{first_name_section(primary_member)}sUtilityBills"
       end
 
       def check_heat

--- a/spec/features/mi_bridges_driving_spec.rb
+++ b/spec/features/mi_bridges_driving_spec.rb
@@ -2,11 +2,11 @@ require "rails_helper"
 
 RSpec.feature "MI Bridges Driving" do
   # to run this in a non-headless way, remove the `:js` flag below
-  scenario "successfully drives, then re-drives a SNAP App", :js, :driving do
+  scenario "successfully drives, then re-drives a SNAP App", :driving do
     WebMock.disable!
 
-    address = create(:mailing_address)
-    member = create(:member, sex: "male")
+    address = build(:mailing_address, county: "Genesee")
+    member = build(:member, sex: "male")
     snap_application = create(
       :snap_application,
       members: [member],


### PR DESCRIPTION
Through the course of exploring our errors, we made some fixes that allowed us to review driven applications more easily. Those fixes are below:

* Update driving tests to complete successfully
* Fix small bug where we were always using 'debug' as log level
* Log 'PageNotFoundError' and 'TooManyAttemptsError' to Driver Errors
* Only catch exceptions for 'run', not 'rerun' with expectation that we do not want to save errors that are redriven because it would be devs doing it manually
* No longer inherit from DebuggerPage on SubmitPage, so driving ends without notice rather than opening a pry
* Don't capitalize member names id in HTML on applications for bills
* MiBridges updated to no longer capitalizing member names on these pages, so we removed our capitalization, as well.
* Updates changed copy for Wife relationship