### PR TITLE
MiBridges: fix relationship bug for households w/ 3+ members & children

### DIFF
--- a/app/lib/mi_bridges/driver/relationship_information_page.rb
+++ b/app/lib/mi_bridges/driver/relationship_information_page.rb
@@ -13,15 +13,17 @@ module MiBridges
       end
 
       def fill_in_required_fields
-        second_members.each do |member|
-          MiBridges::Driver::Services::SubmitRelationship.new(
-            first_member: first_member,
-            second_member: member,
-          ).run
-          MiBridges::Driver::Services::SubmitBuyFoodWith.new(
-            first_member: first_member,
-            second_member: member,
-          ).run
+        if page_asks_about_relationships?
+          second_members.each do |member|
+            MiBridges::Driver::Services::SubmitRelationship.new(
+              first_member: first_member,
+              second_member: member,
+            ).run
+            MiBridges::Driver::Services::SubmitBuyFoodWith.new(
+              first_member: first_member,
+              second_member: member,
+            ).run
+          end
         end
       end
 
@@ -32,6 +34,10 @@ module MiBridges
       private
 
       attr_reader :first_member, :second_members
+
+      def page_asks_about_relationships?
+        !page.has_css?("#MoreAboutChildren")
+      end
 
       def find_first_member
         name = page.first(:xpath, first_member_name_label).text


### PR DESCRIPTION
* For every member, there is a page that asks how that member relates to
the rest of the members. This is the `RelationshipInformationPage`.
* By the time we get to the last member, we know how that member relates
to all of the other members so we do not need to ask any relationship
questions.
* BUT, if that member is a child, MIBridges asks an optional question,
which is "Who acts as a parent for CHILDNAME?"
* When this page is presented, we get an error for
`RelationshipInformationPage`, which always tries to find a dropdown for
identifying relationships.
* We know we are on this edgecase version of the page when it has the
header "More About Childre", so when that is present we will skip the
dropdown logic.
* Was tested / confirmed using the SNAP app id from prod listed in the
tracker ticket.
* [Finishes #153387980]
https://www.pivotaltracker.com/story/show/153387980