### PR TITLE
Add `sr-only` labels for inputs without labels

### DIFF
--- a/app/assets/stylesheets/michigan-benefits/atoms/_form-elements.scss
+++ b/app/assets/stylesheets/michigan-benefits/atoms/_form-elements.scss
@@ -1,16 +1,14 @@
-fieldset {
-  legend.sr-only {
-    position: absolute;
-    margin: -1px 0 0 -1px;
-    padding: 0;
-    display: block;
-    width: 1px;
-    height: 1px;
-    font-size: 1px;
-    line-height: 1px;
-    overflow: hidden;
-    clip: rect(0,0,0,0);
-    border: 0;
-    outline: 0;
-  }
+.sr-only {
+  position: absolute;
+  margin: -1px 0 0 -1px;
+  padding: 0;
+  display: block;
+  width: 1px;
+  height: 1px;
+  font-size: 1px;
+  line-height: 1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+  outline: 0;
 }

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -136,9 +136,11 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     options: {},
     classes: [],
     placeholder: nil,
-    autofocus: nil
+    autofocus: nil,
+    hide_label: false
   )
     classes = classes.append(%w[textarea])
+
     <<-HTML.html_safe
       <div class="form-group#{error_state(object, method)}">
       #{label_and_field(
@@ -157,6 +159,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
           }.merge(options),
         ),
         notes: notes,
+        options: { class: hide_label ? 'sr-only' : '' },
       )}
       #{errors_for(object, method)}
       </div>
@@ -226,7 +229,13 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     HTML
   end
 
-  def mb_select(method, label_text, collection, options = {}, &block)
+  def mb_select(
+    method,
+    label_text,
+    collection,
+    options = {},
+    &block
+  )
     field_values(options, method).map.with_index do |value, i|
       html_options = { class: "select__element" }
 
@@ -238,11 +247,22 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
 
       field_index = (i + 1).to_s
       rendered_label_text = label_text&.gsub("{index}", field_index)
+      formatted_label = label(
+        method,
+        label_contents(
+          rendered_label_text,
+          options[:notes],
+          options[:optional],
+        ),
+        class: options[:hide_label] ? "sr-only" : "",
+      )
 
       <<~HTML
         <div class="form-group#{error_state(object, method)}">
-          #{label(method, label_contents(rendered_label_text, options[:notes], options[:optional]))}
-          <div class="select">#{select(method, collection, options, html_options, &block)}</div>
+          #{formatted_label}
+          <div class="select">
+            #{select(method, collection, options, html_options, &block)}
+          </div>
           #{errors_for(object, method)}
         </div>
       HTML

--- a/app/views/income_change_explanation/edit.html.erb
+++ b/app/views/income_change_explanation/edit.html.erb
@@ -3,8 +3,7 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      In your own words, tell us about the recent change in your household’s
-      income.
+      <%= t("snap.income_change_explanation.edit.title") %>
     </div>
     <p class="text--help text--centered">
       This will help us understand how to interpret other financial information.
@@ -13,7 +12,10 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_textarea :income_change_explanation, '', options: { rows: 6 } %>
+      <%= f.mb_textarea :income_change_explanation,
+        t("snap.income_change_explanation.edit.title"),
+        options: { rows: 6 },
+        hide_label: true %>
       <%= render 'shared/next_step' %>
     <% end %>
   </div>

--- a/app/views/medicaid/amounts_income/edit.html.erb
+++ b/app/views/medicaid/amounts_income/edit.html.erb
@@ -29,24 +29,13 @@
           <legend class="text--section-header">Job #<%= index %></legend>
 
           <%= f.fields_for('employments[]', employment, hidden_field_id: true) do |ff| %>
-
-            <%= ff.mb_input_field(
-              :employer_name,
-              "Employer name",
-            ) %>
-
-            <%= ff.mb_money_field(
-              :pay_quantity,
-              "Average amount / paycheck",
-            ) %>
-
+            <%= ff.mb_input_field(:employer_name, "Employer name") %>
+            <%= ff.mb_money_field(:pay_quantity, "Average amount / paycheck") %>
             <%= ff.mb_select(
               :payment_frequency,
               "How often are you paid that amount?",
               Member::PAYMENT_INTERVALS,
-              {
-                layout: "inline",
-              }
+              { layout: "inline" }
             ) %>
           <% end %>
 

