### PR TITLE
Use same "page" object for all MiBridges summary pages

### DIFF
--- a/app/lib/mi_bridges/driver.rb
+++ b/app/lib/mi_bridges/driver.rb
@@ -28,12 +28,10 @@ module MiBridges
     ].freeze
 
     APPLY_FLOW = [
+      SummaryPage,
       AbsentParentDetailsPage,
-      AbsentParentDetailsSummaryPage,
       AbsentParentInformationPage,
-      AbsentParentSummaryPage,
       AdditionalInformationPage,
-      BasicInformationSummaryPage,
       BenefitsOverviewPage,
       BenefitsSelectorPage,
       ConceptionPage,
@@ -42,16 +40,12 @@ module MiBridges
       FinishPage,
       HealthHospitalizationInsurancePremiumsPage,
       HouseholdMemberQuestionsPage,
-      HouseholdMembersSummaryPage,
       HousingBillsPage,
       HousingUtilityBillsPage,
-      HousingUtilityBillsSummaryPage,
       InformationAboutTheChildPage,
       InpatientHospitalizationNursingCarePage,
       JobIncomeInformationPage,
-      JobIncomeSummaryPage,
       LiquidAssetsPage,
-      LiquidAssetsSummaryPage,
       MailingAddressPage,
       MedicalBillsPage,
       MedicalDentalVisionServicesPage,
@@ -72,10 +66,7 @@ module MiBridges
       MoreAboutWorkersCompensationPage,
       MoreAboutYourPregnancyPage,
       OtherAssetsPage,
-      OtherAssetsSummaryPage,
-      OtherIncomeSummaryPage,
       OtherInformationPage,
-      OtherInformationSummaryPage,
       OtherTypesOfIncomePage,
       PeopleListedPage,
       PersonalCareServicesProvidedInHomePage,
@@ -94,7 +85,6 @@ module MiBridges
       VeteranInformationPage,
       ViewTrackAndPrintYourApplicationPage,
       YourOtherBillsExpensesPage,
-      YourOtherBillsExpensesSummaryPage,
     ].freeze
 
     def initialize(snap_application:, logger: nil)

--- a/app/lib/mi_bridges/driver/absent_parent_details_summary_page.rb
+++ b/app/lib/mi_bridges/driver/absent_parent_details_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class AbsentParentDetailsSummaryPage < ClickNextPage
-      def self.title
-        "Absent Parent Details Summary"
-      end
-    end
-  end
-end

--- a/app/lib/mi_bridges/driver/absent_parent_summary_page.rb
+++ b/app/lib/mi_bridges/driver/absent_parent_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class AbsentParentSummaryPage < ClickNextPage
-      def self.title
-        "Absent Parent Summary"
-      end
-    end
-  end
-end

--- a/app/lib/mi_bridges/driver/basic_information_summary_page.rb
+++ b/app/lib/mi_bridges/driver/basic_information_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class BasicInformationSummaryPage < ClickNextPage
-      def self.title
-        "Basic Information Summary"
-      end
-    end
-  end
-end

--- a/app/lib/mi_bridges/driver/household_members_summary_page.rb
+++ b/app/lib/mi_bridges/driver/household_members_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class HouseholdMembersSummaryPage < ClickNextPage
-      def self.title
-        "Household Members Summary"
-      end
-    end
-  end
-end

--- a/app/lib/mi_bridges/driver/housing_utility_bills_summary_page.rb
+++ b/app/lib/mi_bridges/driver/housing_utility_bills_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class HousingUtilityBillsSummaryPage < ClickNextPage
-      def self.title
-        "Housing and Utility Bills Summary"
-      end
-    end
-  end
-end

--- a/app/lib/mi_bridges/driver/job_income_summary_page.rb
+++ b/app/lib/mi_bridges/driver/job_income_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class JobIncomeSummaryPage < ClickNextPage
-      def self.title
-        "Job Income Summary"
-      end
-    end
-  end
-end

--- a/app/lib/mi_bridges/driver/liquid_assets_summary_page.rb
+++ b/app/lib/mi_bridges/driver/liquid_assets_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class LiquidAssetsSummaryPage < ClickNextPage
-      def self.title
-        "Liquid Assets Summary"
-      end
-    end
-  end
-end

--- a/app/lib/mi_bridges/driver/other_assets_summary_page.rb
+++ b/app/lib/mi_bridges/driver/other_assets_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class OtherAssetsSummaryPage < ClickNextPage
-      def self.title
-        "Other Assets Summary"
-      end
-    end
-  end
-end

--- a/app/lib/mi_bridges/driver/other_income_summary_page.rb
+++ b/app/lib/mi_bridges/driver/other_income_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class OtherIncomeSummaryPage < ClickNextPage
-      def self.title
-        "Other Income Summary"
-      end
-    end
-  end
-end

--- a/app/lib/mi_bridges/driver/other_information_summary_page.rb
+++ b/app/lib/mi_bridges/driver/other_information_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class OtherInformationSummaryPage < ClickNextPage
-      def self.title
-        "Other Information Summary"
-      end
-    end
-  end
-end

--- a/app/lib/mi_bridges/driver/summary_page.rb
+++ b/app/lib/mi_bridges/driver/summary_page.rb
@@ -1,0 +1,11 @@
+module MiBridges
+  class Driver
+    class SummaryPage < ClickNextPage
+      def self.title
+        /Summary/
+      end
+
+      def skip_infinite_loop_check; end
+    end
+  end
+end

--- a/app/lib/mi_bridges/driver/your_other_bills_expenses_summary_page.rb
+++ b/app/lib/mi_bridges/driver/your_other_bills_expenses_summary_page.rb
@@ -1,9 +1,0 @@
-module MiBridges
-  class Driver
-    class YourOtherBillsExpensesSummaryPage < ClickNextPage
-      def self.title
-        "Other Bills / Expenses Summary"
-      end
-    end
-  end
-end


### PR DESCRIPTION
* Rather than having a separate page for each, we can match on the regex
of "Summary" to determine if we are on a summary page
* All summary pages are ClickNext (no other info added)