### PR TITLE
Require answer to authorized representative question

### DIFF
--- a/app/steps/authorized_representative.rb
+++ b/app/steps/authorized_representative.rb
@@ -4,12 +4,17 @@ class AuthorizedRepresentative < Step
     :authorized_representative_name,
   )
 
+  validates(
+    :authorized_representative,
+    presence: { message: "Make sure to answer this question" },
+  )
   validate :name_present_if_authorized_rep_true
 
   def name_present_if_authorized_rep_true
+    return true if authorized_representative == "false" ||
+        authorized_representative.nil?
     return true if authorized_representative &&
         authorized_representative_name.present?
-    return true if !authorized_representative
     errors.add(
       :authorized_representative_name,
       "Make sure to enter your legal representative's full name",

--- a/app/views/authorized_representative/edit.html.erb
+++ b/app/views/authorized_representative/edit.html.erb
@@ -17,12 +17,16 @@
       builder: MbFormBuilder,
       url: current_path,
       method: :put do |f| %>
-    <%= f.mb_radio_set(
-      :authorized_representative,
-      "Would you like to designate someone else to be your authorized representative?",
-      [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
-      layout: "inline") %>
-    <%= f.mb_input_field :authorized_representative_name, "What is their full legal name?" %>
+
+    <div class="form-group">
+      <%= f.mb_radio_set(
+        :authorized_representative,
+        "Would you like to designate someone else to be your authorized representative?",
+        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        layout: "inline") %>
+    </div>
+
+    <%= f.mb_input_field :authorized_representative_name, "If yes, what is their full legal name?" %>
     <%= render "shared/next_step" %>
     <% end %>
   </div>

--- a/spec/controllers/authorized_representative_controller_spec.rb
+++ b/spec/controllers/authorized_representative_controller_spec.rb
@@ -34,16 +34,16 @@ RSpec.describe AuthorizedRepresentativeController do
         session[:snap_application_id] = snap_application.id
 
         params = {
-          authorized_representative: "true",
-          authorized_representative_name: "Child F",
+          authorized_representative: "false",
+          authorized_representative_name: "",
         }
         put :update, params: { step: params }
 
         snap_application.reload
 
         expect(response).to redirect_to(subject.next_path)
-        expect(snap_application.authorized_representative).to eq(true)
-        expect(snap_application.authorized_representative_name).to eq("Child F")
+        expect(snap_application.authorized_representative).to eq(false)
+        expect(snap_application.authorized_representative_name).to eq("")
       end
     end
 

--- a/spec/features/snap_application_with_maximum_info_spec.rb
+++ b/spec/features/snap_application_with_maximum_info_spec.rb
@@ -170,7 +170,7 @@ accounts?",
 
     on_page "Other Details" do
       choose "Yes"
-      fill_in "What is their full legal name?", with: "Annie Dog"
+      fill_in "If yes, what is their full legal name?", with: "Annie Dog"
       click_on "Continue"
     end
 

--- a/spec/features/snap_application_with_minimal_info_spec.rb
+++ b/spec/features/snap_application_with_minimal_info_spec.rb
@@ -90,6 +90,7 @@ RSpec.feature "Submit application with minimal information" do
     end
 
     on_page "Other Details" do
+      choose "No"
       click_on "Continue"
     end
 

--- a/spec/steps/authorized_representative_spec.rb
+++ b/spec/steps/authorized_representative_spec.rb
@@ -29,9 +29,21 @@ RSpec.describe AuthorizedRepresentative do
     context "applicant doesn't have an authorized rep" do
       it "is valid" do
         step = AuthorizedRepresentative.new(
-          authorized_representative: false,
+          authorized_representative: "false",
         )
         expect(step).to be_valid
+      end
+    end
+
+    context "applicant doesn't indicate whether they have an authorized rep" do
+      it "is invalid" do
+        step = AuthorizedRepresentative.new(
+          authorized_representative: nil,
+        )
+        expect(step).not_to be_valid
+        expect(step.errors.count).to eq(1)
+        expect(step.errors[:authorized_representative]).
+          to eq(["Make sure to answer this question"])
       end
     end
   end


### PR DESCRIPTION
* Before, somehow could skip this question
* There was a related bug where if they answered "no" it would require
the auth rep name because "false" was being evaluated to a present value
in the step validation.
* Now, the bug is fixed and we have slightly different behavior too.
* [Finishes #153690105]

<img width="688" alt="screen shot 2017-12-15 at 9 38 10 am" src="https://user-images.githubusercontent.com/601515/34053651-76bbde2a-e17c-11e7-9aad-619fee4981b7.png">

<img width="683" alt="screen shot 2017-12-15 at 9 45 00 am" src="https://user-images.githubusercontent.com/601515/34053700-a6f73c42-e17c-11e7-93db-2543b9d78ed8.png">
