### PR TITLE
Add one-off task to update member data, Update driving code to have default marital status

### DIFF
--- a/app/services/update_member_data.rb
+++ b/app/services/update_member_data.rb
@@ -1,0 +1,33 @@
+class UpdateMemberData
+  def run
+    update_members
+  end
+
+  private
+
+  def update_members
+    members.each do |member|
+      begin
+        member.first_name = member.first_name.strip
+        member.last_name = member.last_name.strip
+
+        if member.other_income_types.nil?
+          member.other_income_types = []
+        end
+
+        puts "Updating member # #{member.id}"
+        member.save!
+      rescue OpenSSL::Cipher::CipherError
+        member.encrypted_last_four_ssn = nil
+        member.encrypted_last_four_ssn_iv = nil
+        member.encrypted_ssn = nil
+        member.encrypted_ssn_iv = nil
+        member.save!
+      end
+    end
+  end
+
+  def members
+    Member.where(benefit_application_type: "SnapApplication")
+  end
+end

--- a/lib/mi_bridges/driver/people_listed_page.rb
+++ b/lib/mi_bridges/driver/people_listed_page.rb
@@ -14,7 +14,12 @@ module MiBridges
       end
 
       def fill_in_required_fields
-        select member.marital_status.titleize, from: "maritalStatus"
+        if member.marital_status.present?
+          select member.marital_status.titleize, from: "maritalStatus"
+        else
+          select "Never Married", from: "maritalStatus"
+        end
+
         select_fap_program_enrollment
 
         if for_next_household_member?

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -2,6 +2,7 @@
 namespace :one_offs do
   desc "runs all one_offs, remove things from here after they are deployed"
   task run_all: :environment do
+    UpdateMemberData.new.run
     EmploymentsMigrator.new.run
   end
 end

--- a/spec/factories/member.rb
+++ b/spec/factories/member.rb
@@ -3,7 +3,6 @@ FactoryBot.define do
     first_name "Lilly"
     last_name "Pad"
     sex "female"
-    marital_status "Widowed"
     birthday { DateTime.parse("August 18, 1990") }
 
     trait :female do

--- a/spec/features/mi_bridges_driving_spec.rb
+++ b/spec/features/mi_bridges_driving_spec.rb
@@ -6,10 +6,11 @@ RSpec.feature "MI Bridges Driving" do
     WebMock.disable!
 
     address = build(:mailing_address, county: "Genesee")
-    member = build(:member, sex: "male")
+    member = build(:member, marital_status: "Married", sex: "male")
+    second_member = build(:member, first_name: "Jojo", sex: "female")
     snap_application = create(
       :snap_application,
-      members: [member],
+      members: [member, second_member],
       mailing_address_same_as_residential_address: true,
       addresses: [address],
     )

--- a/spec/models/dhs1171_pdf_spec.rb
+++ b/spec/models/dhs1171_pdf_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Dhs1171Pdf do
     it "writes application info to file" do
       mailing_address = build(:mailing_address)
       residential_address = build(:residential_address)
-      member = build(:member, ssn: "012345678")
+      member = build(:member, ssn: "012345678", marital_status: "Widowed")
       snap_application = create(
         :snap_application,
         addresses: [mailing_address, residential_address],

--- a/spec/services/update_member_data_spec.rb
+++ b/spec/services/update_member_data_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe UpdateMemberData do
+  describe "#run" do
+    it "removes whitespace from first names and last names" do
+      member = create(
+        :member,
+        first_name: " Ja Christa ",
+        last_name: " Hart Young ",
+        benefit_application: create(:snap_application),
+      )
+
+      UpdateMemberData.new.run
+      member.reload
+
+      expect(member.first_name).to eq "Ja Christa"
+      expect(member.last_name).to eq "Hart Young"
+    end
+
+    it "sets nil other_income_types to be an empty array" do
+      member = build(
+        :member,
+        other_income_types: nil,
+        benefit_application: create(:snap_application),
+      )
+      member.save(validate: false)
+
+      UpdateMemberData.new.run
+      member.reload
+
+      expect(member.other_income_types).to eq []
+    end
+
+    it "deals with invalid SSNs" do
+      member = build(
+        :member,
+        encrypted_ssn: "W+n1fo2E6uEc48Nbysk+U71//HnCcflNDg==\n",
+        encrypted_ssn_iv: "swMLioyO3rHox5tG\n",
+        benefit_application: create(:snap_application),
+      )
+      member.save(validate: false)
+
+      UpdateMemberData.new.run
+      member.reload
+
+      expect(member.ssn).to eq nil
+      expect(member.encrypted_last_four_ssn).to eq nil
+      expect(member.encrypted_last_four_ssn_iv).to eq nil
+    end
+  end
+end


### PR DESCRIPTION
Add one-off task to update member data 
* This is to fix driving problems that occur when names have trailing or
leading whitespace *or* nil value for `other_income_types` *or* messed
up SSN.
* [#153377419]
* [#152982028]


Update driving code to have default marital status
* Right now, in SNAP flow only the primary member reports their marital
status but this is a required field for ALL members in MiBridges
* Product/design work required to figure out how to fix this long term,
but for now we are filling in `Never Married` as a default value.
* [#153382734]