### PR TITLE
Require label text for all radio and checkbox sets

### DIFF
--- a/app/views/authorized_representative/edit.html.erb
+++ b/app/views/authorized_representative/edit.html.erb
@@ -19,14 +19,14 @@
       method: :put do |f| %>
 
     <div class="form-group">
-      <%= f.mb_radio_set(
-        :authorized_representative,
-        "Would you like to designate someone else to be your authorized representative?",
-        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
-        layout: "inline") %>
+      <%= f.mb_radio_set :authorized_representative,
+        label_text: "Would you like to designate someone else to be your authorized representative?",
+        collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        layout: "inline" %>
     </div>
 
     <%= f.mb_input_field :authorized_representative_name, "If yes, what is their full legal name?" %>
+
     <%= render "shared/next_step" %>
     <% end %>
   </div>

--- a/app/views/contact_preference/edit.html.erb
+++ b/app/views/contact_preference/edit.html.erb
@@ -15,10 +15,9 @@
       builder: MbFormBuilder,
       url: current_path,
       method: :put do |f| %>
-    <%= f.mb_radio_set(
-      :sms_consented,
-      "Would you like text message reminders about key steps and documents required to help you through the enrollment process?",
-      [{ value: :true, label: "Yes" }, { value: :false, label: "No" }]) %>
+    <%= f.mb_radio_set :sms_consented,
+      label_text: "Would you like text message reminders about key steps and documents required to help you through the enrollment process?",
+      collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }] %>
 
     <p class='text--secure'>
     <i class='illustration illustration--safety'></i>

--- a/app/views/expenses_additional_sources/edit.html.erb
+++ b/app/views/expenses_additional_sources/edit.html.erb
@@ -20,8 +20,8 @@
 
       <div class="form-card__content">
         <%= f.mb_radio_set :dependent_care,
-          "Does your household have dependent care expenses?",
-          [{ label: "Yes", value: true }, { label: "No", value: false }],
+          label_text: "Does your household have dependent care expenses?",
+          collection: [{ label: "Yes", value: true }, { label: "No", value: false }],
           notes: <<~NOTE
             This includes child care (including day care and after school
             programs) and adult disabled care.
@@ -29,8 +29,8 @@
         %>
 
         <%= f.mb_radio_set :medical,
-          "Does your household have ongoing medical expenses?",
-          [{ label: "Yes", value: true }, { label: "No", value: false }],
+          label_text: "Does your household have ongoing medical expenses?",
+          collection: [{ label: "Yes", value: true }, { label: "No", value: false }],
           notes: <<~NOTE
             This includes health insurance, co-pays, prescriptions, dental,
             hospital bills, etc.
@@ -38,8 +38,8 @@
         %>
 
         <%= f.mb_radio_set :court_ordered,
-          "Does your household have court-ordered expenses?",
-          [{ label: "Yes", value: true }, { label: "No", value: false }],
+          label_text: "Does your household have court-ordered expenses?",
+          collection: [{ label: "Yes", value: true }, { label: "No", value: false }],
           notes: "This includes child support, alimony, arrearages, etc." %>
     </div>
 

--- a/app/views/household_add_member/edit.html.erb
+++ b/app/views/household_add_member/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :header_title, 'Your Household' %>
+<% content_for :header_title, "Your Household" %>
 
 <div class="form-card">
   <header class="form-card__header">
@@ -17,30 +17,37 @@
         autofocus: true %>
       <%= f.mb_input_field :last_name, "What is their last name?" %>
       <%= f.mb_radio_set :sex,
