### PR TITLE
MiBridges: Add Dependent care expenses and details

### DIFF
--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -37,6 +37,7 @@ module MiBridges
       BenefitsOverviewPage,
       BenefitsSelectorPage,
       ConceptionPage,
+      DependentCarePage,
       DisabilityOrBlindnessReviewPage,
       FinishPage,
       HealthHospitalizationInsurancePremiumsPage,

--- a/lib/mi_bridges/driver/dependent_care_page.rb
+++ b/lib/mi_bridges/driver/dependent_care_page.rb
@@ -1,0 +1,31 @@
+module MiBridges
+  class Driver
+    class DependentCarePage < ClickNextPage
+      def self.title
+        "Dependent Care"
+      end
+
+      delegate(
+        :monthly_care_expenses,
+        to: :snap_application,
+      )
+
+      def setup; end
+
+      def fill_in_required_fields
+        fill_in_dependent_care_expenses
+        select_dependent_care_payment_frequency
+      end
+
+      private
+
+      def fill_in_dependent_care_expenses
+        fill_in("supposedToPay_Paid", with: monthly_care_expenses)
+      end
+
+      def select_dependent_care_payment_frequency
+        select("Monthly", from: "payFreqForOtherExpnses")
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
+++ b/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
@@ -7,6 +7,7 @@ module MiBridges
 
       delegate(
         :court_ordered?,
+        :dependent_care?,
         :monthly_medical_expenses?,
         :primary_member,
         to: :snap_application,
@@ -36,7 +37,11 @@ module MiBridges
       end
 
       def check_dependent_care_bills
-        check_no_one_in_section "starDependentCareBills"
+        check_in_section(
+          "starDependentCareBills",
+          condition: dependent_care?,
+          for_label: primary_member.mi_bridges_formatted_name,
+        )
       end
 
       def check_medical_bills

--- a/spec/features/mi_bridges_driving_spec.rb
+++ b/spec/features/mi_bridges_driving_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.feature "MI Bridges Driving" do
   # to run this in a non-headless way, remove the `:js` flag below
-  scenario "successfully drives, then re-drives a SNAP App", :driving do
+  scenario "successfully drives, then re-drives a SNAP App", :js, :driving do
     WebMock.disable!
 
     address = build(:mailing_address, county: "Genesee")
@@ -13,6 +13,7 @@ RSpec.feature "MI Bridges Driving" do
       members: [member, second_member],
       mailing_address_same_as_residential_address: true,
       addresses: [address],
+      dependent_care: true,
     )
 
     MiBridges::Driver.new(snap_application: snap_application).run


### PR DESCRIPTION
* We were previously saying that "No one" had dependent care expenses;
now we are adding them when present and indicating the amount on the
follow up page.
* [Finishes #153570213]
* Confirmed that this works by adding `dependent_care: true` to the Snap
App in the MIBridges spec and running it - it passes.
https://www.pivotaltracker.com/story/show/153570213