### PR TITLE
Do not use employed_number_of_jobs in migrator

### DIFF
--- a/app/services/employments_migrator.rb
+++ b/app/services/employments_migrator.rb
@@ -2,7 +2,7 @@ class EmploymentsMigrator
   def run
     ActiveRecord::Base.transaction do
       members_with_jobs.each do |member|
-        last_employment_index = member.employed_number_of_jobs - 1
+        last_employment_index = member.employed_employer_names.count - 1
         employment_indices = (0..last_employment_index).to_a
         employments = employment_indices.map do |i|
           Employment.new(
@@ -20,8 +20,6 @@ class EmploymentsMigrator
   private
 
   def members_with_jobs
-    Member.
-      where.not(employed_number_of_jobs: nil).
-      where("employed_number_of_jobs > ?", 0)
+    Member.where.not(employed_employer_names: nil)
   end
 end

--- a/spec/services/employments_migrator_spec.rb
+++ b/spec/services/employments_migrator_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe EmploymentsMigrator do
       it "copies data to the employments table" do
         member = build(
           :member,
-          employed_number_of_jobs: 3,
           employed_employer_names: %w(BART Muni SamTrans),
           employed_pay_quantities: %w(40 500 6000),
           employed_payment_frequency: %w(Hourly Weekly Monthly),
@@ -34,11 +33,11 @@ RSpec.describe EmploymentsMigrator do
       end
     end
 
-    context "member has nil number of jobs" do
+    context "member has nil employed_employer_names" do
       it "does not create employment records" do
         member = build(
           :member,
-          employed_number_of_jobs: nil,
+          employed_employer_names: nil,
         )
         create(:medicaid_application, members: [member])
         EmploymentsMigrator.new.run
@@ -46,11 +45,11 @@ RSpec.describe EmploymentsMigrator do
       end
     end
 
-    context "member has zero jobs" do
+    context "member has empty employed_employer_names" do
       it "does not create employment records" do
         member = build(
           :member,
-          employed_number_of_jobs: 0,
+          employed_employer_names: [],
         )
         create(:medicaid_application, members: [member])
         EmploymentsMigrator.new.run
@@ -62,7 +61,6 @@ RSpec.describe EmploymentsMigrator do
       it "does not create new records the second time" do
         member = build(
           :member,
-          employed_number_of_jobs: 3,
           employed_employer_names: %w(BART Muni SamTrans),
           employed_pay_quantities: %w(40 500 6000),
           employed_payment_frequency: %w(Hourly Weekly Monthly),


### PR DESCRIPTION
[#153069646]

Signed-off-by: Ben Golder <bgolder@codeforamerica.org>