-        'What is their sex?',
-        [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
+        label_text: "What is their sex?",
+        collection:  [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
         notes: ["As it appears on your driver’s license"],
         layout: "inline" %>
       <%= f.mb_select :relationship,
-        'What is their relationship to you?',
-        ['Spouse', 'Parent', 'Child', 'Sibling', 'Roommate', 'Other'],
+        "What is their relationship to you?",
+        ["Spouse", "Parent", "Child", "Sibling", "Roommate", "Other"],
         include_blank: "Choose one" %>
-      <%= f.mb_date_select :birthday, "What is their birthday?", { options: { start_year: 1900, end_year: Time.now.year, default: Date.new(1990,1,15), order: [:month, :day, :year] } } %>
+      <%= f.mb_date_select :birthday,
+        "What is their birthday?",
+        options: {
+          start_year: 1900,
+          end_year: Time.now.year,
+          default: Date.new(1990,1,15),
+          order: [:month, :day, :year]
+        } %>
       <%= f.mb_input_field :ssn,
-        'What is their Social Security Number?',
+        "What is their Social Security Number?",
         type: :tel,
         options: { maxlength: 9 },
         notes: ["If they don’t have one or you don’t know it you can skip this"],
         append_html: "<p class='text--secure'><i class='illustration illustration--safety'></i>Social security numbers help ensure you receive the correct benefits. MDHHS maintains strict security guidelines to protect the identities of our residents.</p>" %>
       <%= f.mb_radio_set :requesting_food_assistance,
-        'Is this person requesting food assistance?',
-        [{ value: true, label: "Yes" }, { value: false, label: "No" }],
+        label_text: "Is this person requesting food assistance?",
+        collection: [{ value: true, label: "Yes" }, { value: false, label: "No" }],
         layout: "inline" %>
       <%= f.mb_radio_set :buy_food_with,
-        'Do you buy/make food with this person?',
-        [{ value: true, label: "Yes" }, { value: false, label: "No" }],
+        label_text: "Do you buy/make food with this person?",
+        collection: [{ value: true, label: "Yes" }, { value: false, label: "No" }],
         layout: "inline" %>
-      <%= render 'shared/next_step' %>
+      <%= render "shared/next_step" %>
     <% end %>
   </div>
 </div>

--- a/app/views/household_more_info/edit.html.erb
+++ b/app/views/household_more_info/edit.html.erb
@@ -14,28 +14,29 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_radio_set :everyone_a_citizen,
-        "Is each person a US citizen/national?",
-        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        label_text: "Is each person a US citizen/national?",
+        collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
         layout: "inline" %>
       <%= f.mb_radio_set :anyone_disabled,
-        "Does anyone have a disability?",
-        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        label_text: "Does anyone have a disability?",
+        collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
         notes: ["This includes physical, mental, or emotional health challenges."],
         layout: "inline" %>
       <%= f.mb_radio_set :anyone_new_mom,
-        "Is anyone pregnant or has been pregnant recently?",
-        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        label_text: "Is anyone pregnant or has been pregnant recently?",
+        collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
         notes: ["This includes anyone who has been pregnant in the last two months"],
         layout: "inline" %>
       <%= f.mb_radio_set :anyone_in_college,
-        "Is anyone enrolled in college or vocational school?",
-        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        label_text: "Is anyone enrolled in college or vocational school?",
+        collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
         layout: "inline" %>
       <%= f.mb_radio_set :anyone_living_elsewhere,
-        "Is anyone temporarily living outside the home?",
-        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        label_text: "Is anyone temporarily living outside the home?",
+        collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
         layout: "inline" %>
-      <%= render 'shared/next_step' %>
+
+      <%= render "shared/next_step" %>
     <% end %>
   </div>
 </div>

--- a/app/views/income_additional_sources/edit.html.erb
+++ b/app/views/income_additional_sources/edit.html.erb
@@ -3,8 +3,7 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      Check all additional sources of income received by your household, if
-      any.
+      <%= t("snap.income_additional_sources.edit.title") %>
     </div>
     <p class="text--help text--centered">
       If you don't have additional income, just click Continue.
@@ -22,8 +21,11 @@
           { label: "Social Security", method: :social_security },
           { label: "Child Support", method: :child_support },
           { label: "Other Income", method: :other },
-        ]) %>
-    <%= render 'shared/next_step' %>
+        ],
+        label_text: t("snap.income_additional_sources.edit.title"),
+        legend_class: "sr-only",
+      ) %>
+    <%= render "shared/next_step" %>
     <% end %>
   </div>
 </div>

--- a/app/views/income_change/edit.html.erb
+++ b/app/views/income_change/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      Has your household had a change in income <br> in the past 30 days?
+      <%= t("snap.income_change.edit.title") %>
     </div>
     <p class="text--help text--centered">
       This includes change of jobs, job loss, change in hours or wages, strikes,
@@ -14,8 +14,9 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_radio_set :income_change,
-        '',
-        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }] %>
+        label_text: t("snap.income_change.edit.title"),
+        collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        legend_class: "sr-only" %>
       <%= render 'shared/next_step' %>
     <% end %>
   </div>

