### PR TITLE
Add `FillInAndClickNextPage`

### DIFF
--- a/lib/mi_bridges/driver/absent_parent_details_page.rb
+++ b/lib/mi_bridges/driver/absent_parent_details_page.rb
@@ -1,18 +1,12 @@
 module MiBridges
   class Driver
-    class AbsentParentDetailsPage < BasePage
+    class AbsentParentDetailsPage < FillInAndClickNextPage
       def self.title
         "Absent Parent Details"
       end
 
-      def setup; end
-
       def fill_in_required_fields
         indicate_parent_name_unknown
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/additional_information_page.rb
+++ b/lib/mi_bridges/driver/additional_information_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class AdditionalInformationPage < ClickNextPage
+    class AdditionalInformationPage < FillInAndClickNextPage
       def self.title
         "Additional Information"
       end

--- a/lib/mi_bridges/driver/benefits_selector_page.rb
+++ b/lib/mi_bridges/driver/benefits_selector_page.rb
@@ -1,19 +1,13 @@
 module MiBridges
   class Driver
-    class BenefitsSelectorPage < BasePage
+    class BenefitsSelectorPage < FillInAndClickNextPage
       def self.title
         "Which Benefits Would You Like to Apply For? (All Programs)"
       end
 
-      def setup; end
-
       def fill_in_required_fields
         click_id(food_assistance_checkbox)
         click_id(no_dont_contact_my_energy_provider_radio)
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/fill_in_and_click_next_page.rb
+++ b/lib/mi_bridges/driver/fill_in_and_click_next_page.rb
@@ -1,0 +1,11 @@
+module MiBridges
+  class Driver
+    class FillInAndClickNextPage < BasePage
+      def setup; end
+
+      def continue
+        click_on "Next"
+      end
+    end
+  end
+end

--- a/lib/mi_bridges/driver/household_member_questions_page.rb
+++ b/lib/mi_bridges/driver/household_member_questions_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class HouseholdMemberQuestionsPage < BasePage
+    class HouseholdMemberQuestionsPage < FillInAndClickNextPage
       def self.title
         "Household Member Questions"
       end
@@ -10,8 +10,6 @@ module MiBridges
         :primary_member,
         to: :snap_application,
       )
-
-      def setup; end
 
       def fill_in_required_fields
         check_blindness_or_disability
@@ -23,9 +21,7 @@ module MiBridges
         check_refugee_asylee_or_victim
       end
 
-      def continue
-        click_on "Next"
-      end
+      private
 
       def check_blindness_or_disability
         check_in_section(

--- a/lib/mi_bridges/driver/housing_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_bills_page.rb
@@ -1,20 +1,14 @@
 module MiBridges
   class Driver
-    class HousingBillsPage < BasePage
+    class HousingBillsPage < FillInAndClickNextPage
       def self.title
         "Housing Bills"
       end
 
       delegate :primary_member, to: :snap_application
 
-      def setup; end
-
       def fill_in_required_fields
         check_housing_bills
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/housing_utility_bills_page.rb
+++ b/lib/mi_bridges/driver/housing_utility_bills_page.rb
@@ -1,23 +1,17 @@
 module MiBridges
   class Driver
-    class HousingUtilityBillsPage < BasePage
+    class HousingUtilityBillsPage < FillInAndClickNextPage
       def self.title
         "Housing and Utility Bills"
       end
 
       delegate :primary_member, to: :snap_application
 
-      def setup; end
-
       def fill_in_required_fields
         check_housing_bills
         check_utility_bills
         check_room_and_meals
         select_home_heating_payment
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/information_about_the_child_page.rb
+++ b/lib/mi_bridges/driver/information_about_the_child_page.rb
@@ -1,18 +1,12 @@
 module MiBridges
   class Driver
-    class InformationAboutTheChildPage < BasePage
+    class InformationAboutTheChildPage < FillInAndClickNextPage
       def self.title
         "Information About the Child"
       end
 
-      def setup; end
-
       def fill_in_required_fields
         select "Single-Never Married", from: marital_status_question
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/job_income_information_page.rb
+++ b/lib/mi_bridges/driver/job_income_information_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class JobIncomeInformationPage < BasePage
+    class JobIncomeInformationPage < FillInAndClickNextPage
       def self.title
         "Job Income Information"
       end
@@ -8,16 +8,10 @@ module MiBridges
       delegate :primary_member, to: :snap_application
       delegate :employment_status, to: :primary_member
 
-      def setup; end
-
       def fill_in_required_fields
         check_fulltime_employment_status
         check_self_employment_status
         check_fap_program_benefits
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/liquid_assets_page.rb
+++ b/lib/mi_bridges/driver/liquid_assets_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class LiquidAssetsPage < BasePage
+    class LiquidAssetsPage < FillInAndClickNextPage
       def self.title
         "Liquid Assets"
       end
@@ -12,17 +12,11 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup; end
-
       def fill_in_required_fields
         check_cash_on_hand
         check_savings_account
         check_checking_account
         check_other_liquid_assets
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/mailing_address_page.rb
+++ b/lib/mi_bridges/driver/mailing_address_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class MailingAddressPage < BasePage
+    class MailingAddressPage < FillInAndClickNextPage
       def self.title
         "Mailing Address"
       end
@@ -15,17 +15,11 @@ module MiBridges
         to: :mailing_address,
       )
 
