### PR TITLE
Override all variables related to `color-sky`

### DIFF
--- a/app/assets/stylesheets/michigan-benefits/atoms/_variables.scss
+++ b/app/assets/stylesheets/michigan-benefits/atoms/_variables.scss
@@ -1,5 +1,9 @@
 // Colors
 $color-sky: #0080a7;
+$color-light-sky:     lighten($color-sky, 50%);
+$color-dark-sky:      shade($color-sky, 15%);
+$color-darkest-sky:   shade($color-sky, 30%);
 
 // Button Colors
 $button-cta-color: $color-sky;
+$button-cta-border-color: $color-dark-sky;


### PR DESCRIPTION
**WHY**: Since these vars are defined based on `color-sky`, we need to
re-define them after we have re-defined `color-sky` in our overrides
file.

new button / header stylez:

![screen shot 2017-12-19 at 1 41 31 pm](https://user-images.githubusercontent.com/601515/34180251-db64a462-e4c2-11e7-997a-c3b7d1e3be57.png)
![screen shot 2017-12-19 at 1 41 08 pm](https://user-images.githubusercontent.com/601515/34180252-db7cc43e-e4c2-11e7-840a-a99d55ddc64b.png)

![screen shot 2017-12-19 at 1 40 26 pm](https://user-images.githubusercontent.com/601515/34180253-db96b204-e4c2-11e7-92a7-3b93bd57fa88.png)
![screen shot 2017-12-19 at 1 40 19 pm](https://user-images.githubusercontent.com/601515/34180254-dbaf06e2-e4c2-11e7-8115-3f7acbc3f1c5.png)
