### PR TITLE
[PAIR] Add information to Medicaid Applications admin dashboard

### DIFF
--- a/app/controllers/admin/snap_applications_controller.rb
+++ b/app/controllers/admin/snap_applications_controller.rb
@@ -17,21 +17,6 @@ module Admin
 
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information
-    def resend_email
-      application = SnapApplication.find(params[:id])
-
-      ExportFactory.create!(
-        benefit_application: application,
-        destination: :office_email,
-        force: true,
-      )
-
-      confirmation = "Resent email to #{application.receiving_office.email}" \
-                     " for #{application.signature}!"
-      flash[:notice] = confirmation
-      redirect_to admin_root_path
-    end
-
     def pdf
       application = SnapApplication.find(params[:id])
       send_data(application.pdf.read,

--- a/app/controllers/medicaid/contact_home_address_controller.rb
+++ b/app/controllers/medicaid/contact_home_address_controller.rb
@@ -14,11 +14,7 @@ module Medicaid
     end
 
     def skip?
-      unstable_housing?
-    end
-
-    def unstable_housing?
-      !current_application&.stable_housing?
+      current_application.unstable_housing?
     end
 
     def update_application

--- a/app/dashboards/medicaid_application_dashboard.rb
+++ b/app/dashboards/medicaid_application_dashboard.rb
@@ -30,6 +30,7 @@ class MedicaidApplicationDashboard < Administrate::BaseDashboard
     phone_number: Field::String,
     sms_phone_number: Field::String,
     email: Field::String,
+    last_emailed_office_at: Field::DateTime,
     sms_consented: Field::Boolean,
     birthday: Field::DateTime,
     self_employment_expenses: Field::Number,
@@ -67,15 +68,19 @@ class MedicaidApplicationDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     phone_number
+    office_location
+    email
     signed_at
+    last_emailed_office_at
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-    members
-    addresses
     id
+    members
+    exports
+    addresses
     michigan_resident
     created_at
     updated_at
@@ -176,10 +181,7 @@ class MedicaidApplicationDashboard < Administrate::BaseDashboard
     anyone_married
   ].freeze
 
-  # Overwrite this method to customize how medicaid applications are displayed
-  # across all pages of the admin dashboard.
-  #
-  # def display_resource(medicaid_application)
-  #   "MedicaidApplication ##{medicaid_application.id}"
-  # end
+  def display_resource(medicaid_application)
+    "Medicaid Application ##{medicaid_application.id}"
+  end
 end

--- a/app/dashboards/snap_application_dashboard.rb
+++ b/app/dashboards/snap_application_dashboard.rb
@@ -19,8 +19,6 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     email: Field::String,
     last_emailed_office_at: Field::DateTime,
     everyone_a_citizen: Field::Boolean,
-    fax_metadata: Field::String.with_options(searchable: false),
-    faxed_successfully_at: Field::DateTime,
     financial_accounts: Field::String.with_options(searchable: false),
     income_change: Field::Boolean,
     income_change_explanation: Field::Text.with_options(searchable: false),
@@ -70,8 +68,6 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     phone_number
     office_location
     email
-    faxed_successfully_at
-    fax_metadata
     signed_at
     last_emailed_office_at
   ].freeze

--- a/app/models/concerns/common_benefit_application.rb
+++ b/app/models/concerns/common_benefit_application.rb
@@ -1,0 +1,33 @@
+module CommonBenefitApplication
+  extend ActiveSupport::Concern
+
+  def last_emailed_office_at
+    exports.emailed_office.succeeded.first&.completed_at
+  end
+
+  def signed_at_est
+    signed_at&.
+      in_time_zone("Eastern Time (US & Canada)")&.
+      strftime("%m/%d/%Y at %I:%M%p %Z")
+  end
+
+  def primary_member
+    members.order(:id).first || NullMember.new
+  end
+
+  def non_applicant_members
+    members - [primary_member]
+  end
+
+  def display_name
+    primary_member.display_name
+  end
+
+  def mailing_address
+    addresses.where(mailing: true).first || NullAddress.new
+  end
+
+  def unstable_housing?
+    !stable_housing?
+  end
+end

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -1,5 +1,6 @@
 class MedicaidApplication < ApplicationRecord
   include Submittable
