### PR TITLE
Add current date and applicant name to attachment filename

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -16,7 +16,7 @@ class ApplicationMailer < ActionMailer::Base
     applicant_name:,
     office_location: nil
   )
-    attachments["snap_application.pdf"] = File.read(file_name)
+    attachments[attachment_name(applicant_name, "1171")] = File.read(file_name)
     @office_location = office_location
 
     mail(
@@ -32,12 +32,12 @@ class ApplicationMailer < ActionMailer::Base
     recipient_email:,
     applicant_name:
   )
-    attachments["medicaid_application.pdf"] = File.read(file_name)
+    attachments[attachment_name(applicant_name, "1426")] = File.read(file_name)
 
     mail(
       from: %("Michigan Benefits" <hello@#{ENV['EMAIL_DOMAIN']}>),
       to: recipient_email,
-      subject: "A new 1426 from #{applicant_name} has been submitted!",
+      subject: "A new 1426 from #{applicant_name} was submitted!",
       template_name: "office_medicaid_application_notification",
     )
   end
@@ -46,9 +46,9 @@ class ApplicationMailer < ActionMailer::Base
 
   def subject(office_location, applicant_name)
     if office_location.present?
-      "A new 1171 from #{applicant_name} (in the lobby) has been submitted!"
+      "A new 1171 from #{applicant_name} (in the lobby) was submitted!"
     else
-      "A new 1171 from #{applicant_name} (online) has been submitted!"
+      "A new 1171 from #{applicant_name} (online) was submitted!"
     end
   end
 
@@ -58,5 +58,13 @@ class ApplicationMailer < ActionMailer::Base
     else
       "office_snap_application_notification"
     end
+  end
+
+  def attachment_name(applicant_name, type)
+    "#{formatted_date} #{applicant_name} #{type}.pdf"
+  end
+
+  def formatted_date
+    Date.current.in_time_zone("Eastern Time (US & Canada)").strftime("%Y-%m-%d")
   end
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -23,54 +23,67 @@ RSpec.describe ApplicationMailer do
   describe ".office_snap_application_notification" do
     context "office_location not present" do
       it "sets the correct headers" do
-        with_modified_env EMAIL_DOMAIN: "example.com" do
-          email = ApplicationMailer.office_snap_application_notification(
-            file_name: "#{Rails.root}/spec/fixtures/image.jpg",
-            recipient_email: "user@example.com",
-            applicant_name: "Alice Algae",
-          )
-          from_header = email.header.select do |header|
-            header.name == "From"
-          end.first.value
+        time = Time.utc(2017, 12, 30, 10, 5, 0)
+        Timecop.freeze(time) do
+          with_modified_env EMAIL_DOMAIN: "example.com" do
+            email = ApplicationMailer.office_snap_application_notification(
+              file_name: "#{Rails.root}/spec/fixtures/image.jpg",
+              recipient_email: "user@example.com",
+              applicant_name: "Alice Algae",
+            )
+            from_header = email.header.select do |header|
+              header.name == "From"
+            end.first.value
 
-          expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
-          expect(email.from).to eq(["hello@example.com"])
-          expect(email.to).to eq(["user@example.com"])
-          expect(email.subject).to eq(
-            "A new 1171 from Alice Algae (online) has been submitted!",
-          )
-          expect(email.body.encoded).not_to include(
-            "client in your office lobby",
-          )
+            expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
+            expect(email.from).to eq(["hello@example.com"])
+            expect(email.to).to eq(["user@example.com"])
+            expect(email.subject).to eq(
+              "A new 1171 from Alice Algae (online) was submitted!",
+            )
+            expect(email.body.encoded).not_to include(
+              "client in your office lobby",
+            )
+            expect(email.attachments[0].filename).to eq(
+              "2017-12-30 Alice Algae 1171.pdf",
+            )
+          end
         end
       end
     end
 
     context "office_location present" do
       it "sets the correct values" do
-        with_modified_env EMAIL_DOMAIN: "example.com" do
-          email = ApplicationMailer.office_snap_application_notification(
-            file_name: "#{Rails.root}/spec/fixtures/image.jpg",
-            recipient_email: "user@example.com",
-            office_location: "union",
-            applicant_name: "Freddy Fungus",
-          )
-          from_header = email.header.select do |header|
-            header.name == "From"
-          end.first.value
+        time = Time.utc(2008, 9, 1, 10, 5, 0)
+        Timecop.freeze(time) do
+          with_modified_env EMAIL_DOMAIN: "example.com" do
+            email = ApplicationMailer.office_snap_application_notification(
+              file_name: "#{Rails.root}/spec/fixtures/image.jpg",
+              recipient_email: "user@example.com",
+              office_location: "union",
+              applicant_name: "Freddy Fungus",
+            )
 
-          expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
-          expect(email.from).to eq(["hello@example.com"])
-          expect(email.to).to eq(["user@example.com"])
-          expect(email.subject).to eq(
-            "A new 1171 from Freddy Fungus (in the lobby) has been submitted!",
-          )
-          expect(email.body.encoded).to include(
-            "Union",
-          )
-          expect(email.body.encoded).to include(
-            "client in your office lobby",
-          )
+            from_header = email.header.select do |header|
+              header.name == "From"
+            end.first.value
+
+            expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
+            expect(email.from).to eq(["hello@example.com"])
+            expect(email.to).to eq(["user@example.com"])
+            expect(email.subject).to eq(
+              "A new 1171 from Freddy Fungus (in the lobby) was submitted!",
+            )
+            expect(email.body.encoded).to include(
+              "Union",
+            )
+            expect(email.body.encoded).to include(
+              "client in your office lobby",
+            )
+            expect(email.attachments[0].filename).to eq(
+              "2008-09-01 Freddy Fungus 1171.pdf",
+            )
+          end
         end
       end
     end
@@ -78,22 +91,29 @@ RSpec.describe ApplicationMailer do
 
   describe ".office_medicaid_application_notification" do
     it "sets the correct headers" do
-      with_modified_env EMAIL_DOMAIN: "example.com" do
-        email = ApplicationMailer.office_medicaid_application_notification(
-          file_name: "#{Rails.root}/spec/fixtures/image.jpg",
-          recipient_email: "user@example.com",
-          applicant_name: "Larry Lichen",
-        )
-        from_header = email.header.select do |header|
-          header.name == "From"
-        end.first.value
+      time = Time.utc(1999, 1, 1, 10, 5, 0)
+      Timecop.freeze(time) do
+        with_modified_env EMAIL_DOMAIN: "example.com" do
+          email = ApplicationMailer.office_medicaid_application_notification(
+            file_name: "#{Rails.root}/spec/fixtures/image.jpg",
+            recipient_email: "user@example.com",
+            applicant_name: "Larry Lichen",
+          )
 
-        expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
-        expect(email.from).to eq(["hello@example.com"])
-        expect(email.to).to eq(["user@example.com"])
-        expect(email.subject).to eq(
-          "A new 1426 from Larry Lichen has been submitted!",
-        )
+          from_header = email.header.select do |header|
+            header.name == "From"
+          end.first.value
+
+          expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
+          expect(email.from).to eq(["hello@example.com"])
+          expect(email.to).to eq(["user@example.com"])
+          expect(email.subject).to eq(
+            "A new 1426 from Larry Lichen was submitted!",
+          )
+          expect(email.attachments[0].filename).to eq(
+            "1999-01-01 Larry Lichen 1426.pdf",
+          )
+        end
       end
     end
   end


### PR DESCRIPTION
* Previously, were using generic names
* This way, case workers can more easily identify which files are for
which applicants
* [Finishes #153763110]