### PR TITLE
[PAIR] Adds aria-labelledby support for mb_textarea + mb_select.

### DIFF
--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -195,8 +195,8 @@ RSpec.describe MbFormBuilder do
           <p class="text--help" id="sample_birthday__help">(For surprises)</p>
           <div class="input-group--inline">
             <div class="select">
-              <label for="sample_birthday_2i" class="sr-only">Month</label>
-              <select id="sample_birthday_2i" name="sample[birthday(2i)]" class="select__element">
+              <label for="sample_birthday_2i" class="sr-only" id="sample_birthday_2i__label">Month</label>
+              <select id="sample_birthday_2i" name="sample[birthday(2i)]" class="select__element" aria-labelledby="sample_birthday__label sample_birthday__help sample_birthday_2i__label">
                 <option value="1">January</option>
                 <option value="2">February</option>
                 <option value="3" selected="selected">March</option>
@@ -212,8 +212,8 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
-              <label for="sample_birthday_3i" class="sr-only">Day</label>
-              <select id="sample_birthday_3i" name="sample[birthday(3i)]" class="select__element">
+              <label for="sample_birthday_3i" class="sr-only" id="sample_birthday_3i__label">Day</label>
+              <select id="sample_birthday_3i" name="sample[birthday(3i)]" class="select__element" aria-labelledby="sample_birthday__label sample_birthday__help sample_birthday_3i__label">
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>
@@ -248,8 +248,8 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
-              <label for="sample_birthday_1i" class="sr-only">Year</label>
-              <select id="sample_birthday_1i" name="sample[birthday(1i)]" class="select__element">
+              <label for="sample_birthday_1i" class="sr-only" id="sample_birthday_1i__label">Year</label>
+              <select id="sample_birthday_1i" name="sample[birthday(1i)]" class="select__element" aria-labelledby="sample_birthday__label sample_birthday__help sample_birthday_1i__label">
                 <option value="1990" selected="selected">1990</option>
                 <option value="1991">1991</option>
                 <option value="1992">1992</option>
@@ -296,12 +296,12 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
         <fieldset class="form-group">
-          <legend class="form-question " id="sample[members][72]_birthday__label">What is your birthday?</legend>
-          <p class="text--help" id="sample[members][72]_birthday__help">(For surprises)</p>
+          <legend class="form-question " id="sample_members_72_birthday__label">What is your birthday?</legend>
+          <p class="text--help" id="sample_members_72_birthday__help">(For surprises)</p>
           <div class="input-group--inline">
             <div class="select">
-              <label for="sample_members_72_birthday_2i" class="sr-only">Month</label>
-              <select id="sample_members_72_birthday_2i" name="sample[members][72][birthday(2i)]" class="select__element">
+              <label for="sample_members_72_birthday_2i" class="sr-only" id="sample_members_72_birthday_2i__label">Month</label>
+              <select id="sample_members_72_birthday_2i" name="sample[members][72][birthday(2i)]" class="select__element" aria-labelledby="sample_members_72_birthday__label sample_members_72_birthday__help sample_members_72_birthday_2i__label">
                 <option value="1">January</option>
                 <option value="2">February</option>
                 <option value="3" selected="selected">March</option>
@@ -317,8 +317,8 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
-              <label for="sample_members_72_birthday_3i" class="sr-only">Day</label>
-              <select id="sample_members_72_birthday_3i" name="sample[members][72][birthday(3i)]" class="select__element">
+              <label for="sample_members_72_birthday_3i" class="sr-only" id="sample_members_72_birthday_3i__label">Day</label>
+              <select id="sample_members_72_birthday_3i" name="sample[members][72][birthday(3i)]" class="select__element" aria-labelledby="sample_members_72_birthday__label sample_members_72_birthday__help sample_members_72_birthday_3i__label">
                 <option value="1">1</option>
                 <option value="2">2</option>
                 <option value="3">3</option>
@@ -353,8 +353,8 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
-              <label for="sample_members_72_birthday_1i" class="sr-only">Year</label>
-              <select id="sample_members_72_birthday_1i" name="sample[members][72][birthday(1i)]" class="select__element">
+              <label for="sample_members_72_birthday_1i" class="sr-only" id="sample_members_72_birthday_1i__label">Year</label>
+              <select id="sample_members_72_birthday_1i" name="sample[members][72][birthday(1i)]" class="select__element" aria-labelledby="sample_members_72_birthday__label sample_members_72_birthday__help sample_members_72_birthday_1i__label">
                 <option value="1990" selected="selected">1990</option>
                 <option value="1991">1991</option>
                 <option value="1992">1992</option>


### PR DESCRIPTION
* Created method called aria_labelledby
* Moved __label id to the question instead of <label>
* Sanitize ids for situations with objects that have brackets

[#152814700]

Signed-off-by: Paras Sanghavi <paras@codeforamerica.org>