### PR TITLE
[PAIR] Improves contrast and text sizing for a11y

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -62,6 +62,7 @@
 @import 'templates/styleguide';
 
 /* Michigan Benefits Overrides */
+@import 'michigan-benefits/atoms/variables';
 @import 'michigan-benefits/atoms/base';
 @import 'michigan-benefits/atoms/icons';
 @import 'michigan-benefits/atoms/typography';

--- a/app/assets/stylesheets/michigan-benefits/atoms/_buttons.scss
+++ b/app/assets/stylesheets/michigan-benefits/atoms/_buttons.scss
@@ -9,3 +9,15 @@
 .button--nav-center {
   margin: 0 auto;
 }
+
+.button--cta {
+  background-color: $button-cta-color;
+
+  &:hover {
+    background-color: tint($button-cta-color, 20%);
+  }
+
+  &:active {
+    background-color: shade($button-cta-color, 15%);
+  }
+}

--- a/app/assets/stylesheets/michigan-benefits/atoms/_typography.scss
+++ b/app/assets/stylesheets/michigan-benefits/atoms/_typography.scss
@@ -6,5 +6,5 @@
 
 .text--little-help {
   font-size: 14px;
-  color: $color-grey;
+  color: $color-dark-grey;
 }

--- a/app/assets/stylesheets/michigan-benefits/atoms/_variables.scss
+++ b/app/assets/stylesheets/michigan-benefits/atoms/_variables.scss
@@ -1,0 +1,2 @@
+// Colors
+$color-sky: #0080a7;

--- a/app/assets/stylesheets/michigan-benefits/organisms/_document-preview.scss
+++ b/app/assets/stylesheets/michigan-benefits/organisms/_document-preview.scss
@@ -28,5 +28,7 @@
 .uploadable-status {
   &.successful {
     color: $color-green;
+    font-size: 1.3em;
+    padding-right: 0.2em;
   }
 }

--- a/app/assets/stylesheets/michigan-benefits/organisms/_form-card.scss
+++ b/app/assets/stylesheets/michigan-benefits/organisms/_form-card.scss
@@ -67,7 +67,7 @@
 
 .form-card--security-message,
 .form-card--benefit-label {
-  color: $color-medium-grey;
+  color: $color-dark-grey;
   font-size: $font-size-smallest;
 }
 


### PR DESCRIPTION
## Improve the contrast for background color in header and buttons
Before:
![introduction 2017-12-18 12-42-38](https://user-images.githubusercontent.com/417/34121009-98aaf810-e3f5-11e7-803f-798555b6e560.png)
After:
![introduction 2017-12-18 12-43-00](https://user-images.githubusercontent.com/417/34121012-9bdfcd44-e3f5-11e7-908c-a914a4e09d92.png)
Before:
![documents 2017-12-18 13-01-11](https://user-images.githubusercontent.com/417/34121028-acf6d0b4-e3f5-11e7-9270-8d31363ba8e7.png)
After:
![documents 2017-12-18 13-09-41](https://user-images.githubusercontent.com/417/34121043-b95dd370-e3f5-11e7-9871-e55397e58e47.png)

## Improve contrast for helper text and security message
Before:
![application submitted 2017-12-18 12-45-33](https://user-images.githubusercontent.com/417/34121078-d4244edc-e3f5-11e7-83a9-61982d550a29.png)
After:
![application submitted 2017-12-18 12-46-22](https://user-images.githubusercontent.com/417/34121086-dac68c1e-e3f5-11e7-953d-30c38d621a57.png)
Before:
![application submitted 2017-12-18 12-48-12](https://user-images.githubusercontent.com/417/34121114-effe54fe-e3f5-11e7-9134-73039b427d88.png)
After:
![application submitted 2017-12-18 12-49-00](https://user-images.githubusercontent.com/417/34121117-f4b68e6c-e3f5-11e7-9c5c-44f10d66863a.png)

https://www.pivotaltracker.com/story/show/153647011

Signed-off-by: Jessie Young <jessie@cylinder.work>