### PR TITLE
[PAIR] Specify members to populate many members steps

### DIFF
--- a/app/controllers/medicaid/contact_social_security_controller.rb
+++ b/app/controllers/medicaid/contact_social_security_controller.rb
@@ -1,11 +1,5 @@
 module Medicaid
   class ContactSocialSecurityController < Medicaid::ManyMemberStepsController
-    def step
-      @step ||= step_class.new(
-        members: members_requesting_health_insurance,
-      )
-    end
-
     private
 
     def skip?
@@ -20,7 +14,7 @@ module Medicaid
       %i[ssn birthday]
     end
 
-    def members_requesting_health_insurance
+    def members
       current_application.
         members.
         where(requesting_health_insurance: true)

--- a/app/controllers/medicaid/health_pregnancy_member_controller.rb
+++ b/app/controllers/medicaid/health_pregnancy_member_controller.rb
@@ -2,6 +2,10 @@ module Medicaid
   class HealthPregnancyMemberController < Medicaid::ManyMemberStepsController
     private
 
+    def members
+      current_application.members.select(&:female?)
+    end
+
     def skip?
       no_pregnancies? || only_males? || single_female_member_is_pregnant?
     end
@@ -15,7 +19,7 @@ module Medicaid
     end
 
     def only_males?
-      current_application.members.select(&:female?).empty?
+      members.empty?
     end
 
     def single_female_member_is_pregnant?
@@ -23,7 +27,7 @@ module Medicaid
     end
 
     def only_one_female?
-      current_application.members.select(&:female?).count == 1
+      members.count == 1
     end
 
     def application_has_a_new_mom?

--- a/app/controllers/medicaid/insurance_current_member_controller.rb
+++ b/app/controllers/medicaid/insurance_current_member_controller.rb
@@ -1,6 +1,16 @@
 module Medicaid
   class InsuranceCurrentMemberController < Medicaid::ManyMemberStepsController
+    helper_method :members_not_needing_insurance
+
+    def members_not_needing_insurance
+      current_application.members.reject(&:requesting_health_insurance)
+    end
+
     private
+
+    def members
+      current_application.members.select(&:requesting_health_insurance)
+    end
 
     def skip?
       single_member_household? || current_application.nobody_insured?

--- a/app/controllers/medicaid/many_member_steps_controller.rb
+++ b/app/controllers/medicaid/many_member_steps_controller.rb
@@ -24,20 +24,16 @@ module Medicaid
     def assign_household_member_attributes
       step.members.each do |member|
         attrs = params.dig(:step, :members, member.to_param)
-
-        if attrs.present?
-          member.assign_attributes(attrs.permit(member_attrs))
-        end
+        member.assign_attributes(attrs.permit(member_attrs))
       end
     end
 
     def step
-      @step ||= step_class.new(
-        current_application.
-          attributes.
-          slice(*step_attrs).
-          merge(members: current_application.members),
-      )
+      @step ||= step_class.new(members: members)
+    end
+
+    def members
+      current_application.members
     end
 
     def member_attrs

--- a/app/controllers/medicaid/tax_filing_with_household_members_member_controller.rb
+++ b/app/controllers/medicaid/tax_filing_with_household_members_member_controller.rb
@@ -13,5 +13,9 @@ module Medicaid
         !current_application.filing_federal_taxes_next_year? ||
         !current_application.filing_taxes_with_household_members?
     end
+
+    def members
+      current_application.non_applicant_members
+    end
   end
 end

--- a/app/steps/medicaid/health_pregnancy_member.rb
+++ b/app/steps/medicaid/health_pregnancy_member.rb
@@ -1,9 +1,5 @@
 module Medicaid
   class HealthPregnancyMember < Step
     step_attributes(:members)
-
-    def female_members
-      members.select(&:female?)
-    end
   end
 end

--- a/app/steps/medicaid/insurance_current_member.rb
+++ b/app/steps/medicaid/insurance_current_member.rb
@@ -1,22 +1,11 @@
 module Medicaid
   class InsuranceCurrentMember < Step
-    step_attributes(
-      :insured,
-      :members,
-    )
+    step_attributes(:members)
 
     validate :members_needing_insurance_selected
 
-    def members_needing_insurance
-      members.select(&:requesting_health_insurance)
-    end
-
-    def members_not_needing_insurance
-      members.reject(&:requesting_health_insurance)
-    end
-
     def members_needing_insurance_selected
