### PR TITLE
Use current date in EST for email attachment names

### DIFF
--- a/app/helpers/time_zone_helper.rb
+++ b/app/helpers/time_zone_helper.rb
@@ -1,0 +1,9 @@
+module TimeZoneHelper
+  class << self
+    def date_in_est(datetime)
+      datetime.
+        in_time_zone("Eastern Time (US & Canada)").
+        to_date
+    end
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -65,6 +65,6 @@ class ApplicationMailer < ActionMailer::Base
   end
 
   def formatted_date
-    Date.current.in_time_zone("Eastern Time (US & Canada)").strftime("%Y-%m-%d")
+    TimeZoneHelper.date_in_est(DateTime.now).strftime("%Y-%m-%d")
   end
 end

--- a/app/views/fields/date_time/_index.html.erb
+++ b/app/views/fields/date_time/_index.html.erb
@@ -17,8 +17,5 @@ as a localized date & time string.
 %>
 
 <% if field.data %>
-  <%= field.datetime.
-      in_time_zone("Eastern Time (US & Canada)")&.
-      to_date
-  %>
+  <%= TimeZoneHelper.date_in_est(field.datetime) %>
 <% end %>

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe TimeZoneHelper do
+  describe "#date_in_est" do
+    it "returns date in Eastern Standard Time" do
+      now = DateTime.new(2018,01,9,3,0,0)
+      date = TimeZoneHelper.date_in_est(now)
+
+      expect(date).to eq(Date.new(2018,1,8))
+    end
+  end
+end


### PR DESCRIPTION
Previously we were using Date.today.in_timezone to convert the dates for email attachments to Eastern Standard Time. Because of Rails timezones being confusing, this didn't actually produce today's date in EST.

Instead, we have to use DateTime.now (which holds timezone info, unlike Date.today). Since this isn't straightforward and we do it in another place, I extracted it into a helper.

[Fixes #154011675]