### PR TITLE
[PAIR] Fixes blank space on office landing pages.

### DIFF
--- a/app/views/static_pages/clio.html.erb
+++ b/app/views/static_pages/clio.html.erb
@@ -29,5 +29,5 @@ end %>
   </div>
 </div>
 
-<% render "home_page_bottom_section", office_location: "clio" %>
+<%= render "home_page_bottom_section", office_location: "clio" %>
 <%= render 'shared/footer' %>

--- a/app/views/static_pages/union.html.erb
+++ b/app/views/static_pages/union.html.erb
@@ -28,5 +28,5 @@ end %>
   </div>
 </div>
 
-<% render "home_page_bottom_section", office_location: "union" %>
+<%= render "home_page_bottom_section", office_location: "union" %>
 <%= render 'shared/footer' %>


### PR DESCRIPTION
* The `=` was missing from the ERB tag.

[Resolves #153688176]

Signed-off-by: Jessie Young <jessie@cylinder.work>