### PR TITLE
Use correct label for= values on nested date selects

### DIFF
--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -466,7 +466,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
   end
 
   def select_label_for(object_name, method, position)
-    object_name.gsub(/([\[\(])|(\]\[)/, "_").gsub(/[\]\)]/, "") + "_" +
+    object_name.to_s.gsub(/([\[\(])|(\]\[)/, "_").gsub(/[\]\)]/, "") + "_" +
       select_field_id(method, position)
   end
 end

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -180,7 +180,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
         #{fieldset_label_contents(label_text: label_text, notes: notes)}
         <div class="input-group--inline">
           <div class="select">
-            <label for="#{object_name}_#{select_field_id(method, '2i')}" class="sr-only">Month</label>
+            <label for="#{select_label_for(object_name, method, '2i')}" class="sr-only">Month</label>
             #{select_month(
               options[:default],
               { field_name: select_field_name(method, '2i'),
@@ -191,7 +191,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
             )}
           </div>
           <div class="select">
-            <label for="#{object_name}_#{select_field_id(method, '3i')}" class="sr-only">Day</label>
+            <label for="#{select_label_for(object_name, method, '3i')}" class="sr-only">Day</label>
             #{select_day(
               options[:default],
               { field_name: select_field_name(method, '3i'),
@@ -201,7 +201,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
             )}
           </div>
           <div class="select">
-            <label for="#{object_name}_#{select_field_id(method, '1i')}" class="sr-only">Year</label>
+            <label for="#{select_label_for(object_name, method, '1i')}" class="sr-only">Year</label>
             #{select_year(
               options[:default],
               { field_name: select_field_name(method, '1i'),
@@ -463,5 +463,10 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
 
   def select_field_name(method, position)
     "#{method}(#{position})"
+  end
+
+  def select_label_for(object_name, method, position)
+    object_name.gsub(/([\[\(])|(\]\[)/, "_").gsub(/[\]\)]/, "") + "_" +
+      select_field_id(method, position)
   end
 end

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -253,6 +253,107 @@ RSpec.describe MbFormBuilder do
         </fieldset>
       HTML
     end
+
+    it "renders an accessible many member date select" do
+      class SampleManyStep < ManyMembersStep
+        step_attributes :members
+      end
+
+      medicaid_application = create(
+        :medicaid_application,
+        anyone_other_income: true,
+        )
+
+      sample = SampleManyStep.new(members: [create(:member, id: 72, benefit_application: medicaid_application)])
+      member = sample.members.first
+      form = MbFormBuilder.new("sample", sample, template, {})
+
+      output = form.fields_for('members[]', member, builder: MbFormBuilder) do |ff|
+        ff.mb_date_select(
+          :birthday,
+          "What is your birthday?",
+          notes: ["(For surprises)"],
+          options: {
+            start_year: 1990,
+            end_year: 1992,
+            default: Date.new(1990, 3, 25),
+            order: %i{month day year},
+          },
+          )
+      end
+
+      expect(output).to be_html_safe
+
+      expect(output).to match_html <<-HTML
+        <fieldset class="form-group">
+          <legend class="form-question ">What is your birthday?</legend>
+          <p class="text--help">(For surprises)</p>
+          <div class="input-group--inline">
+            <div class="select">
+              <label for="sample_members_72_birthday_2i" class="sr-only">Month</label>
+              <select id="sample_members_72_birthday_2i" name="sample[members][72][birthday(2i)]" class="select__element">
+                <option value="1">January</option>
+                <option value="2">February</option>
+                <option value="3" selected="selected">March</option>
+                <option value="4">April</option>
+                <option value="5">May</option>
+                <option value="6">June</option>
+                <option value="7">July</option>
+                <option value="8">August</option>
+                <option value="9">September</option>
+                <option value="10">October</option>
+                <option value="11">November</option>
+                <option value="12">December</option>
+              </select>
+            </div>
+            <div class="select">
+              <label for="sample_members_72_birthday_3i" class="sr-only">Day</label>
+              <select id="sample_members_72_birthday_3i" name="sample[members][72][birthday(3i)]" class="select__element">
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="3">3</option>
+                <option value="4">4</option>
+                <option value="5">5</option>
+                <option value="6">6</option>
+                <option value="7">7</option>
+                <option value="8">8</option>
+                <option value="9">9</option>
+                <option value="10">10</option>
+                <option value="11">11</option>
+                <option value="12">12</option>
+                <option value="13">13</option>
+                <option value="14">14</option>
+                <option value="15">15</option>
+                <option value="16">16</option>
+                <option value="17">17</option>
+                <option value="18">18</option>
+                <option value="19">19</option>
+                <option value="20">20</option>
+                <option value="21">21</option>
+                <option value="22">22</option>
+                <option value="23">23</option>
+                <option value="24">24</option>
+                <option value="25" selected="selected">25</option>
+                <option value="26">26</option>
+                <option value="27">27</option>
+                <option value="28">28</option>
+                <option value="29">29</option>
+                <option value="30">30</option>
+                <option value="31">31</option>
+              </select>
+            </div>
+            <div class="select">
+              <label for="sample_members_72_birthday_1i" class="sr-only">Year</label>
+              <select id="sample_members_72_birthday_1i" name="sample[members][72][birthday(1i)]" class="select__element">
+                <option value="1990" selected="selected">1990</option>
+                <option value="1991">1991</option>
+                <option value="1992">1992</option>
+              </select>
+            </div>
+          </div>
+        </fieldset>
+      HTML
+    end
   end
 
   describe "#mb_radio_set" do

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe MbFormBuilder do
       end
 
       sample = SampleStep.new
-      form = MbFormBuilder.new("sample", sample, template, {})
+      form = MbFormBuilder.new(:sample, sample, template, {})
       output = form.mb_date_select(
         :birthday,
         "What is your birthday?",
@@ -266,7 +266,7 @@ RSpec.describe MbFormBuilder do
 
       sample = SampleManyStep.new(members: [create(:member, id: 72, benefit_application: medicaid_application)])
       member = sample.members.first
-      form = MbFormBuilder.new("sample", sample, template, {})
+      form = MbFormBuilder.new(:sample, sample, template, {})
 
       output = form.fields_for('members[]', member, builder: MbFormBuilder) do |ff|
         ff.mb_date_select(


### PR DESCRIPTION
* Was causing an axe-matchers error due to label for= not matching
  id= of select element.

https://www.pivotaltracker.com/story/show/153764112

Signed-off-by: Jessie Young <jessie@cylinder.work>