-      return true if members_needing_insurance.select(&:insured).any?
+      return true if members.select(&:insured).any?
       errors.add(
         :insured,
         "Make sure you select a person",

--- a/app/steps/medicaid/insurance_needed.rb
+++ b/app/steps/medicaid/insurance_needed.rb
@@ -1,9 +1,6 @@
 module Medicaid
   class InsuranceNeeded < Step
-    step_attributes(
-      :members,
-      :requesting_health_insurance,
-    )
+    step_attributes(:members)
 
     validate :members_requesting_health_insurance_selected
 

--- a/app/steps/medicaid/intro_college_member.rb
+++ b/app/steps/medicaid/intro_college_member.rb
@@ -1,9 +1,6 @@
 module Medicaid
   class IntroCollegeMember < Step
-    step_attributes(
-      :in_college,
-      :members,
-    )
+    step_attributes(:members)
 
     validate :in_college_selected
 

--- a/app/steps/medicaid/intro_marital_status_member.rb
+++ b/app/steps/medicaid/intro_marital_status_member.rb
@@ -1,9 +1,6 @@
 module Medicaid
   class IntroMaritalStatusMember < Step
-    step_attributes(
-      :members,
-      :married,
-    )
+    step_attributes(:members)
 
     validate :married_selected
 

--- a/app/views/medicaid/health_pregnancy_member/edit.html.erb
+++ b/app/views/medicaid/health_pregnancy_member/edit.html.erb
@@ -18,7 +18,7 @@
       method: :put do |f| %>
 
       <fieldset class="form-group">
-        <% @step.female_members.each do |member| %>
+        <% @step.members.each do |member| %>
           <%= f.fields_for("members[]", member) do |ff| %>
             <%= ff.mb_checkbox(
               :new_mom,

--- a/app/views/medicaid/insurance_current_member/edit.html.erb
+++ b/app/views/medicaid/insurance_current_member/edit.html.erb
@@ -5,11 +5,11 @@
     <div class="form-card__title">
       <%= t("medicaid.insurance_current_member.edit.title") %>
     </div>
-    <% if @step.members_not_needing_insurance.present? %>
+    <% if members_not_needing_insurance.present? %>
       <p class="text--help text--centered">
         <%= t("medicaid.insurance_current_member.edit.helper_text",
-              count: @step.members_not_needing_insurance.count,
-              names: @step.members_not_needing_insurance.map(&:display_name).to_sentence) %>
+              count: members_not_needing_insurance.count,
+              names: members_not_needing_insurance.map(&:display_name).to_sentence) %>
       </p>
     <% end %>
   </header>
@@ -20,7 +20,7 @@
           <legend class="sr-only">
             <%= t("medicaid.insurance_current_member.edit.title") %>
           </legend>
-          <% @step.members_needing_insurance.each do |member| %>
+          <% @step.members.each do |member| %>
               <%= f.fields_for("members[]", member) do |ff| %>
                 <%= ff.mb_checkbox(
                     :insured,

--- a/app/views/medicaid/tax_filing_with_household_members_member/edit.html.erb
+++ b/app/views/medicaid/tax_filing_with_household_members_member/edit.html.erb
@@ -15,7 +15,7 @@
                  method: :put do |f| %>
 
         <fieldset class="form-group">
-          <% current_application.non_applicant_members.each do |member| %>
+          <% @step.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
                   <%= ff.mb_checkbox :filing_taxes_with_primary_member, member.display_name %>
               <% end %>

--- a/spec/controllers/medicaid/health_pregnancy_member_controller_spec.rb
+++ b/spec/controllers/medicaid/health_pregnancy_member_controller_spec.rb
@@ -49,16 +49,24 @@ RSpec.describe Medicaid::HealthPregnancyMemberController, type: :controller do
 
     context "members include females" do
       it "renders :edit" do
+        female_member1 = build(:member, sex: "female")
+        female_member2 = build(:member, sex: "female")
+        members = [
+          female_member1,
+          female_member2,
+          build(:member, sex: "male"),
+        ]
         medicaid_application = create(
           :medicaid_application,
           anyone_new_mom: true,
-          members: build_list(:member, 2, sex: "female"),
+          members: members,
         )
         session[:medicaid_application_id] = medicaid_application.id
 
         get :edit
 
         expect(response).to render_template(:edit)
+        expect(assigns[:step].members).to eq [female_member1, female_member2]
       end
     end
   end

--- a/spec/controllers/medicaid/insurance_current_member_controller_spec.rb
+++ b/spec/controllers/medicaid/insurance_current_member_controller_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::InsuranceCurrentMemberController, type: :controller do
+  describe "#next_path" do
+    it "is the  path" do
+      expect(subject.next_path).to eq(
+        "/steps/medicaid/insurance-current-type",
+      )
+    end
+  end
+
+  it_should_behave_like "Medicaid multi-member controller", :anyone_insured
+
+  describe "#edit" do
+    context "multi member household with one member requesting insurance" do
+      it "renders with correct members" do
+        member_requesting_insurance = build(
+          :member,
+          requesting_health_insurance: true,
+        )
+        member_not_requesting_insurance = build(
+          :member,
+          requesting_health_insurance: false,
+        )
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_insured: true,
+          members: [
+            member_requesting_insurance,
+            member_not_requesting_insurance,
+          ],
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to render_template(:edit)
+        expect(assigns[:step].members).to eq [member_requesting_insurance]
+      end
+    end
+  end
+
+  describe "#members_not_needing_insurance" do
+    context "multi member household with one member requesting insurance" do
+      it "returns members not requesting insurance" do
+        member_requesting_insurance = build(
+          :member,
+          requesting_health_insurance: true,
+        )
+        member_not_requesting_insurance = build(
+          :member,
+          requesting_health_insurance: false,
+        )
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_insured: true,
+          members: [
+            member_requesting_insurance,
+            member_not_requesting_insurance,
+          ],
+        )
+
+        session[:medicaid_application_id] = medicaid_application.id
+
+        expect(subject.members_not_needing_insurance).to eq [member_not_requesting_insurance]
+      end
+    end
+  end
+
+  describe "#update" do
+    context "multi member household with one member requesting insurance" do
+      it "with correct members" do
+        member = build(
+          :member,
+          requesting_health_insurance: true,
+        )
+        medicaid_application = create(
+          :medicaid_application,
+          anyone_insured: true,
+          members: [member],
+        )
+        session[:medicaid_application_id] = medicaid_application.id
+
+        put :update, params: {
+          step: {
+            members: {
+              member.id => { insured: 1 },
+            }
+          }
+        }
+
+        member.reload
+        expect(member.insured).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/tax_filing_with_household_members_member_controller_spec.rb
+++ b/spec/controllers/medicaid/tax_filing_with_household_members_member_controller_spec.rb
@@ -44,9 +44,14 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersMemberController do
       context "is filing federal taxes next year" do
         context "is filing taxes with household members" do
           it "renders edit" do
+            primary_member = build(:member)
+            non_applicant_member = build(:member)
             medicaid_application = create(
               :medicaid_application,
-              members: build_list(:member, 2),
+              members: [
+                primary_member,
+                non_applicant_member,
+              ],
               filing_federal_taxes_next_year: true,
               filing_taxes_with_household_members: true,
             )
@@ -55,6 +60,7 @@ RSpec.describe Medicaid::TaxFilingWithHouseholdMembersMemberController do
             get :edit
 
             expect(response).to render_template(:edit)
+            expect(assigns[:step].members).to eq [non_applicant_member]
           end
         end
 

--- a/spec/steps/medicaid/insurance_current_member_spec.rb
+++ b/spec/steps/medicaid/insurance_current_member_spec.rb
@@ -4,15 +4,11 @@ RSpec.describe Medicaid::InsuranceCurrentMember do
   describe "Validations" do
     context "at least one household member is insured" do
       it "is valid" do
-        member = build(:member,
-                        requesting_health_insurance: true,
-                        insured: true)
-        member_not_insured = build(:member,
-                                    requesting_health_insurance: true,
-                                    insured: false)
-
         step = Medicaid::InsuranceCurrentMember.new(
-          members: [member, member_not_insured],
+          members: [
+            build(:member, insured: true),
+            build(:member, insured: false),
+          ],
         )
 
         expect(step).to be_valid
@@ -21,11 +17,9 @@ RSpec.describe Medicaid::InsuranceCurrentMember do
 
     context "no household member is insured" do
       it "is invalid" do
-        members = build_list(:member, 2,
-                              requesting_health_insurance: true,
-                              insured: false)
-
-        step = Medicaid::InsuranceCurrentMember.new(members: members)
+        step = Medicaid::InsuranceCurrentMember.new(
+          members: build_list(:member, 2, insured: false),
+        )
 
         expect(step).not_to be_valid
       end


### PR DESCRIPTION
 * Previously, `ManyMembersStepsController` had to check if attributes
 were present, because there were times where only specific members
 populate a form, but when assigning attributes, it uses all members in
 application
 * No steps using `ManyMembersStepsController` have fields in the
 application, just on members, so no need to merge attributes
 * Remove some unused attributes from steps

 [#153526809]

Signed-off-by: Paras Sanghavi <paras@codeforamerica.org>