### PR TITLE
Strip first name and last name leading/trailing whitespace

### DIFF
--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -77,6 +77,14 @@ class Member < ApplicationRecord
     key: Rails.application.secrets.secret_key_for_ssn_encryption,
   )
 
+  def first_name=(value)
+    super(value.try(:strip))
+  end
+
+  def last_name=(value)
+    super(value.try(:strip))
+  end
+
   def other_income_types_inclusion
     if (other_income_types - OTHER_INCOME_TYPES).any?
       errors.add(:other_income_types, "Not a valid income type")

--- a/spec/controllers/introduce_yourself_controller_spec.rb
+++ b/spec/controllers/introduce_yourself_controller_spec.rb
@@ -38,6 +38,26 @@ RSpec.describe IntroduceYourselfController do
   end
 
   describe "#update" do
+    context "name contains leading or trailing whitespace" do
+      it "strips whitespace" do
+        params = {
+          step: {
+            first_name: " Space ",
+            last_name: " Case ",
+            "birthday(3i)" => "31",
+            "birthday(2i)" => "1",
+            "birthday(1i)" => "1950",
+          },
+        }
+
+        put :update, params: params
+        member.reload
+
+        expect(member.first_name).to eq "Space"
+        expect(member.last_name).to eq "Case"
+      end
+    end
+
     context "no office location present" do
       context "valid params" do
         it "updates the application" do
@@ -85,7 +105,12 @@ RSpec.describe IntroduceYourselfController do
   end
 
   def member
-    build(:member, first_name: "bob", last_name: "booboo", birthday: birthday)
+    @_member ||= build(
+      :member,
+      first_name: "bob",
+      last_name: "booboo",
+      birthday: birthday,
+    )
   end
 
   def valid_params


### PR DESCRIPTION
* This is important for driving code because in MiBridges we depend on
first name to know which household member we are answering questions
about
* Could have used a gem instead, but this seemed like the simplest solution. See: https://stackoverflow.com/questions/3268053/rails-before-validation-strip-whitespace-best-practices
* [Finishes #153377419]
https://www.pivotaltracker.com/story/show/153377419