### PR TITLE
[PAIR] Add Page History to DriverApplication

### DIFF
--- a/app/dashboards/driver_error_dashboard.rb
+++ b/app/dashboards/driver_error_dashboard.rb
@@ -2,7 +2,7 @@ require "administrate/base_dashboard"
 
 class DriverErrorDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
-    driver_application: Field::BelongsTo,
+    page_history: Field::String,
     snap_application: Field::HasOne,
     id: Field::Number,
     error_class: Field::String,
@@ -26,6 +26,7 @@ class DriverErrorDashboard < Administrate::BaseDashboard
     error_class
     error_message
     page_class
+    page_history
     backtrace
     page_html
     created_at

--- a/app/models/driver_error.rb
+++ b/app/models/driver_error.rb
@@ -7,4 +7,8 @@ class DriverError < ApplicationRecord
   validates :error_message, presence: true
   validates :page_class, presence: true
   validates :page_html, presence: true
+
+  def page_history
+    driver_application.page_history.join("<br>").html_safe
+  end
 end

--- a/db/migrate/20171212193613_add_page_history_to_driver_applications.rb
+++ b/db/migrate/20171212193613_add_page_history_to_driver_applications.rb
@@ -1,0 +1,7 @@
+class AddPageHistoryToDriverApplications < ActiveRecord::Migration[5.1]
+  def change
+    add_column :driver_applications, :page_history, :string, array: true
+
+    change_column_default :driver_applications, :page_history, from: nil, to: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171212175033) do
+ActiveRecord::Schema.define(version: 20171212193613) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 20171212175033) do
     t.string "encrypted_secret_question_2_answer_iv", null: false
     t.string "encrypted_user_id", null: false
     t.string "encrypted_user_id_iv", null: false
+    t.string "page_history", default: [], array: true
     t.bigint "snap_application_id", null: false
     t.string "tracking_number"
     t.datetime "updated_at", null: false

--- a/lib/mi_bridges/driver.rb
+++ b/lib/mi_bridges/driver.rb
@@ -169,8 +169,6 @@ module MiBridges
     end
 
     def save_error(e, page)
-      return if latest_drive_attempt.nil?
-
       latest_drive_attempt.
         driver_errors.
         create(
@@ -197,6 +195,11 @@ module MiBridges
 
     def setup
       Capybara.default_driver = ENV.fetch("WEB_DRIVER", "chrome").to_sym
+      if latest_drive_attempt.blank?
+        MiBridges::Driver::Services::DriverApplicationFactory.new(
+          snap_application: snap_application,
+        ).run
+      end
     end
 
     def find_page_klass

--- a/lib/mi_bridges/driver/base_page.rb
+++ b/lib/mi_bridges/driver/base_page.rb
@@ -9,6 +9,7 @@ module MiBridges
 
       def initialize(snap_application, logger: nil)
         @logger = logger
+        snap_application.latest_drive_attempt.page_history << self.class.name
         log("filling out page")
         @snap_application = snap_application
         return if skip_infinite_loop_check?

--- a/lib/mi_bridges/driver/create_account_page.rb
+++ b/lib/mi_bridges/driver/create_account_page.rb
@@ -1,10 +1,6 @@
 module MiBridges
   class Driver
     class CreateAccountPage < BasePage
-      MAXIMUM_SECRET_QUESTION_ANSWER_CHAR_COUNT = 20
-      MAXIMUM_USER_ID_CHAR_COUNT = 20
-      MAXIMUM_PASSWORD_CHAR_COUNT = 16
-
       def self.title
         "Setting Up Your Account"
       end
@@ -14,10 +10,6 @@ module MiBridges
       def setup; end
 
       def fill_in_required_fields
-        if latest_drive_attempt.blank?
-          create_driver_application
-        end
-
         fill_in "First Name", with: primary_member.first_name
         fill_in "Last Name", with: primary_member.last_name
 
@@ -42,32 +34,6 @@ module MiBridges
       end
 
       private
-
-      def create_driver_application
-        snap_application.driver_applications.create(
-          user_id: generate_user_id,
-          password: generate_password,
-          secret_question_1_answer: generate_secret_question_1_answer,
-          secret_question_2_answer: generate_secret_question_2_answer,
-          driven_at: DateTime.current,
-        )
-      end
-
-      def generate_user_id
-        SecureRandom.hex(MAXIMUM_USER_ID_CHAR_COUNT / 2)
-      end
-
-      def generate_password
-        SecureRandom.hex(MAXIMUM_PASSWORD_CHAR_COUNT / 2)
-      end
-
-      def generate_secret_question_1_answer
-        SecureRandom.hex(MAXIMUM_SECRET_QUESTION_ANSWER_CHAR_COUNT / 2)
-      end
-
-      def generate_secret_question_2_answer
-        SecureRandom.hex(MAXIMUM_SECRET_QUESTION_ANSWER_CHAR_COUNT / 2)
-      end
 
       def primary_member
         @_primary_member ||= snap_application.primary_member

--- a/lib/mi_bridges/driver/services/driver_application_factory.rb
+++ b/lib/mi_bridges/driver/services/driver_application_factory.rb
@@ -1,0 +1,45 @@
+module MiBridges
+  class Driver
+    module Services
+      class DriverApplicationFactory
+        MAXIMUM_SECRET_QUESTION_ANSWER_CHAR_COUNT = 20
+        MAXIMUM_USER_ID_CHAR_COUNT = 20
+        MAXIMUM_PASSWORD_CHAR_COUNT = 16
+
+        def initialize(snap_application:)
+          @snap_application = snap_application
+        end
+
+        def run
+          snap_application.driver_applications.create(
+            user_id: generate_user_id,
+            password: generate_password,
+            secret_question_1_answer: generate_secret_question_1_answer,
+            secret_question_2_answer: generate_secret_question_2_answer,
+            driven_at: DateTime.current,
+          )
+        end
+
+        private
+
+        attr_reader :snap_application
+
+        def generate_user_id
+          SecureRandom.hex(MAXIMUM_USER_ID_CHAR_COUNT / 2)
+        end
+
+        def generate_password
+          SecureRandom.hex(MAXIMUM_PASSWORD_CHAR_COUNT / 2)
+        end
+
+        def generate_secret_question_1_answer
+          SecureRandom.hex(MAXIMUM_SECRET_QUESTION_ANSWER_CHAR_COUNT / 2)
+        end
+
+        def generate_secret_question_2_answer
+          SecureRandom.hex(MAXIMUM_SECRET_QUESTION_ANSWER_CHAR_COUNT / 2)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/admin_dashboard_driver_errors_spec.rb
+++ b/spec/features/admin_dashboard_driver_errors_spec.rb
@@ -15,6 +15,11 @@ RSpec.feature "Admin viewing driver errors dashboard", type: :feature do
       backtrace: "the error happened on a line right here, see?!",
     )
 
