### PR TITLE
Link to SnapApplication from DriverError in admin

### DIFF
--- a/app/views/admin/driver_errors/_collection.html.erb
+++ b/app/views/admin/driver_errors/_collection.html.erb
@@ -1,0 +1,106 @@
+<%#
+# Collection
+
+This partial is used on the `index` and `show` pages
+to display a collection of resources in an HTML table.
+
+## Local variables:
+
+- `collection_presenter`:
+  An instance of [Administrate::Page::Collection][1].
+  The table presenter uses `ResourceDashboard::COLLECTION_ATTRIBUTES` to determine
+  the columns displayed in the table
+- `resources`:
+  An ActiveModel::Relation collection of resources to be displayed in the table.
+  By default, the number of resources is limited by pagination
+  or by a hard limit to prevent excessive page load times
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<table aria-labelledby="<%= table_title %>">
+  <thead>
+    <tr>
+
+      <th class="cell-label cell-label--application_id">SNAP Application</th>
+
+      <% collection_presenter.attribute_types.each do |attr_name, attr_type| %>
+        <th class="cell-label
+        cell-label--<%= attr_type.html_class %>
+        cell-label--<%= collection_presenter.ordered_html_class(attr_name) %>"
+        scope="col"
+        role="columnheader"
+        aria-sort="<%= sort_order(collection_presenter.ordered_html_class(attr_name)) %>">
+        <%= link_to(sanitized_order_params.merge(
+          collection_presenter.order_params_for(attr_name)
+        )) do %>
+        <%= t(
+          "helpers.label.#{collection_presenter.resource_name}.#{attr_name}",
+          default: attr_name.to_s,
+        ).titleize %>
+
+            <% if collection_presenter.ordered_by?(attr_name) %>
+              <span class="cell-label__sort-indicator cell-label__sort-indicator--<%= collection_presenter.ordered_html_class(attr_name) %>">
+                <svg aria-hidden="true">
+                  <use xlink:href="#icon-up-caret" />
+                </svg>
+              </span>
+            <% end %>
+          <% end %>
+        </th>
+      <% end %>
+      <% [valid_action?(:edit, collection_presenter.resource_name),
+          valid_action?(:destroy, collection_presenter.resource_name)].count(true).times do %>
+        <th scope="col"></th>
+      <% end %>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% resources.each do |resource| %>
+      <tr class="js-table-row"
+          tabindex="0"
+          <% if valid_action? :show, collection_presenter.resource_name %>
+            <%= %(role=link data-url=#{polymorphic_path([namespace, resource])}) %>
+          <% end %>
+          >
+
+        <td class="cell-data cell-data--application">
+          <%=  link_to(
+                   resource.driver_application.snap_application_id,
+                   [namespace, resource.driver_application.snap_application],
+           ) %>
+
+        </td>
+
+        <% collection_presenter.attributes_for(resource).each do |attribute| %>
+          <td class="cell-data cell-data--<%= attribute.html_class %>">
+            <a href="<%= polymorphic_path([namespace, resource]) -%>"
+               class="action-show"
+               >
+              <%= render_field attribute %>
+            </a>
+          </td>
+        <% end %>
+
+        <% if valid_action? :edit, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.edit"),
+            [:edit, namespace, resource],
+            class: "action-edit",
+          ) %></td>
+        <% end %>
+
+        <% if valid_action? :destroy, collection_presenter.resource_name %>
+          <td><%= link_to(
+            t("administrate.actions.destroy"),
+            [namespace, resource],
+            class: "text-color-red",
+            method: :delete,
+            data: { confirm: t("administrate.actions.confirm") }
+          ) %></td>
+        <% end %>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/driver_errors/index.html.erb
+++ b/app/views/admin/driver_errors/index.html.erb
@@ -1,0 +1,61 @@
+<%#
+# Index
+
+This view is the template for the index page.
+It is responsible for rendering the search bar, header and pagination.
+It renders the `_table` partial to display details about the resources.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Collection][1].
+  Contains helper methods to help display a table,
+  and knows which attributes should be displayed in the resource's table.
+- `resources`:
+  An instance of `ActiveRecord::Relation` containing the resources
+  that match the user's search criteria.
+  By default, these resources are passed to the table partial to be displayed.
+- `search_term`:
+  A string containing the term the user has searched for, if any.
+- `show_search_bar`:
+  A boolean that determines if the search bar should be shown.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Collection
+%>
+
+<% content_for(:title) do %>
+  <%= display_resource_name(page.resource_name) %>
+<% end %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title" id="page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <% if show_search_bar %>
+    <%= render(
+      "search",
+      search_term: search_term,
+      resource_name: display_resource_name(page.resource_name)
+    ) %>
+  <% end %>
+
+  <div>
+    <%= link_to(
+      "#{t("administrate.actions.new")} #{page.resource_name.titleize.downcase}",
+      [:new, namespace, page.resource_path],
+      class: "button",
+    ) if valid_action? :new %>
+  </div>
+</header>
+
+<section class="main-content__body main-content__body--flush">
+  <%= render(
+    "collection",
+    collection_presenter: page,
+    resources: resources,
+    table_title: "page-title"
+  ) %>
+
+  <%= paginate resources %>
+</section>