--- a/app/views/medicaid/contact_social_security/edit.html.erb
+++ b/app/views/medicaid/contact_social_security/edit.html.erb
@@ -37,7 +37,6 @@
                   default: Date.new(1990,1,15),
                   order: [:month, :day, :year],
                 } %>
-
             </div>
           <% end %>
         </div>

--- a/app/views/medicaid/income_job_number_member/edit.html.erb
+++ b/app/views/medicaid/income_job_number_member/edit.html.erb
@@ -17,8 +17,9 @@
           <legend class="text--section-header"><%= member.display_name %></legend>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
               <%= ff.mb_select :employed_number_of_jobs,
-                "",
-                (0..10).map { |number| [pluralize(number, "job"), number] } %>
+                "Number of jobs",
+                (0..10).map { |number| [pluralize(number, "job"), number] },
+                hide_label: true %>
           <% end %>
         </fieldset>
       <% end %>

--- a/app/views/personal_detail/edit.html.erb
+++ b/app/views/personal_detail/edit.html.erb
@@ -14,7 +14,7 @@
           [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
           notes: [" As it appears on your driver’s license"],
           layout: "inline" %>
-        <%= f.mb_select :marital_status,
+      <%= f.mb_select :marital_status,
         'What is your marital status?',
         Member::MARITAL_STATUSES,
         include_blank: "Choose one" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -13,6 +13,10 @@ en:
         title: "Who in your household is currently employed, or has been in the
         past 30 days?"
         title_help: Employment includes temporary or contract jobs. Self employment includes odd jobs, home businesses, online businesses, etc.
+    income_change_explanation:
+      edit:
+        title: In your own words, tell us about the recent change in your
+          household’s income.
   medicaid:
     expenses_alimony_member:
       edit:

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -77,6 +77,26 @@ RSpec.describe MbFormBuilder do
     end
   end
 
+  describe "#mb_textarea" do
+    it "renders a label with the sr-only class when hide_label set to true" do
+      class SampleStep < Step
+        step_attributes(:name)
+      end
+      sample = SampleStep.new
+      form = MbFormBuilder.new("sample", sample, template, {})
+      output = form.mb_textarea(:name, "Write a lot?", hide_label: true)
+      expect(output).to be_html_safe
+      expect(output).to match_html <<-HTML
+        <div class="form-group">
+         <label class="sr-only" for="sample_name">
+           <p class="form-question">Write a lot?</p>
+         </label>
+         <textarea class="textarea" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" name="sample[name]" id="sample_name"></textarea>
+       </div>
+      HTML
+    end
+  end
+
   describe "#mb_phone_field" do
     it "renders a tel input with a '+1' prefix" do
       class SampleStep < Step
@@ -102,7 +122,7 @@ RSpec.describe MbFormBuilder do
   end
 
   describe "#mb_select" do
-    it "can render a range of numeric options with an empty label" do
+    it "renders a range of numeric options with a screen-reader only label" do
       class SampleStep < Step
         step_attributes(:how_many)
       end
@@ -111,15 +131,17 @@ RSpec.describe MbFormBuilder do
       form = MbFormBuilder.new("sample", sample, template, {})
       output = form.mb_select(
         :how_many,
-        "",
+        "This is for screen readers!",
         (0..10).map { |number| [pluralize(number, "thing"), number] },
+        {},
+        hide_label: true,
       )
       expect(output).to be_html_safe
 
       expect(output).to match_html <<-HTML
         <div class="form-group">
-          <label for="sample_how_many">
-            <p class="form-question"></p>
+          <label class="sr-only" for="sample_how_many">
+            <p class="form-question">This is for screen readers!</p>
           </label>
           <div class="select">
             <select class="select__element" name="sample[how_many]" id="sample_how_many">

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -133,7 +133,6 @@ RSpec.describe MbFormBuilder do
         :how_many,
         "This is for screen readers!",
         (0..10).map { |number| [pluralize(number, "thing"), number] },
-        {},
         hide_label: true,
       )
       expect(output).to be_html_safe


### PR DESCRIPTION
* These labels are in the page header so they are visible to people
looking at a browser but will not be read by a screen reader.
* [#153646862]

Signed-off-by: Luigi Ray-Montanez <luigi@codeforamerica.org>