### PR TITLE
Add 'Last emailed office at' to admin dashboard for SNAP

### DIFF
--- a/app/dashboards/snap_application_dashboard.rb
+++ b/app/dashboards/snap_application_dashboard.rb
@@ -17,7 +17,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     dependent_care: Field::Boolean,
     documents: Field::String.with_options(searchable: false),
     email: Field::String,
-    emailed_at: Field::DateTime,
+    last_emailed_office_at: Field::DateTime,
     everyone_a_citizen: Field::Boolean,
     fax_metadata: Field::String.with_options(searchable: false),
     faxed_successfully_at: Field::DateTime,
@@ -73,7 +73,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     faxed_successfully_at
     fax_metadata
     signed_at
-    emailed_at
+    last_emailed_office_at
   ].freeze
 
   SHOW_PAGE_ATTRIBUTES = %i[

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -147,12 +147,8 @@ class SnapApplication < ApplicationRecord
     signed_at.present?
   end
 
-  def emailed?
-    emailed_at.present?
-  end
-
-  def emailed_at
-    exports.emailed.succeeded.first&.completed_at
+  def last_emailed_office_at
+    exports.emailed_office.succeeded.first&.completed_at
   end
 
   def signed_at_est

--- a/spec/features/admin_dashboard_snap_applications_spec.rb
+++ b/spec/features/admin_dashboard_snap_applications_spec.rb
@@ -1,9 +1,19 @@
 require "rails_helper"
 
-RSpec.feature "Submit application with minimal information" do
+RSpec.feature "Submit snap application with minimal information" do
   before do
     user = create(:admin_user)
     login_as(user)
+  end
+
+  scenario "logging out", javascript: true do
+    visit admin_root_path
+
+    click_link "Sign Out"
+
+    visit admin_root_path
+
+    expect(page).to have_content("Log in")
   end
 
   scenario "The stats are accurate", javascript: true do
@@ -57,15 +67,5 @@ RSpec.feature "Submit application with minimal information" do
     expect(page).to have_content("Created At 04/04/2017 at 09:30PM EDT")
     expect(page).to have_content("Updated At 04/04/2017 at 10:30PM EDT")
     expect(page).to have_content("Signed At 04/04/2017 at 11:30PM EDT")
-  end
-
-  scenario "logging out", javascript: true do
-    visit admin_root_path
-
-    click_link "Sign Out"
-
-    visit admin_root_path
-
-    expect(page).to have_content("Log in")
   end
 end

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -244,4 +244,36 @@ RSpec.describe SnapApplication do
       expect(app.latest_drive_attempt).to eq latest
     end
   end
+
+  describe "#emailed_office_at" do
+    it "returns time application was last successfully emailed to office" do
+      snap_application = create(:snap_application)
+
+      completed_at_time = DateTime.new(2018, 1, 1, 1, 30)
+
+      create(:export,
+        :emailed_office,
+        :succeeded,
+        completed_at: completed_at_time - 1.day,
+        benefit_application: snap_application)
+      create(:export,
+        :emailed_office,
+        :succeeded,
+        completed_at: completed_at_time,
+        benefit_application: snap_application)
+
+      create(:export,
+        :emailed_client,
+        :succeeded,
+        completed_at: completed_at_time - 1.day,
+        benefit_application: snap_application)
+      create(:export,
+        :emailed_office,
+        :failed,
+        completed_at: completed_at_time - 1.day,
+        benefit_application: snap_application)
+
+      expect(snap_application.last_emailed_office_at).to eq(completed_at_time)
+    end
+  end
 end


### PR DESCRIPTION
Fixes broken stat in admin dashboard that is super useful for debugging.

[Fixes #154000383]

Going to auto-merge since small change, and should only impact the admin dashboard.