--- a/app/views/income_employment_status/edit.html.erb
+++ b/app/views/income_employment_status/edit.html.erb
@@ -15,8 +15,12 @@
       <% @step.members.each do |member| %>
         <%= f.fields_for("members[]", member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_radio_set :employment_status,
-            member.display_name,
-            [{ value: :employed, label: "Employed" }, { value: :self_employed, label: "Self Employed" }, { value: :not_employed, label: "Not Employed" }],
+            label_text: member.display_name,
+            collection: [
+              { value: :employed, label: "Employed", },
+              { value: :self_employed, label: "Self Employed" },
+              { value: :not_employed, label: "Not Employed" },
+            ],
             legend_class: "text--section-header" %>
         <% end %>
       <% end %>

--- a/app/views/income_other_assets/edit.html.erb
+++ b/app/views/income_other_assets/edit.html.erb
@@ -13,16 +13,16 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_radio_set :money_or_accounts_income,
-        "Does your household have any money or accounts?",
-        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        label_text: "Does your household have any money or accounts?",
+        collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
         notes: ["This includes Checking/Savings accounts, 401Ks, Trusts, Stocks, etc. You will be asked to verify by providing bank and account statements."] %>
       <%= f.mb_radio_set :real_estate_income,
-        "Does your household own any property or real estate?",
-        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        label_text: "Does your household own any property or real estate?",
+        collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
         notes: ["You should include your primary home. But don’t worry - it won’t be counted against you."] %>
       <%= f.mb_radio_set :vehicle_income,
-        "Does your household own any vehicles?",
-        [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
+        label_text: "Does your household own any vehicles?",
+        collection: [{ value: :true, label: "Yes" }, { value: :false, label: "No" }],
         notes: ["Don’t worry - your first vehicle will not be counted against you."] %>
       <%= render 'shared/next_step' %>
     <% end %>

--- a/app/views/introduction_change_office_location/edit.html.erb
+++ b/app/views/introduction_change_office_location/edit.html.erb
@@ -3,18 +3,19 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      Where would you like to submit your application?
+      <%= t("snap.introduction_change_office_location.edit.title") %>
     </div>
   </header>
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_radio_set :office_location,
-          "",
-        [
-         { value: "clio", label: "Clio Road" },
-         { value: "union", label: "Union Street" },
-        ] %>
+        label_text: t("snap.introduction_change_office_location.edit.title"),
+        collection: [
+          { value: "clio", label: "Clio Road" },
+          { value: "union", label: "Union Street" },
+        ],
+        legend_class: "sr-only" %>
       <%= render 'shared/next_step' %>
     <% end %>
 </div>

--- a/app/views/legal_agreement/edit.html.erb
+++ b/app/views/legal_agreement/edit.html.erb
@@ -24,10 +24,9 @@
 
     </p>
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-     <%= f.mb_radio_set :consent_to_terms,
-          '',
-          [{ value: true, label: "I agree" }],
-          layout: "inline" %>
+      <%= f.mb_radio_button :consent_to_terms,
+        [{ value: true, label: "I agree" }],
+        "inline" %>
       <%= render 'shared/next_step' %>
     <% end %>
   </div>

--- a/app/views/mailing_address/edit.html.erb
+++ b/app/views/mailing_address/edit.html.erb
@@ -11,9 +11,9 @@
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= render "shared/address", f: f %>
       <%= f.mb_radio_set :mailing_address_same_as_residential_address,
-          'Is this address the same as your home address?',
-          [{ value: true, label: "Yes" }, { value: false, label: "No" }],
-          layout: "inline" %>
+        label_text: "Is this address the same as your home address?",
+        collection: [{ value: true, label: "Yes" }, { value: false, label: "No" }],
+        layout: "inline" %>
       <%= render 'shared/next_step' %>
     <% end %>
   </div>

--- a/app/views/medicaid/contact_home_address/edit.html.erb
+++ b/app/views/medicaid/contact_home_address/edit.html.erb
@@ -14,11 +14,9 @@
       <%= f.mb_input_field :city, "City" %>
       <%= f.mb_input_field :zip, "ZIP code", type: :tel, options: { maxlength: 5 } %>
 
-      <%= f.mb_checkbox(
-        :mailing_address_same_as_residential_address,
+      <%= f.mb_checkbox :mailing_address_same_as_residential_address,
         "This is the same as my mailing address",
-        { checked_value: "1", unchecked_value: "0" },
-      ) %>
+        { checked_value: "1", unchecked_value: "0" } %>
 
       <%= render "medicaid/next_step" %>
     <% end %>

--- a/app/views/medicaid/income_job_number/edit.html.erb
+++ b/app/views/medicaid/income_job_number/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      Tell us how many jobs you currently have.
+      <%= t("medicaid.income_job_number.edit.title") %>
     </div>
   </header>
 
@@ -15,13 +15,14 @@
       method: :put do |f| %>
 
       <%= f.mb_radio_set :employed_number_of_jobs,
-        "",
-        [
+        label_text: t("medicaid.income_job_number.edit.title"),
+        collection: [
           { value: "1", label: "1 job" },
           { value: "2", label: "2 jobs" },
           { value: "3", label: "3 jobs" },
           { value: "4", label: "4 or more jobs" },
-        ] %>
+        ],
+        legend_class: "sr-only" %>
 
       <%= render "medicaid/next_step" %>
     <% end %>

--- a/app/views/medicaid/income_job_number_continued/edit.html.erb
+++ b/app/views/medicaid/income_job_number_continued/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      Tell us how many jobs you currently have.
+      <%= t("medicaid.income_job_number_continued.edit.title") %>
     </div>
   </header>
 
@@ -11,8 +11,8 @@
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
 
       <%= f.mb_radio_set :employed_number_of_jobs,
-        '',
-        [
+        label_text: t("medicaid.income_job_number_continued.edit.title"),
+        collection: [
           { value: "4", label: "4 jobs" },
           { value: "5", label: "5 jobs" },
           { value: "6", label: "6 jobs" },
@@ -20,7 +20,8 @@
           { value: "8", label: "8 jobs" },
           { value: "9", label: "9 jobs" },
           { value: "10", label: "10 jobs" },
-        ] %>
+        ],
+        legend_class: "sr-only" %>
 
       <%= render "medicaid/next_step" %>
     <% end %>

--- a/app/views/medicaid/income_other_income_type/edit.html.erb
+++ b/app/views/medicaid/income_other_income_type/edit.html.erb
@@ -26,7 +26,10 @@
           { method: :retirement, label: "Retirement" },
           { method: :alimony, label: "Alimony" },
           { method: :other, label: "Other" },
-        ]) %>
+        ],
+        label_text: t("medicaid.income_other_income_type.edit.title", count: current_application.members_count, name: current_member.display_name),
+        legend_class: "sr-only",
+      ) %>
 
       <%= render "medicaid/next_step" %>
     <% end %>

