### PR TITLE
Don't overwrite office location if no params present

### DIFF
--- a/app/controllers/medicaid/intro_location_controller.rb
+++ b/app/controllers/medicaid/intro_location_controller.rb
@@ -4,11 +4,11 @@ module Medicaid
 
     def edit
       super
-      app = current_or_new_medicaid_application
-      app.update!(
-        office_location: params[:office_location],
-      )
-      set_current_application(app)
+      if params[:office_location].present?
+        app = current_or_new_medicaid_application
+        app.update!(office_location: params[:office_location])
+        set_current_application(app)
+      end
     end
 
     def update

--- a/spec/controllers/medicaid/intro_location_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_location_controller_spec.rb
@@ -23,16 +23,34 @@ RSpec.describe Medicaid::IntroLocationController do
       end
     end
 
-    context "with office location get param" do
-      it "updates the office location" do
-        medicaid_application = create(:medicaid_application)
-        session[:medicaid_application_id] = medicaid_application.id
+    context "with existing application" do
+      context "with office location get param" do
+        it "updates the office location" do
+          medicaid_application = create(:medicaid_application)
+          session[:medicaid_application_id] = medicaid_application.id
 
-        get :edit, params: { office_location: "my office" }
+          get :edit, params: { office_location: "my office" }
 
-        medicaid_application.reload
+          medicaid_application.reload
 
-        expect(medicaid_application.office_location).to eq("my office")
+          expect(medicaid_application.office_location).to eq("my office")
+        end
+      end
+
+      context "with empty param" do
+        it "does not delete existing location" do
+          medicaid_application = create(
+            :medicaid_application,
+            office_location: "bajora",
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          get :edit
+
+          medicaid_application.reload
+
+          expect(medicaid_application.office_location).to eq("bajora")
+        end
       end
     end
   end


### PR DESCRIPTION
Previously if someone started an application and clicked back, if they hit the intro-location page we would overwrite the office_location to be empty. This fixes that behavior by only updating office_location if there is an office_location param.

(We thought we had included this in the previous PR, but accidentally left out!)