### PR TITLE
Fill in "Other" as pay interval when "Hourly"

### DIFF
--- a/lib/mi_bridges/driver/more_about_job_income_page.rb
+++ b/lib/mi_bridges/driver/more_about_job_income_page.rb
@@ -16,7 +16,7 @@ module MiBridges
         )
 
         select(
-          current_member.employed_pay_interval,
+          pay_interval,
           from: "How often does #{name} get paid? This is #{name}'s pay period",
         )
 
@@ -32,6 +32,14 @@ module MiBridges
       end
 
       private
+
+      def pay_interval
+        if current_member.employed_pay_interval == "Hourly"
+          "Other"
+        else
+          current_member.employed_pay_interval
+        end
+      end
 
       def not_salaried?
         current_member.employed_pay_interval != "Yearly"


### PR DESCRIPTION
* Hourly is not an option in MiBridges, but it is in our SNAP flow
* Pay interval is a required question for employed members in MiBridges,
so whenever they've reported it to us as Hourly, the flow fails on this
page
* This issue presents a larger product question, but for now the way we
can move past it and continue to drive apps where there is an employed
household member is to select "Other" in this case.
* Tagging the product / design story in here so we can un-do this
default select when we have more clarity on the longer term fix.
* [#153378349]
* I confirmed that this works with the SNAP id referenced in the story