+  include CommonBenefitApplication
 
   has_many(
     :members,
@@ -48,24 +49,8 @@ class MedicaidApplication < ApplicationRecord
     !anyone_caretaker_or_parent?
   end
 
-  def display_name
-    primary_member.display_name
-  end
-
-  def primary_member
-    members.order(:id).first || NullMember.new
-  end
-
-  def non_applicant_members
-    members - [primary_member]
-  end
-
   def residential_address
     addresses.where(mailing: false).first || NullAddress.new
-  end
-
-  def mailing_address
-    addresses.where(mailing: true).first || NullAddress.new
   end
 
   def pdf
@@ -75,10 +60,6 @@ class MedicaidApplication < ApplicationRecord
   end
 
   private
-
-  def unstable_housing?
-    !stable_housing?
-  end
 
   def no_self_employment?
     !anyone_self_employed?

--- a/app/views/admin/snap_applications/_collection.html.erb
+++ b/app/views/admin/snap_applications/_collection.html.erb
@@ -71,18 +71,6 @@ to display a collection of resources in an HTML table.
           </td>
         <% end %>
 
-        <td>
-          <% if resource.is_a? SnapApplication  -%>
-            <%= button_to(
-                 "Resend email to office",
-                 resend_email_admin_snap_application_path(resource),
-                 class: "button",
-                 method: :post,
-                 data: { confirm: "This will resend the office email for additional processing. Are you sure?" }
-            ) %>
-          <% end -%>
-        </td>
-
         <% if resource.is_a? SnapApplication -%>
           <td><%= link_to("Download", pdf_admin_snap_application_path(resource)) %></td>
         <% end -%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,6 @@ Rails.application.routes.draw do
 
     namespace :admin do
       resources :snap_applications do
-        post "resend_email", on: :member
         get "pdf", on: :member
       end
       resources :medicaid_applications do

--- a/spec/features/admin_dashboard_exports_spec.rb
+++ b/spec/features/admin_dashboard_exports_spec.rb
@@ -16,7 +16,7 @@ RSpec.feature "Admins can view exports" do
 
     within "[data-url='#{admin_export_path(medicaid_export)}']" do
       expect(page).to have_content(
-        "MedicaidApplication ##{medicaid_application.id}",
+        "Medicaid Application ##{medicaid_application.id}",
       )
     end
 

--- a/spec/features/admin_dashboard_snap_applications_spec.rb
+++ b/spec/features/admin_dashboard_snap_applications_spec.rb
@@ -30,23 +30,6 @@ RSpec.feature "Submit snap application with minimal information" do
     expect(page).to have_content "1 Faxed (4.5%)"
   end
 
-  scenario "resending a fax", javascript: true do
-    application = create(:snap_application, :faxed, signed_at: 5.days.ago)
-    visit admin_root_path
-
-    click_link_or_button "Resend email to office"
-
-    confirmation = "Resent email to #{application.receiving_office.email}" \
-                   " for #{application.signature}!"
-
-    expect(page).to have_content(confirmation)
-
-    faxes = application.exports.for_destination(:fax)
-    emails = application.exports.for_destination(:office_email)
-    expect(faxes.count).to eq 1
-    expect(emails.count).to eq 1
-  end
-
   scenario "dashboard timestamps are converted to EST", javascript: true do
     date = DateTime.new(2017, 4, 5, 1, 30)
 

--- a/spec/helpers/formatting_helper_spec.rb
+++ b/spec/helpers/formatting_helper_spec.rb
@@ -3,10 +3,10 @@ require "rails_helper"
 RSpec.describe TimeZoneHelper do
   describe "#date_in_est" do
     it "returns date in Eastern Standard Time" do
-      now = DateTime.new(2018,01,9,3,0,0)
+      now = DateTime.new(2018, 1, 9, 3, 0, 0)
       date = TimeZoneHelper.date_in_est(now)
 
-      expect(date).to eq(Date.new(2018,1,8))
+      expect(date).to eq(Date.new(2018, 1, 8))
     end
   end
 end

--- a/spec/models/medicaid_application_spec.rb
+++ b/spec/models/medicaid_application_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
 RSpec.describe MedicaidApplication do
+  describe "common benefit application" do
+    let(:subject) do
+      create(:medicaid_application)
+    end
+
+    it_should_behave_like "common benefit application"
+  end
+
   describe "#members" do
     it "returns them created_at ascending order" do
       old_member = build(:member, created_at: 1.year.ago)

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -1,6 +1,13 @@
 require "rails_helper"
 
 RSpec.describe SnapApplication do
+  describe "common benefit application" do
+    let(:subject) do
+      create(:medicaid_application)
+    end
+
+    it_should_behave_like "common benefit application"
+  end
   describe "validations" do
     [
       [:care_expenses, SnapApplication::CARE_EXPENSES],
@@ -127,50 +134,6 @@ RSpec.describe SnapApplication do
     end
   end
 
-  describe "#mailing_address" do
-    context "mailing address exists" do
-      it "returns mailing address" do
-        app = create(:snap_application)
-        mailing_address = create(:mailing_address, benefit_application: app)
-
-        expect(app.mailing_address).to eq(mailing_address)
-      end
-    end
-
-    context "mailing address does not exist" do
-      it "returns NullAddress" do
-        app = create(:snap_application)
-        create(:residential_address, benefit_application: app)
-
-        expect(app.mailing_address.class).to eq(NullAddress)
-      end
-    end
-  end
-
-  describe "#signed_at_est" do
-    context "signed_at present" do
-      it "returns the UTC time in EST" do
-        # September 1, 2008 10:05:00 AM UTC
-        time = Time.utc(2008, 9, 1, 10, 5, 0)
-        snap_app = build(:snap_application, signed_at: time)
-
-        Timecop.freeze(time) do
-          expect(snap_app.signed_at_est).to eq(
-            "09/01/2008 at 06:05AM EDT",
-          )
-        end
-      end
-    end
-
-    context "signed_at not present" do
-      it "returns nil" do
-        snap_app = build(:snap_application, signed_at: nil)
-
-        expect(snap_app.signed_at_est).to eq(nil)
-      end
-    end
-  end
-
   describe "#faxed?" do
     context "when no fax attempts have been made" do
       it "returns false" do
@@ -242,38 +205,6 @@ RSpec.describe SnapApplication do
       latest = create(:driver_application, snap_application: app)
 
       expect(app.latest_drive_attempt).to eq latest
-    end
-  end
-
-  describe "#emailed_office_at" do
-    it "returns time application was last successfully emailed to office" do
-      snap_application = create(:snap_application)
-
-      completed_at_time = DateTime.new(2018, 1, 1, 1, 30)
-
-      create(:export,
-        :emailed_office,
-        :succeeded,
-        completed_at: completed_at_time - 1.day,
-        benefit_application: snap_application)
-      create(:export,
-        :emailed_office,
-        :succeeded,
-        completed_at: completed_at_time,
-        benefit_application: snap_application)
-
-      create(:export,
-        :emailed_client,
-        :succeeded,
-        completed_at: completed_at_time - 1.day,
-        benefit_application: snap_application)
-      create(:export,
-        :emailed_office,
-        :failed,
-        completed_at: completed_at_time - 1.day,
-        benefit_application: snap_application)
-
-      expect(snap_application.last_emailed_office_at).to eq(completed_at_time)
     end
   end
 end

--- a/spec/support/shared_examples/common_benefit_application.rb
+++ b/spec/support/shared_examples/common_benefit_application.rb
@@ -1,0 +1,138 @@
+RSpec.shared_examples "common benefit application" do
+  describe "#last_emailed_office_at" do
+    it "returns time application was last successfully emailed to office" do
+      completed_at_time = DateTime.new(2018, 1, 1, 1, 30)
+
+      create(:export,
+        :emailed_office,
+        :succeeded,
+        completed_at: completed_at_time - 1.day,
+        benefit_application: subject)
+      create(:export,
+        :emailed_office,
+        :succeeded,
+        completed_at: completed_at_time,
+        benefit_application: subject)
+
+      create(:export,
+        :emailed_client,
+        :succeeded,
+        completed_at: completed_at_time - 1.day,
+        benefit_application: subject)
+      create(:export,
+        :emailed_office,
+        :failed,
+        completed_at: completed_at_time - 1.day,
+        benefit_application: subject)
+
+      expect(subject.last_emailed_office_at).to eq(completed_at_time)
+    end
+  end
+
+  describe "#signed_at_est" do
+    context "signed_at present" do
+      it "returns the UTC time in EST" do
+        # September 1, 2008 10:05:00 AM UTC
+        time = Time.utc(2008, 9, 1, 10, 5, 0)
+        subject.update(signed_at: time)
+
+        Timecop.freeze(time) do
+          expect(subject.signed_at_est).to eq(
+            "09/01/2008 at 06:05AM EDT",
+          )
+        end
+      end
+    end
+
+    context "signed_at not present" do
+      it "returns nil" do
+        subject.update(signed_at: nil)
+
+        expect(subject.signed_at_est).to eq(nil)
+      end
+    end
+  end
+
+  describe "#primary_member" do
+    context "when at least one member is present" do
+      it "returns the member with the lowest id" do
+        members = build_list(:member, 3)
+        subject.update(members: members)
+
+        expect(subject.primary_member).to eq(members.first)
+      end
+    end
+
+    context "when no members are present" do
+      it "returns NullMember" do
+        subject.update(members: [])
+
+        expect(subject.primary_member).to be_a(NullMember)
+      end
+    end
+  end
+
+  describe "#non_applicant_members" do
+    context "when one member is present" do
+      it "returns an empty array" do
+        subject.update(members: [build(:member)])
+
+        expect(subject.non_applicant_members).to eq([])
+      end
+    end
+
+    context "when 2 members are present" do
+      it "returns an array without the primary member" do
+        members = build_list(:member, 2)
+        subject.update(members: members)
+
+        expect(subject.non_applicant_members).to match_array([members.second])
+      end
+    end
+  end
+
+  describe "#display_name" do
+    it "returns the display name of the primary member" do
+      member = double("member", display_name: "Octopus Cuttlefish")
+      allow(subject).to receive(:primary_member) { member }
+      expect(subject.display_name).to eq("Octopus Cuttlefish")
+    end
+  end
+
+  describe "#mailing_address" do
+    context "mailing address exists" do
+      it "returns mailing address" do
+        mailing_address = build(:mailing_address)
+        subject.update(addresses: [mailing_address])
+
+        expect(subject.mailing_address).to eq(mailing_address)
+      end
+    end
+
+    context "mailing address does not exist" do
+      it "returns NullAddress" do
+        subject.update(addresses: [build(:residential_address)])
+
+        expect(subject.mailing_address).to be_a(NullAddress)
+      end
+    end
+  end
+
+  describe "#unstable_housing?" do
+    context "when stable_housing is true" do
+      it "returns false" do
+        subject.stable_housing = true
+
+        expect(subject.unstable_housing?).to eq(false)
+      end
+    end
+
+    context "when stable_housing is false" do
+      it "returns true" do
+        subject.stable_housing = false
+
+        expect(subject.unstable_housing?).to eq(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
In prep for the Medicaid release tomorrow, we're adding some diagnostics info to the admin dashboard! Took the opportunity to consolidate some shared logic between the different applications, too.

- Creates a CommonBenefitApplication shared concern (and
  associated shared example) that  collects common functionality
  of both Medicaid and SNAP application models.
- Give Medicaid Application admin collection the same fields as
  SNAP application (except SMS consent and Resend email to office)
- Tiny rubocop fixes