--- a/app/views/admin/driver_errors/show.html.erb
+++ b/app/views/admin/driver_errors/show.html.erb
@@ -1,0 +1,58 @@
+<%#
+# Show
+
+This view is the template for the show page.
+It renders the attributes of a resource,
+as well as a link to its edit page.
+
+## Local variables:
+
+- `page`:
+  An instance of [Administrate::Page::Show][1].
+  Contains methods for accessing the resource to be displayed on the page,
+  as well as helpers for describing how each attribute of the resource
+  should be displayed.
+
+[1]: http://www.rubydoc.info/gems/administrate/Administrate/Page/Show
+%>
+
+<% content_for(:title) { "#{t("administrate.actions.show")} #{page.page_title}" } %>
+
+<header class="main-content__header" role="banner">
+  <h1 class="main-content__page-title">
+    <%= content_for(:title) %>
+  </h1>
+
+  <div>
+    <%= link_to(
+      "#{t("administrate.actions.edit")} #{page.page_title}",
+      [:edit, namespace, page.resource],
+      class: "button",
+    ) if valid_action? :edit %>
+  </div>
+</header>
+
+<section class="main-content__body">
+  <dl>
+    <dt class="attribute-label" id="snap_application_id>">
+      SNAP Application
+    </dt>
+    <dd class="attribute-data attribute-data--snap_application_id">
+      <%=  link_to(
+               page.resource.driver_application.snap_application_id,
+               [namespace, page.resource.driver_application.snap_application],
+           ) %>
+    </dd>
+    <% page.attributes.each do |attribute| %>
+      <dt class="attribute-label" id="<%= attribute.name %>">
+      <%= t(
+        "helpers.label.#{resource_name}.#{attribute.name}",
+        default: attribute.name.titleize,
+      ) %>
+      </dt>
+
+      <dd class="attribute-data attribute-data--<%=attribute.html_class%>"
+          ><%= render_field attribute %></dd>
+    <% end %>
+  </dl>
+</section>

--- a/spec/features/admin_dashboard_driver_errors_spec.rb
+++ b/spec/features/admin_dashboard_driver_errors_spec.rb
@@ -18,9 +18,19 @@ RSpec.feature "Admin viewing driver errors dashboard", type: :feature do
     visit admin_root_path
 
     click_on "Driver Errors"
+
+    expect(page).to have_link(
+      driver_error.driver_application.snap_application_id,
+    )
+
     click_on "FakeError"
+
     expect(page).to have_content(
       "the error happened on a line right here, see?!",
+    )
+
+    expect(page).to have_link(
+      driver_error.driver_application.snap_application_id,
     )
   end
 end


### PR DESCRIPTION
Administrate does not seem to make it particularly easy to add attributes that span across related tables.

This creates [customized page views](https://administrate-prototype.herokuapp.com/customizing_page_views) that link to related snap applications.

Totally open to the idea that we may not want to solve in this way, but it works.

[#153521242]

<img width="396" alt="screen shot 2017-12-11 at 3 52 13 pm" src="https://user-images.githubusercontent.com/451510/33859968-59f1f5d4-de8b-11e7-92c2-39240241d12e.png">
<img width="533" alt="screen shot 2017-12-11 at 3 52 02 pm" src="https://user-images.githubusercontent.com/451510/33859970-5a07cd50-de8b-11e7-9743-2d5ae5a70943.png">
