### PR TITLE
[PAIR] Quick way to specify office location for Medicaid apps

### DIFF
--- a/app/controllers/medicaid/intro_location_controller.rb
+++ b/app/controllers/medicaid/intro_location_controller.rb
@@ -2,6 +2,15 @@ module Medicaid
   class IntroLocationController < MedicaidStepsController
     skip_before_action :ensure_application_present
 
+    def edit
+      super
+      app = current_or_new_medicaid_application
+      app.update!(
+        office_location: params[:office_location],
+      )
+      set_current_application(app)
+    end
+
     def update
       @step = step_class.new(step_params)
 

--- a/app/views/medicaid/welcome/edit.html.erb
+++ b/app/views/medicaid/welcome/edit.html.erb
@@ -16,7 +16,7 @@
   </div>
 
   <footer class="form-card__button_right">
-    <%= link_to next_path, class: "button button--nav  button--cta button--full-mobile" do %>
+    <%= link_to(next_path(office_location: params[:office_location]), class: "button button--nav  button--cta button--full-mobile") do %>
       Next
     <% end %>
   </footer>

--- a/db/migrate/20171214235857_remove_michigan_resident_null_constraint.rb
+++ b/db/migrate/20171214235857_remove_michigan_resident_null_constraint.rb
@@ -1,0 +1,5 @@
+class RemoveMichiganResidentNullConstraint < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :medicaid_applications, :michigan_resident, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171213212138) do
+ActiveRecord::Schema.define(version: 20171214235857) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -157,7 +157,7 @@ ActiveRecord::Schema.define(version: 20171213212138) do
     t.boolean "income_unemployment"
     t.boolean "mailing_address_same_as_residential_address"
     t.integer "members_count", default: 0
-    t.boolean "michigan_resident", null: false
+    t.boolean "michigan_resident"
     t.boolean "need_medical_expense_help_3_months"
     t.string "office_location"
     t.string "paperwork", array: true

--- a/spec/controllers/medicaid/intro_location_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_location_controller_spec.rb
@@ -10,6 +10,30 @@ RSpec.describe Medicaid::IntroLocationController do
 
         expect(response).to render_template(:edit)
       end
+
+      context "with office location get param" do
+        it "updates the office location and stores app in the session" do
+          get :edit, params: { office_location: "my office" }
+
+          app = MedicaidApplication.last
+
+          expect(app.office_location).to eq("my office")
+          expect(session[:medicaid_application_id]).to eq(app.id)
+        end
+      end
+    end
+
+    context "with office location get param" do
+      it "updates the office location" do
+        medicaid_application = create(:medicaid_application)
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit, params: { office_location: "my office" }
+
+        medicaid_application.reload
+
+        expect(medicaid_application.office_location).to eq("my office")
+      end
     end
   end
 end


### PR DESCRIPTION
- On `intro-location`, update `office_location` from get params
- Forward `office_location` param from `welcome` to `intro-location` in link

Implemented for testing medicaid app in specific field offices. Field offices can visit `/steps/medicaid/welcome?office_location=union` and have the stated office be recorded in their application (and routed appropriately).

Can be rolled back—and should be!