-      def setup; end
-
       def fill_in_required_fields
         fill_in "Street Address or P.O. Box Number", with: street_address
         select county, from: "County"
         fill_in "City", with: city
         fill_in "Zip Code", with: zip
-      end
-
-      def continue
-        click_on "Next"
       end
     end
   end

--- a/lib/mi_bridges/driver/medical_bills_page.rb
+++ b/lib/mi_bridges/driver/medical_bills_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class MedicalBillsPage < BasePage
+    class MedicalBillsPage < FillInAndClickNextPage
       def self.title
         "Medical Bills"
       end
@@ -11,18 +11,12 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup; end
-
       def fill_in_required_fields
         check_health_insurance
         check_prescriptions
         check_dental
         check_in_home_care
         check_hospital_bills
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/money_other_sources_page.rb
+++ b/lib/mi_bridges/driver/money_other_sources_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class MoneyOtherSourcesPage < BasePage
+    class MoneyOtherSourcesPage < FillInAndClickNextPage
       def self.title
         "Money From Other Sources"
       end
@@ -13,18 +13,12 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup; end
-
       def fill_in_required_fields
         check_retirement_survivors_disability_insurance
         check_child_support_income
         check_other_income
         check_supplemental_security_income
         check_room_and_meals
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/more_about_cash_on_hand_page.rb
+++ b/lib/mi_bridges/driver/more_about_cash_on_hand_page.rb
@@ -1,11 +1,9 @@
 module MiBridges
   class Driver
-    class MoreAboutCashOnHandPage < BasePage
+    class MoreAboutCashOnHandPage < FillInAndClickNextPage
       def self.title
         /More About (.*)'s Cash on Hand/
       end
-
-      def setup; end
 
       def fill_in_required_fields
         if snap_application.total_money.present?
@@ -13,10 +11,6 @@ module MiBridges
         else
           click_id("#iDontknow")
         end
-      end
-
-      def continue
-        click_on "Next"
       end
     end
   end

--- a/lib/mi_bridges/driver/more_about_checking_account_page.rb
+++ b/lib/mi_bridges/driver/more_about_checking_account_page.rb
@@ -1,18 +1,12 @@
 module MiBridges
   class Driver
-    class MoreAboutCheckingAccountPage < BasePage
+    class MoreAboutCheckingAccountPage < FillInAndClickNextPage
       def self.title
         /More About (.*)'s Checking Account/
       end
 
-      def setup; end
-
       def fill_in_required_fields
         click_id "#iDontknow"
-      end
-
-      def continue
-        click_on "Next"
       end
     end
   end

--- a/lib/mi_bridges/driver/more_about_disability_benefits_page.rb
+++ b/lib/mi_bridges/driver/more_about_disability_benefits_page.rb
@@ -1,21 +1,15 @@
 module MiBridges
   class Driver
