### PR TITLE
Add <label>s to date selects for a11y!

### DIFF
--- a/app/assets/stylesheets/michigan-benefits/atoms/_form-elements.scss
+++ b/app/assets/stylesheets/michigan-benefits/atoms/_form-elements.scss
@@ -1,16 +1,14 @@
-fieldset {
-  legend.sr-only {
-    position: absolute;
-    margin: -1px 0 0 -1px;
-    padding: 0;
-    display: block;
-    width: 1px;
-    height: 1px;
-    font-size: 1px;
-    line-height: 1px;
-    overflow: hidden;
-    clip: rect(0,0,0,0);
-    border: 0;
-    outline: 0;
-  }
+.sr-only {
+  position: absolute;
+  margin: -1px 0 0 -1px;
+  padding: 0;
+  display: block;
+  width: 1px;
+  height: 1px;
+  font-size: 1px;
+  line-height: 1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+  outline: 0;
 }

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -175,9 +175,11 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
       <fieldset class="form-group#{error_state(object, method)}">
         #{fieldset_label_contents(label_text, notes)}
         <div class="input-group--inline">
-          <div class="select">
-            #{date_select(method, { autofocus: autofocus, date_separator: '</div><div class="select">' }.merge(options), class: 'select__element')}
-          </div>
+          #{date_select(
+            method,
+            { autofocus: autofocus }.merge(options),
+            class: 'select__element',
+          )}
         </div>
         #{errors_for(object, method)}
       </fieldset>
@@ -395,5 +397,41 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     <<-HTML.html_safe
       #{check_box(method, options, checked_value, unchecked_value)} #{label_text}
     HTML
+  end
+end
+
+module ActionView
+  module Helpers
+    class DateTimeSelector
+
+      # Given an ordering of datetime components, create the selection HTML
+      # and join them with their appropriate separators.
+      def build_selects_from_types(order)
+        select = ""
+        order.reverse_each do |type|
+          separator = separator(type)
+          select.insert(0, separator.to_s + send("select_#{type}").to_s + "</div>")
+        end
+        select.html_safe
+      end
+
+      # Returns the separator for a given datetime component.
+      def separator(type)
+        return "" if @options[:use_hidden]
+        field_name = "#{@options[:prefix]}_#{@options[:field_name]}"
+        case type
+          when :year
+            "<div class='select'><label for='#{field_name}_1i' class='sr-only'>Year</label>"
+          when :month
+            "<div class='select'><label for='#{field_name}_2i' class='sr-only'>Month</label>"
+          when :day
+            "<div class='select'><label for='#{field_name}_3i' class='sr-only'>Day</label>"
+          when :hour
+            (@options[:discard_year] && @options[:discard_day]) ? "" : @options[:datetime_separator]
+          when :minute, :second
+            @options[:"discard_#{type}"] ? "" : @options[:time_separator]
+        end
+      end
+    end
   end
 end

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -168,6 +168,7 @@ RSpec.describe MbFormBuilder do
           <p class="text--help">(For surprises)</p>
           <div class="input-group--inline">
             <div class="select">
+              <label for="sample_birthday_2i" class="sr-only">Month</label>
               <select id="sample_birthday_2i" name="sample[birthday(2i)]" class="select__element">
                 <option value="1">January</option>
                 <option value="2">February</option>
@@ -184,6 +185,7 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
+              <label for="sample_birthday_3i" class="sr-only">Day</label>
               <select id="sample_birthday_3i" name="sample[birthday(3i)]" class="select__element">
                 <option value="1">1</option>
                 <option value="2">2</option>
@@ -219,6 +221,7 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
+              <label for="sample_birthday_1i" class="sr-only">Year</label>
               <select id="sample_birthday_1i" name="sample[birthday(1i)]" class="select__element">
                 <option value="1990" selected="selected">1990</option>
                 <option value="1991">1991</option>


### PR DESCRIPTION
* Monkey-patches build_selects_from_types because:
  * No default way to pass a label for a date
    selector in Rails
  * Could get around this using the date_separator
    option, but that didn’t work because
    date_separator would be same for every
    element and we need them to be dynamic to
    match the ID of the input.
  * Also, date_separator always skips the first
    date select field because date_separator is
    pre-pended to the field.

[#153646862]

Signed-off-by: Jessie Young <jessie@cylinder.work>