### PR TITLE
Compute the daily summary for day *in Detroit*

### DIFF
--- a/lib/summarizer/application_summary.rb
+++ b/lib/summarizer/application_summary.rb
@@ -1,7 +1,7 @@
 module Summarizer
   class ApplicationSummary
-    def initialize(date)
-      @date = date
+    def initialize(datetime, timezone)
+      @date = datetime.in_time_zone(timezone)
       date_range = @date.beginning_of_day..@date.end_of_day
       @snap_applications = SnapApplication.where(created_at: date_range)
       @medicaid_applications = MedicaidApplication.where(created_at: date_range)

--- a/lib/tasks/slack.rake
+++ b/lib/tasks/slack.rake
@@ -1,7 +1,10 @@
 namespace :summarizer do
   desc "Posts an update about the last day's app activity"
   task :post_update, [:channel] => [:environment] do |_, args|
-    text = Summarizer::ApplicationSummary.new(Date.yesterday).daily_summary
+    text = Summarizer::ApplicationSummary.new(
+      DateTime.now - 1.day,
+      "America/New_York", # Timezone for Detroit
+    ).daily_summary
     client = Slack::Web::Client.new
     client.chat_postMessage(channel: args[:channel], text: text, as_user: true)
   end

--- a/spec/lib/summarizer/application_summary_spec.rb
+++ b/spec/lib/summarizer/application_summary_spec.rb
@@ -3,15 +3,20 @@ require "#{Rails.root}/lib/summarizer/application_summary"
 
 RSpec.describe Summarizer::ApplicationSummary do
   describe "#run" do
-    it "outputs a summary of applications for a given date" do
-      date = Date.new(2017, 12, 1, 5)
+    it "returns a summary of daily applications for date and timezone" do
+      date = DateTime.new(2017, 12, 1, 0, 0)
       create_list(:snap_application, 2, created_at: date)
       create(:medicaid_application, created_at: date)
 
       create(:snap_application, created_at: date - 1.day)
+      create(:snap_application, created_at: date + 21.hours)
       create(:medicaid_application, created_at: date + 1.day)
 
-      text = Summarizer::ApplicationSummary.new(date).daily_summary
+      text = Summarizer::ApplicationSummary.new(
+        date,
+        "Europe/Samara", # +4 UTC Offset
+      ).daily_summary
+
       expect(text).to eq(
         "On Fri, Dec 01, we processed 2 SNAP and 1 Medicaid applications.",
       )


### PR DESCRIPTION
Before we were calculating the day using UTC time. Now our task bases its understanding (and report) of daily stats based on the start and end of day in Detroit (Eastern Standard Time).