### PR TITLE
Convert max attempts for delayed jobs to integer

### DIFF
--- a/app/dashboards/export_dashboard.rb
+++ b/app/dashboards/export_dashboard.rb
@@ -14,6 +14,7 @@ class ExportDashboard < Administrate::BaseDashboard
   }.freeze
 
   COLLECTION_ATTRIBUTES = %i[
+    id
     completed_at
     destination
     metadata

--- a/config/initializers/delayed_job.rb
+++ b/config/initializers/delayed_job.rb
@@ -1,3 +1,5 @@
 Delayed::Worker.max_run_time =
   ENV.fetch("DELAYED_WORKER_MAX_RUN_TIME", "15").to_i.minutes
-Delayed::Worker.max_attempts = ENV.fetch("DELAYED_WORKER_MAX_ATTEMPTS", "5")
+Delayed::Worker.max_attempts =
+  ENV.fetch("DELAYED_WORKER_MAX_ATTEMPTS", "5").to_i
+Delayed::Worker.destroy_failed_jobs = false


### PR DESCRIPTION
When a delayed job failed, a problem with our configuration (storing the number of max attempts as a string) was causing the worker to crash when it tried to reschedule. As a result, the job never got its number of attempts updated and unlocked, so a failed job would continue on forever, blocking any new delayed jobs that got queued. See this ticket for a symptom: https://www.pivotaltracker.com/story/show/153996535.

This PR does two things:
* Converts our configuration to an integer, which is what delayed job expects. This prevents the worker from crashing when it tries to rescheudle a failed job.
* Prevents delayed job from deleting failed jobs (the default). This will allow us to see what jobs are regularly failing in the future—otherwise, they just disappear into the ether. Here's a good article recommending this as a best practice https://www.sitepoint.com/delayed-jobs-best-practices/

And one little thing:
* Adds ID to Exports dashboard in admin view. I wanted this while trying to track down failed delayed_jobs that involved exports, but the easiest thing to reference in the logs is the Export ID and that currently isn't in the collection view of the dashboard.

[Fixes #153996535]

cc @bengolder @luigi, since you might find this interesting!