+    driver_application = driver_error.driver_application
+    driver_application.update(
+      page_history: ["FirstPage", "SecondPage"],
+    )
+
     visit admin_root_path
 
     click_on "Driver Errors"
@@ -32,5 +37,8 @@ RSpec.feature "Admin viewing driver errors dashboard", type: :feature do
     expect(page).to have_link(
       driver_error.driver_application.snap_application_id,
     )
+
+    expect(page).to have_content("FirstPage")
+    expect(page).to have_content("SecondPage")
   end
 end

--- a/spec/lib/mi_bridges/driver/pages_spec.rb
+++ b/spec/lib/mi_bridges/driver/pages_spec.rb
@@ -9,6 +9,9 @@ RSpec.describe "Driver pages" do
     describe "methods" do
       it "setup, fill_in_required_fields, continue are defined" do
         snap_application = double
+        driver = double(page_history: [])
+        allow(snap_application).to receive(:latest_drive_attempt).
+          and_return(driver)
         page = page.new(snap_application)
 
         expect(page).to respond_to(:setup)
@@ -21,6 +24,9 @@ RSpec.describe "Driver pages" do
   context "when instantiating a page too many times" do
     it "raises an exception" do
       snap_application = double
+      driver = double(page_history: [])
+      allow(snap_application).to receive(:latest_drive_attempt).
+        and_return(driver)
       limit = MiBridges::Driver::BasePage::INSTANTIATION_LIMIT + 1
 
       expect do
@@ -33,6 +39,9 @@ RSpec.describe "Driver pages" do
 
     it "passes the name of the child class name to the error" do
       snap_application = double
+      driver = double(page_history: [])
+      allow(snap_application).to receive(:latest_drive_attempt).
+        and_return(driver)
       limit = MiBridges::Driver::BasePage::INSTANTIATION_LIMIT + 1
 
       module MiBridges
@@ -53,6 +62,9 @@ RSpec.describe "Driver pages" do
 
     it "ignores the limit on pages that are instantiated many times" do
       snap_application = double
+      driver = double(page_history: [])
+      allow(snap_application).to receive(:latest_drive_attempt).
+        and_return(driver)
       limit = MiBridges::Driver::BasePage::INSTANTIATION_LIMIT + 1
 
       module MiBridges


### PR DESCRIPTION
* Move driver application creation to earlier in the driving sequence so
we can save the pages visited each time we instantiate a driver page
* Now we can capture errors that occur before or during sign up
* Show Page History for each driver error in admin dashboard
* [Finishes #153521242]
https://www.pivotaltracker.com/story/show/153521242