### PR TITLE
Reset exception handling within page loop

### DIFF
--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -97,16 +97,8 @@ module MiBridges
 
     def run
       setup
-      begin
-        sign_up_for_account
-        complete_application
-      rescue MiBridges::Errors::TooManyAttempts => e
-        save_error(e, @page)
-        raise e
-      rescue StandardError => e
-        save_error(e, @page)
-        debug(e)
-      end
+      sign_up_for_account
+      complete_application
       teardown
     end
 
@@ -138,10 +130,18 @@ module MiBridges
 
     def run_flow(flow)
       flow.each do |klass|
-        @page = klass.new(@snap_application, logger: logger)
-        @page.setup
-        @page.fill_in_required_fields
-        @page.continue
+        begin
+          @page = klass.new(@snap_application, logger: logger)
+          @page.setup
+          @page.fill_in_required_fields
+          @page.continue
+        rescue MiBridges::Errors::TooManyAttempts => e
+          save_error(e, @page)
+          raise e
+        rescue StandardError => e
+          save_error(e, @page)
+          debug(e)
+        end
       end
     end
 
@@ -176,11 +176,12 @@ module MiBridges
     end
 
     def debug(e)
-      if ENV["DEBUG_DRIVE"]
+      if ENV["DEBUG_DRIVE"] == "true"
         # rubocop:disable Debugger
         binding.pry
         # rubocop:enable Debugger
       else
+        logger.log(e.backtrace)
         raise e
       end
     end


### PR DESCRIPTION
When we moved exception handling a level higher, we lost the ability for a drive to pick up where the exception was raised. This resets it to the original behavior and adds backtrace logging. It does not handle properly catching and logging problems with logging errors when we hit TooManyAttempts error(?), which moving exception handling up was meant to solve, so will still need to handle that elsewhere.

[#152982028]

Signed-off-by: Ben Golder <bgolder@codeforamerica.org>