### PR TITLE
Add applicant names to office email subject lines

### DIFF
--- a/app/jobs/medicaid/office_email_application_job.rb
+++ b/app/jobs/medicaid/office_email_application_job.rb
@@ -5,6 +5,7 @@ module Medicaid
         ApplicationMailer.office_medicaid_application_notification(
           file_name: medicaid_application.pdf.path,
           recipient_email: medicaid_application.receiving_office_email,
+          applicant_name: medicaid_application.primary_member.display_name,
         ).deliver
 
         logger.info(

--- a/app/jobs/office_email_application_job.rb
+++ b/app/jobs/office_email_application_job.rb
@@ -5,6 +5,7 @@ class OfficeEmailApplicationJob < ApplicationJob
         file_name: snap_application.pdf.path,
         recipient_email: snap_application.receiving_office_email,
         office_location: snap_application.office_location,
+        applicant_name: snap_application.primary_member.display_name,
       ).deliver
 
       logger.info("Emailed to #{snap_application.receiving_office_email} "\

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -13,6 +13,7 @@ class ApplicationMailer < ActionMailer::Base
   def office_snap_application_notification(
     file_name:,
     recipient_email:,
+    applicant_name:,
     office_location: nil
   )
     attachments["snap_application.pdf"] = File.read(file_name)
@@ -21,29 +22,33 @@ class ApplicationMailer < ActionMailer::Base
     mail(
       from: %("Michigan Benefits" <hello@#{ENV['EMAIL_DOMAIN']}>),
       to: recipient_email,
-      subject: subject(office_location),
+      subject: subject(office_location, applicant_name),
       template_name: template_name(office_location),
     )
   end
 
-  def office_medicaid_application_notification(file_name:, recipient_email:)
+  def office_medicaid_application_notification(
+    file_name:,
+    recipient_email:,
+    applicant_name:
+  )
     attachments["medicaid_application.pdf"] = File.read(file_name)
 
     mail(
       from: %("Michigan Benefits" <hello@#{ENV['EMAIL_DOMAIN']}>),
       to: recipient_email,
-      subject: "A new 1426 from someone online has been submitted!",
+      subject: "A new 1426 from #{applicant_name} has been submitted!",
       template_name: "office_medicaid_application_notification",
     )
   end
 
   private
 
-  def subject(office_location)
+  def subject(office_location, applicant_name)
     if office_location.present?
-      "A new 1171 from someone in the lobby has been submitted!"
+      "A new 1171 from #{applicant_name} (in the lobby) has been submitted!"
     else
-      "A new 1171 from someone online has been submitted!"
+      "A new 1171 from #{applicant_name} (online) has been submitted!"
     end
   end
 

--- a/spec/jobs/medicaid/office_email_application_job_spec.rb
+++ b/spec/jobs/medicaid/office_email_application_job_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Medicaid::OfficeEmailApplicationJob do
   describe "#perform" do
     it "sends an email" do
       medicaid_application = create(:medicaid_application, :with_member)
+      primary_member = medicaid_application.primary_member
       export = Export.create(
         benefit_application: medicaid_application,
         destination: :office_email,
@@ -22,6 +23,7 @@ RSpec.describe Medicaid::OfficeEmailApplicationJob do
         with(
           hash_including(
             recipient_email: medicaid_application.receiving_office_email,
+            applicant_name: primary_member.display_name,
           ),
         )
     end

--- a/spec/jobs/office_email_application_job_spec.rb
+++ b/spec/jobs/office_email_application_job_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe OfficeEmailApplicationJob do
   describe "#perform" do
     it "sends an email" do
       snap_application = create(:snap_application, :with_member)
+      primary_member = snap_application.primary_member
       export = Export.create(
         benefit_application: snap_application,
         destination: :office_email,
@@ -23,6 +24,7 @@ RSpec.describe OfficeEmailApplicationJob do
           hash_including(
             recipient_email: snap_application.receiving_office_email,
             office_location: snap_application.office_location,
+            applicant_name: primary_member.display_name,
           ),
         )
     end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe ApplicationMailer do
           email = ApplicationMailer.office_snap_application_notification(
             file_name: "#{Rails.root}/spec/fixtures/image.jpg",
             recipient_email: "user@example.com",
+            applicant_name: "Alice Algae",
           )
           from_header = email.header.select do |header|
             header.name == "From"
@@ -36,7 +37,7 @@ RSpec.describe ApplicationMailer do
           expect(email.from).to eq(["hello@example.com"])
           expect(email.to).to eq(["user@example.com"])
           expect(email.subject).to eq(
-            "A new 1171 from someone online has been submitted!",
+            "A new 1171 from Alice Algae (online) has been submitted!",
           )
           expect(email.body.encoded).not_to include(
             "client in your office lobby",
@@ -52,6 +53,7 @@ RSpec.describe ApplicationMailer do
             file_name: "#{Rails.root}/spec/fixtures/image.jpg",
             recipient_email: "user@example.com",
             office_location: "union",
+            applicant_name: "Freddy Fungus",
           )
           from_header = email.header.select do |header|
             header.name == "From"
@@ -61,7 +63,7 @@ RSpec.describe ApplicationMailer do
           expect(email.from).to eq(["hello@example.com"])
           expect(email.to).to eq(["user@example.com"])
           expect(email.subject).to eq(
-            "A new 1171 from someone in the lobby has been submitted!",
+            "A new 1171 from Freddy Fungus (in the lobby) has been submitted!",
           )
           expect(email.body.encoded).to include(
             "Union",
@@ -70,6 +72,28 @@ RSpec.describe ApplicationMailer do
             "client in your office lobby",
           )
         end
+      end
+    end
+  end
+
+  describe ".office_medicaid_application_notification" do
+    it "sets the correct headers" do
+      with_modified_env EMAIL_DOMAIN: "example.com" do
+        email = ApplicationMailer.office_medicaid_application_notification(
+          file_name: "#{Rails.root}/spec/fixtures/image.jpg",
+          recipient_email: "user@example.com",
+          applicant_name: "Larry Lichen",
+        )
+        from_header = email.header.select do |header|
+          header.name == "From"
+        end.first.value
+
+        expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
+        expect(email.from).to eq(["hello@example.com"])
+        expect(email.to).to eq(["user@example.com"])
+        expect(email.subject).to eq(
+          "A new 1426 from Larry Lichen has been submitted!",
+        )
       end
     end
   end


### PR DESCRIPTION
* [Finishes #153763281]
* This brings up one thing that is inconsistent between the mailers,
which is that we show a different subject for 1171 if the applicant is
in the office but the subject is always the same for the 1426.