--- a/app/views/medicaid/insurance_current_type/edit.html.erb
+++ b/app/views/medicaid/insurance_current_type/edit.html.erb
@@ -17,10 +17,12 @@
 
       <%= f.hidden_field(:id) %>
 
-      <%= f.mb_radio_set :insurance_type, "",
-        @step.class::INSURANCE_TYPES.map { |value, label|
-        { value: value, label: label }
-      } %>
+      <%= f.mb_radio_set :insurance_type,
+        label_text: t("medicaid.insurance_current_type.edit.title", name: current_member.display_name),
+        collection: @step.class::INSURANCE_TYPES.map { |value, label|
+          { value: value, label: label }
+        },
+        legend_class: "sr-only" %>
 
       <%= render "medicaid/next_step" %>
     <% end %>

--- a/app/views/medicaid/intro_household_member/edit.html.erb
+++ b/app/views/medicaid/intro_household_member/edit.html.erb
@@ -12,8 +12,8 @@
         autofocus: true %>
       <%= f.mb_input_field :last_name, "What is their last name?" %>
       <%= f.mb_radio_set :sex,
-        'What is their gender?',
-        [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
+        label_text: "What is their gender?",
+        collection: [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
         notes: ["As it appears on official government documents"],
         layout: "inline" %>
 

--- a/app/views/medicaid/intro_marital_status_indicate_spouse/edit.html.erb
+++ b/app/views/medicaid/intro_marital_status_indicate_spouse/edit.html.erb
@@ -18,10 +18,12 @@
       <%= f.mb_form_errors :spouse %>
       <%= f.hidden_field(:id) %>
 
-      <%= f.mb_radio_set :spouse_id, "",
-        current_member.spouse_options.map { |member|
-        { value: member.id, label: member.display_name }
-       } %>
+      <%= f.mb_radio_set :spouse_id,
+        label_text: t("medicaid.intro_marital_status_indicate_spouse.edit.title", name: current_member.display_name),
+        collection: current_member.spouse_options.map { |member|
+          { value: member.id, label: member.display_name }
+        },
+        legend_class: "sr-only" %>
 
       <%= render "medicaid/next_step" %>
     <% end %>

--- a/app/views/medicaid/intro_name/edit.html.erb
+++ b/app/views/medicaid/intro_name/edit.html.erb
@@ -14,8 +14,8 @@
         autofocus: true %>
       <%= f.mb_input_field :last_name, "What is your last name?" %>
       <%= f.mb_radio_set :sex,
-        'What is your gender?',
-        [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
+        label_text: "What is your gender?",
+        collection: [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
         notes: ["As it appears on official government documents"],
         layout: "inline" %>
       <%= render "medicaid/next_step" %>

--- a/app/views/medicaid/legal_agreement/edit.html.erb
+++ b/app/views/medicaid/legal_agreement/edit.html.erb
@@ -24,10 +24,9 @@
 
     </p>
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-     <%= f.mb_radio_set :consent_to_terms,
-          '',
-          [{ value: true, label: "I agree" }],
-          layout: "inline" %>
+     <%= f.mb_radio_button :consent_to_terms,
+       [{ value: true, label: "I agree" }],
+       layout: "inline" %>
       <%= render "medicaid/next_step" %>
     <% end %>
   </div>

--- a/app/views/personal_detail/edit.html.erb
+++ b/app/views/personal_detail/edit.html.erb
@@ -10,23 +10,23 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_radio_set :sex,
-          'What is your sex?',
-          [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
-          notes: [" As it appears on your driver’s license"],
-          layout: "inline" %>
+        label_text: "What is your sex?",
+        collection: [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
+        notes: [" As it appears on your driver’s license"],
+        layout: "inline" %>
       <%= f.mb_select :marital_status,
-        'What is your marital status?',
+        "What is your marital status?",
         Member::MARITAL_STATUSES,
         include_blank: "Choose one" %>
       <%= f.mb_input_field :ssn,
-      "What is your Social Security Number?",
-      type: :tel,
-      options: { maxlength: 9 },
-      notes: ["If you don’t have one or don’t want to answer now it’s okay to skip this"],
-      append_html: "<p class='text--secure'><i class='illustration illustration--safety'></i>#{t('ssn.description')}</p>",
-      optional: true %>
+        "What is your Social Security Number?",
+        type: :tel,
+        options: { maxlength: 9 },
+        notes: ["If you don’t have one or don’t want to answer now it’s okay to skip this"],
+        append_html: "<p class='text--secure'><i class='illustration illustration--safety'></i>#{t("ssn.description")}</p>",
+        optional: true %>
 
-    <%= render partial: 'shared/next_step' %>
+    <%= render partial: "shared/next_step" %>
     <% end %>
   </div>
 </div>

--- a/app/views/residential_address/edit.html.erb
+++ b/app/views/residential_address/edit.html.erb
@@ -10,8 +10,11 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= render "shared/address", f: f %>
-      <%= f.mb_checkbox_set [{ label: 'Check this box if you do not have a stable address', method: :unstable_housing }] %>
-      <%= render 'shared/next_step' %>
+      <div class="form-group">
+        <%= f.mb_checkbox :unstable_housing,
+          "Check this box if you do not have a stable address" %>
+      </div>
+      <%= render "shared/next_step" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -17,7 +17,19 @@ en:
       edit:
         title: In your own words, tell us about the recent change in your
           household’s income.
+    income_change:
+      edit:
+        title: Has your household had a change in income in the past 30 days?
+    income_additional_sources:
+      edit:
+        title: Check all additional sources of income received by your household, if any.
+    introduction_change_office_location:
+      edit:
+        title: Where would you like to submit your application?
   medicaid:
+    income_job_number:
+      edit:
+        title: Tell us how many jobs you currently have.
     expenses_alimony_member:
       edit:
         title: Tell us who pays child support, alimony, or arrears.
@@ -27,6 +39,9 @@ en:
     income_other_income_member:
       edit:
         title: Tell us who gets income that’s not from a job.
+    income_job_number_continued:
+      edit:
+        title: Tell us how many jobs you currently have.
     income_self_employment_member:
       edit:
         title: Tell us who in the household self-employed.

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -262,8 +262,11 @@ RSpec.describe MbFormBuilder do
       form = MbFormBuilder.new("sample", sample, template, {})
       output = form.mb_radio_set(
         :dependent_care,
-        "Does your household have dependent care expenses?",
-        [{ label: "Yep", value: true }, { label: "Nope", value: false }],
+        label_text: "Does your household have dependent care expenses?",
+        collection: [
+          { label: "Yep", value: true },
+          { label: "Nope", value: false },
+        ],
         notes: <<~NOTE
           This includes child care (including day care and after school
           programs) and adult disabled care.


### PR DESCRIPTION
* We are not requiring a label for all radio and checkbox sets by having
`label_text` as a required argument for each.
* Using named (as opposed to positional) arguments is easier to read
anyway
* If we want label text that is only visible to a screenreader, we can
pass `sr-only` as the `legend_class` argument.