### PR TITLE
Rename ENV var that enables MiBridges spec to run

### DIFF
--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -216,7 +216,7 @@ module MiBridges
     end
 
     def teardown
-      if ENV["PRE_DEPLOY_TEST"] != "true"
+      if ENV["RUN_MI_BRIDGES_TEST"] != "true"
         MiBridges::Driver::BasePage.new(snap_application, logger: logger).close
       end
     end

--- a/lib/mi_bridges/driver/submit_page.rb
+++ b/lib/mi_bridges/driver/submit_page.rb
@@ -11,7 +11,9 @@ module MiBridges
       def fill_in_required_fields; end
 
       def continue
-        close unless ENV["PRE_DEPLOY_TEST"] == "true"
+        unless ENV["RUN_MI_BRIDGES_TEST"] == "true"
+          close
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
 
   config.filter_run :focus
 
-  if ENV["PRE_DEPLOY_TEST"] == "true"
+  if ENV["RUN_MI_BRIDGES_TEST"] == "true"
     config.filter_run :driving
   else
     config.filter_run_excluding :driving


### PR DESCRIPTION
* We used to run it as part of a pre-deploy test so this ENV var made
sense then, but we no longer do that.