### PR TITLE
Log all web requests from delayed_job_web

### DIFF
--- a/lib/delayed_job_web_logger.rb
+++ b/lib/delayed_job_web_logger.rb
@@ -5,7 +5,12 @@ class DelayedJobWebLogger
 
   def call(env)
     if in_delayed_job?(env) && env["warden"].authenticated?
-      Rails.logger.tagged(env["warden"].user.email) do
+      email = env["warden"].user.email
+      path = env["REQUEST_PATH"]
+      unless path.match?(/\.(css|js|png|poll)/)
+        Rails.logger.info("delayed_job_web | #{email} requested #{path}")
+      end
+      Rails.logger.tagged(email) do
         @app.call(env)
       end
     else


### PR DESCRIPTION
* Log user email
* Don’t log requests for assets
* Don’t log requests for the polling endpoint

https://www.pivotaltracker.com/story/show/154155900

The [original PR](https://github.com/codeforamerica/michigan-benefits/pull/459) added the user email to existing log lines, but those were only generated for ActiveRecord activity, not web requests. This PR explicitly logs web requests.