### PR TITLE
Add a <label> to each component in a date select

### DIFF
--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -1,4 +1,6 @@
 class MbFormBuilder < ActionView::Helpers::FormBuilder
+  include ActionView::Helpers::DateHelper
+
   def mb_input_field(
     method,
     label_text,
@@ -173,18 +175,38 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     options: {},
     autofocus: nil
   )
-
     <<~HTML.html_safe
       <fieldset class="form-group#{error_state(object, method)}">
         #{fieldset_label_contents(label_text, notes)}
         <div class="input-group--inline">
           <div class="select">
-            #{date_select(
-              method,
-              {
-                autofocus: autofocus,
-                date_separator: '</div><div class="select">',
-              }.merge(options),
+            <label for="#{object_name}_#{select_field_id(method, '2i')}" class="sr-only">Month</label>
+            #{select_month(
+              options[:default],
+              { field_name: select_field_name(method, '2i'),
+                field_id: select_field_id(method, '2i'),
+                prefix: object_name }.merge(options),
+              class: 'select__element',
+              autofocus: autofocus,
+            )}
+          </div>
+          <div class="select">
+            <label for="#{object_name}_#{select_field_id(method, '3i')}" class="sr-only">Day</label>
+            #{select_day(
+              options[:default],
+              { field_name: select_field_name(method, '3i'),
+                field_id: select_field_id(method, '3i'),
+                prefix: object_name }.merge(options),
+              class: 'select__element',
+            )}
+          </div>
+          <div class="select">
+            <label for="#{object_name}_#{select_field_id(method, '1i')}" class="sr-only">Year</label>
+            #{select_year(
+              options[:default],
+              { field_name: select_field_name(method, '1i'),
+                field_id: select_field_id(method, '1i'),
+                prefix: object_name }.merge(options),
               class: 'select__element',
             )}
           </div>
@@ -423,5 +445,13 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     <<~HTML.html_safe
       #{check_box(method, options, checked_value, unchecked_value)} #{label_text}
     HTML
+  end
+
+  def select_field_id(method, position)
+    "#{method}_#{position}"
+  end
+
+  def select_field_name(method, position)
+    "#{method}(#{position})"
   end
 end

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -189,6 +189,7 @@ RSpec.describe MbFormBuilder do
           <p class="text--help">(For surprises)</p>
           <div class="input-group--inline">
             <div class="select">
+              <label for="sample_birthday_2i" class="sr-only">Month</label>
               <select id="sample_birthday_2i" name="sample[birthday(2i)]" class="select__element">
                 <option value="1">January</option>
                 <option value="2">February</option>
@@ -205,6 +206,7 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
+              <label for="sample_birthday_3i" class="sr-only">Day</label>
               <select id="sample_birthday_3i" name="sample[birthday(3i)]" class="select__element">
                 <option value="1">1</option>
                 <option value="2">2</option>
@@ -240,6 +242,7 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
+              <label for="sample_birthday_1i" class="sr-only">Year</label>
               <select id="sample_birthday_1i" name="sample[birthday(1i)]" class="select__element">
                 <option value="1990" selected="selected">1990</option>
                 <option value="1991">1991</option>


### PR DESCRIPTION
This is an alternative approach to #597. Instead of monkeypatching Rails, it:

* Drops `date_select` in favor of `select_month`,
  `select_day`, `select_year`
* Adds some helper methods to format `id=` and `name=`

It adds the same test as #597.

https://www.pivotaltracker.com/story/show/153646862