-    class MoreAboutDisabilityBenefitsPage < BasePage
+    class MoreAboutDisabilityBenefitsPage < FillInAndClickNextPage
       def self.title
         /More About (.*)'s Disability Benefits/
       end
-
-      def setup; end
 
       def fill_in_required_fields
         fill_in(
           "How much is each payment for Disability Benefits?",
           with: snap_application.income_ssi_or_disability,
         )
-      end
-
-      def continue
-        click_on "Next"
       end
     end
   end

--- a/lib/mi_bridges/driver/more_about_job_income_page.rb
+++ b/lib/mi_bridges/driver/more_about_job_income_page.rb
@@ -1,13 +1,11 @@
 module MiBridges
   class Driver
-    class MoreAboutJobIncomePage < BasePage
+    class MoreAboutJobIncomePage < FillInAndClickNextPage
       def self.title
         /More About (.*)'s Job/
       end
 
       delegate :members, to: :snap_application
-
-      def setup; end
 
       def fill_in_required_fields
         fill_in(
@@ -25,10 +23,6 @@ module MiBridges
         else
           fill_in_salary
         end
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/more_about_other_income_page.rb
+++ b/lib/mi_bridges/driver/more_about_other_income_page.rb
@@ -1,21 +1,15 @@
 module MiBridges
   class Driver
-    class MoreAboutOtherIncomePage < BasePage
+    class MoreAboutOtherIncomePage < FillInAndClickNextPage
       def self.title
         /More About (.*)'s Other Income/
       end
-
-      def setup; end
 
       def fill_in_required_fields
         fill_in(
           "howMuchOtherIncomeAmt",
           with: snap_application.income_other,
         )
-      end
-
-      def continue
-        click_on "Next"
       end
     end
   end

--- a/lib/mi_bridges/driver/more_about_pension_or_retirement_page.rb
+++ b/lib/mi_bridges/driver/more_about_pension_or_retirement_page.rb
@@ -1,21 +1,15 @@
 module MiBridges
   class Driver
-    class MoreAboutPensionOrRetirementPage < BasePage
+    class MoreAboutPensionOrRetirementPage < FillInAndClickNextPage
       def self.title
         /More About (.*)'s Pension or Retirement/
       end
-
-      def setup; end
 
       def fill_in_required_fields
         fill_in(
           "How much is each payment from this Pension or Retirement account?",
           with: snap_application.income_pension,
         )
-      end
-
-      def continue
-        click_on "Next"
       end
     end
   end

--- a/lib/mi_bridges/driver/more_about_self_employment_page.rb
+++ b/lib/mi_bridges/driver/more_about_self_employment_page.rb
@@ -1,23 +1,17 @@
 module MiBridges
   class Driver
-    class MoreAboutSelfEmploymentPage < BasePage
+    class MoreAboutSelfEmploymentPage < FillInAndClickNextPage
       def self.title
         /More About (.*)'s Self-Employment/
       end
 
       delegate :members, to: :snap_application
 
-      def setup; end
-
       def fill_in_required_fields
         members.each do |member|
           fill_in_all_programs_for(member)
           fill_in_fap_program_benefits_for(member)
         end
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/more_about_supplemental_security_income_page.rb
+++ b/lib/mi_bridges/driver/more_about_supplemental_security_income_page.rb
@@ -1,21 +1,15 @@
 module MiBridges
   class Driver
-    class MoreAboutSupplementalSecurityIncomePage < BasePage
+    class MoreAboutSupplementalSecurityIncomePage < FillInAndClickNextPage
       def self.title
         /More About (.*)'s Supplemental Security Income \(SSI\)/
       end
-
-      def setup; end
 
       def fill_in_required_fields
         fill_in(
           "How much is each payment for Supplemental Security Income (SSI)?",
           with: snap_application.income_ssi_or_disability,
         )
-      end
-
-      def continue
-        click_on "Next"
       end
     end
   end

--- a/lib/mi_bridges/driver/more_about_unemployment_benefits_page.rb
+++ b/lib/mi_bridges/driver/more_about_unemployment_benefits_page.rb
@@ -1,21 +1,15 @@
 module MiBridges
   class Driver
-    class MoreAboutUnemploymentBenefitsPage < BasePage
+    class MoreAboutUnemploymentBenefitsPage < FillInAndClickNextPage
       def self.title
         /More About (.*)'s Unemployment Benefits/
       end
-
-      def setup; end
 
       def fill_in_required_fields
         fill_in(
           "How much is each payment for Unemployment Benefits?",
           with: snap_application.income_unemployment_insurance,
         )
-      end
-
-      def continue
-        click_on "Next"
       end
     end
   end

--- a/lib/mi_bridges/driver/more_about_workers_compensation_page.rb
+++ b/lib/mi_bridges/driver/more_about_workers_compensation_page.rb
@@ -1,21 +1,15 @@
 module MiBridges
   class Driver
-    class MoreAboutWorkersCompensationPage < BasePage
+    class MoreAboutWorkersCompensationPage < FillInAndClickNextPage
       def self.title
         /More About (.*)'s Workers Compensation/
       end
-
-      def setup; end
 
       def fill_in_required_fields
         fill_in(
           "How much is each payment for Workers Compensation?",
           with: snap_application.income_workers_compensation,
         )
-      end
-
-      def continue
-        click_on "Next"
       end
     end
   end

--- a/lib/mi_bridges/driver/multi_factor_auth_page.rb
+++ b/lib/mi_bridges/driver/multi_factor_auth_page.rb
@@ -1,14 +1,8 @@
 module MiBridges
   class Driver
-    class MultiFactorAuthPage < BasePage
-      def setup; end
-
+    class MultiFactorAuthPage < FillInAndClickNextPage
       def fill_in_required_fields
         click_id(security_question_radio_button)
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/other_assets_page.rb
+++ b/lib/mi_bridges/driver/other_assets_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class OtherAssetsPage < BasePage
+    class OtherAssetsPage < FillInAndClickNextPage
       def self.title
         "Other Assets"
       end
@@ -13,8 +13,6 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup; end
-
       def fill_in_required_fields
         check_vehicles
         check_real_estate
@@ -22,10 +20,6 @@ module MiBridges
         check_life_insurance
         check_additional_assets
         check_selling_or_giving_away
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/other_types_of_income_page.rb
+++ b/lib/mi_bridges/driver/other_types_of_income_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class OtherTypesOfIncomePage < BasePage
+    class OtherTypesOfIncomePage < FillInAndClickNextPage
       def self.title
         "Other Types of Income"
       end
@@ -11,17 +11,11 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup; end
-
       def fill_in_required_fields
         check_unemployment
         check_workers_compensation
         check_pension_or_retirement
         check_other_income
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/people_listed_page.rb
+++ b/lib/mi_bridges/driver/people_listed_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class PeopleListedPage < BasePage
+    class PeopleListedPage < FillInAndClickNextPage
       def self.title
         "People Listed On Your Application"
       end
@@ -33,10 +33,6 @@ module MiBridges
         else
           fill_in "peopleInYourHome", with: snap_application.members.size
         end
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/pregnancy_information_page.rb
+++ b/lib/mi_bridges/driver/pregnancy_information_page.rb
@@ -1,13 +1,11 @@
 module MiBridges
   class Driver
-    class PregnancyInformationPage < BasePage
+    class PregnancyInformationPage < FillInAndClickNextPage
       def self.title
         "Pregnancy Information"
       end
 
       delegate :members, to: :snap_application
-
-      def setup; end
 
       def fill_in_required_fields
         if no_one_pregnant?
@@ -23,10 +21,6 @@ module MiBridges
             end
           end
         end
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/privacy_pin_page.rb
+++ b/lib/mi_bridges/driver/privacy_pin_page.rb
@@ -1,18 +1,12 @@
 module MiBridges
   class Driver
-    class PrivacyPinPage < BasePage
+    class PrivacyPinPage < FillInAndClickNextPage
       def self.title
         "Privacy PIN"
       end
 
-      def setup; end
-
       def fill_in_required_fields
         click_id(this_is_a_private_computer_id)
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/real_properties_page.rb
+++ b/lib/mi_bridges/driver/real_properties_page.rb
@@ -1,18 +1,12 @@
 module MiBridges
   class Driver
-    class RealPropertiesPage < BasePage
+    class RealPropertiesPage < FillInAndClickNextPage
       def self.title
         "Real Properties"
       end
 
-      def setup; end
-
       def fill_in_required_fields
         click_other_real_properties_box
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/school_enrollment_page.rb
+++ b/lib/mi_bridges/driver/school_enrollment_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class SchoolEnrollmentPage < ClickNextPage
+    class SchoolEnrollmentPage < FillInAndClickNextPage
       def self.title
         "School Enrollment"
       end
@@ -9,6 +9,8 @@ module MiBridges
         choose_enrollment_time_for(snap_application.primary_member)
         choose_highest_grade_completion_for(snap_application.primary_member)
       end
+
+      private
 
       def choose_enrollment_time_for(member)
         selector = if member.in_college

--- a/lib/mi_bridges/driver/security_questions_page.rb
+++ b/lib/mi_bridges/driver/security_questions_page.rb
@@ -1,17 +1,11 @@
 module MiBridges
   class Driver
-    class SecurityQuestionsPage < BasePage
+    class SecurityQuestionsPage < FillInAndClickNextPage
       delegate :latest_drive_attempt, to: :snap_application
-
-      def setup; end
 
       def fill_in_required_fields
         fill_in "Answer to Secret Question1:", with: answer_1
         fill_in "Answer to Secret Question2:", with: answer_2
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/start_page.rb
+++ b/lib/mi_bridges/driver/start_page.rb
@@ -1,21 +1,15 @@
 module MiBridges
   class Driver
-    class StartPage < BasePage
+    class StartPage < FillInAndClickNextPage
       CIVILLA_COMMUNITY_PARTNER_ID = 3949
 
       def self.title
         "Help With Filing MI Bridges Application"
       end
 
-      def setup; end
-
       def fill_in_required_fields
         fill_in "agencyNumber", with: CIVILLA_COMMUNITY_PARTNER_ID
         click_id(a_staff_person_or_volunteer_at_an_agency)
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/utility_bills_page.rb
+++ b/lib/mi_bridges/driver/utility_bills_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class UtilityBillsPage < BasePage
+    class UtilityBillsPage < FillInAndClickNextPage
       def self.title
         "Utility Bills"
       end
@@ -16,8 +16,6 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup; end
-
       def fill_in_required_fields
         check_heat
         check_cooling
@@ -26,10 +24,6 @@ module MiBridges
         check_trash
         check_phone
         check_none
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/vehicles_page.rb
+++ b/lib/mi_bridges/driver/vehicles_page.rb
@@ -1,18 +1,12 @@
 module MiBridges
   class Driver
-    class VehiclesPage < BasePage
+    class VehiclesPage < FillInAndClickNextPage
       def self.title
         "Vehicles"
       end
 
-      def setup; end
-
       def fill_in_required_fields
         click_other_vehicles_box
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private

--- a/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
+++ b/lib/mi_bridges/driver/your_other_bills_expenses_page.rb
@@ -1,6 +1,6 @@
 module MiBridges
   class Driver
-    class YourOtherBillsExpensesPage < BasePage
+    class YourOtherBillsExpensesPage < FillInAndClickNextPage
       def self.title
         "Your Other Bills / Expenses"
       end
@@ -12,17 +12,11 @@ module MiBridges
         to: :snap_application,
       )
 
-      def setup; end
-
       def fill_in_required_fields
         check_child_spousal_payments
         check_dependent_care_bills
         check_medical_bills
         check_medicare
-      end
-
-      def continue
-        click_on "Next"
       end
 
       private


### PR DESCRIPTION
* We already have `ClickNextPage` for pages where all we want to do is
click next
* For many other pages, the API is different but similar: fill in fields
then click next. Now, we have a parent class to inherit from. This will
mean that we need less boilerplate code when adding a new Page class for
MiBridges.