### PR TITLE
Log email address of admin user

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
     {
       application_id: controller.current_application.try(:id),
       application_type: controller.current_application.try(:class),
-      current_admin_user_email: controller.current_admin_user.try(:email),
+      admin_user_email: controller.current_admin_user.try(:email),
     }
   end
 end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -6,6 +6,7 @@ Rails.application.configure do
     {
       application_id: controller.current_application.try(:id),
       application_type: controller.current_application.try(:class),
+      current_admin_user_email: controller.current_admin_user.try(:email)
     }
   end
 end

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,12 +1,11 @@
 Rails.application.configure do
   config.lograge.enabled = true
 
-
   config.lograge.custom_payload do |controller|
     {
       application_id: controller.current_application.try(:id),
       application_type: controller.current_application.try(:class),
-      current_admin_user_email: controller.current_admin_user.try(:email)
+      current_admin_user_email: controller.current_admin_user.try(:email),
     }
   end
 end


### PR DESCRIPTION
Use lograge's custom payload to insert the `current_admin_user`'s email address into each log line.

This fixes a bug where the email address was not being saved for log lines on controller requests:

https://www.pivotaltracker.com/story/show/153882480

As documented on [Stack Overflow](https://stackoverflow.com/questions/11124821/rails-tagged-logging#comment64603906_13371397), the [previous approach](https://github.com/codeforamerica/michigan-benefits/commit/d5a8bfc910a3984c1030326b56ab713edbc2b7e4) used does not work for controller request log lines. The technique does work for logs on ActiveRecord activity, but those aren't logged in staging/production.