### PR TITLE
Check "no one" for common absent parent question

### DIFF
--- a/app/lib/mi_bridges/driver/absent_parent_information_page.rb
+++ b/app/lib/mi_bridges/driver/absent_parent_information_page.rb
@@ -1,8 +1,22 @@
 module MiBridges
   class Driver
-    class AbsentParentInformationPage < ClickNextPage
+    class AbsentParentInformationPage < FillInAndClickNextPage
       def self.title
         "Absent Parent Information"
+      end
+
+      def skip_infinite_loop_check; end
+
+      def fill_in_required_fields
+        if page.has_css?("#starCommonAbsentParent")
+          check_no_one_for_common_absent_parent
+        end
+      end
+
+      private
+
+      def check_no_one_for_common_absent_parent
+        click_id("NoOne_ABSENT")
       end
     end
   end


### PR DESCRIPTION
* If both parents are not in the household, MIBridges asks which
children have a common absent parent
* We are selecting "No one" in all cases. This info can be corrected
during an interview.
* Also had to override `skip_infinite_loop_check` since this page shows
up TWICE for each child, which would trigger an infinite loop check if
there are more than 2 children in a household with an absent parent.
* This was confirmed by driving the SNAP app with id mentioned in the
tracker ticket.
* [Finishes #153388256]
https://www.pivotaltracker.com/story/show/153388256

This is what the page looks like (names redacted):

![screen shot 2017-12-19 at 11 54 17 am](https://user-images.githubusercontent.com/601515/34176189-e959bc6a-e4b3-11e7-89de-f9d7bbd5ae34.png)
