### PR TITLE
Fixes "MiBridges: Closing the driver causes an error"

### DIFF
--- a/app/lib/mi_bridges/driver/privacy_pin_page.rb
+++ b/app/lib/mi_bridges/driver/privacy_pin_page.rb
@@ -6,10 +6,19 @@ module MiBridges
       end
 
       def fill_in_required_fields
-        click_id(this_is_a_private_computer_id)
+        wait_until_options_are_loaded
+        click_this_is_a_private_computer
       end
 
       private
+
+      def wait_until_options_are_loaded
+        page.find(this_is_a_private_computer_id, visible: false)
+      end
+
+      def click_this_is_a_private_computer
+        click_id(this_is_a_private_computer_id)
+      end
 
       def this_is_a_private_computer_id
         "#radioGroup_No"

--- a/app/lib/mi_bridges/driver/submit_page.rb
+++ b/app/lib/mi_bridges/driver/submit_page.rb
@@ -10,11 +10,7 @@ module MiBridges
 
       def fill_in_required_fields; end
 
-      def continue
-        unless ENV["RUN_MI_BRIDGES_TEST"] == "true"
-          close
-        end
-      end
+      def continue; end
     end
   end
 end


### PR DESCRIPTION
* The final step was calling `close`, so when the teardown method in
`Driver.rb` tried to close the browser, it got an error because the
driver had already been closed
* This also fixed another bug that popped up recently where the Privacy
PIN  page option was not being selected properly. The error showed up as
`Selenium::WebDriver $ is not defined`. Fixed by calling `find` on the
element so that it is loaded (Capybara waits for it) before clicking on
the id.
* [Finishes #153571372]