### PR TITLE
Add aria-labelledby to standalone checkboxes.

### DIFF
--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -307,12 +307,16 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     html_output.html_safe
   end
 
-  def mb_checkbox(method, label_text, options = {})
+  def mb_checkbox(method, label_text, legend_id: nil, options: {})
     checked_value = options[:checked_value] || "1"
     unchecked_value = options[:unchecked_value] || "0"
 
+    options["aria-labelledby"] = aria_labelledby(method: method,
+                                                 help_text: nil,
+                                                 prefix: legend_id)
+
     <<~HTML.html_safe
-      <label class="checkbox">
+      <label class="checkbox" id="#{sanitized_id(method)}__label">
         #{check_box(method, options, checked_value, unchecked_value)} #{label_text}
       </label>
       #{errors_for(object, method)}
@@ -455,8 +459,11 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     position ? "#{name}_#{method}_#{position}" : "#{name}_#{method}"
   end
 
-  def aria_labelledby(method:, help_text:)
+  def aria_labelledby(method:, help_text:, prefix: "")
     aria_labels = []
+
+    aria_labels << prefix if prefix.present?
+
     if object.errors.present?
       aria_labels << "#{sanitized_id(method)}__errors"
     end

--- a/app/views/household_more_info_per_member/_member_checkboxes.html.erb
+++ b/app/views/household_more_info_per_member/_member_checkboxes.html.erb
@@ -1,5 +1,5 @@
 <% step.members.each do |member| %>
   <%= f.fields_for('members[]', member) do |ff| %>
-    <%= ff.mb_checkbox(method, member.display_name) %>
+    <%= ff.mb_checkbox(method, member.display_name, legend_id: legend_id) %>
   <% end %>
 <% end %>

--- a/app/views/household_more_info_per_member/edit.html.erb
+++ b/app/views/household_more_info_per_member/edit.html.erb
@@ -11,7 +11,7 @@
 
       <% if !current_application.everyone_a_citizen? %>
         <fieldset class="form-group">
-          <legend class="form-question">
+          <legend class="form-question" id="citizen__legend">
             <%= t("snap.household_more_info_per_member.edit.prompt") %>
             <span class="form-card__optional">(optional)</span>
           </legend>
@@ -20,7 +20,8 @@
               <%= ff.mb_checkbox(
                 :citizen,
                 member.display_name,
-                { checked_value: "0", unchecked_value: "1" },
+                legend_id: "citizen__legend",
+                options: {checked_value: "0", unchecked_value: "1"},
               ) %>
             <% end %>
           <% end %>
@@ -29,29 +30,29 @@
 
       <% if current_application.anyone_disabled? %>
         <fieldset class="form-group">
-          <legend class="form-question">Who has a disability?<span class="form-card__optional">(optional)</span></legend>
-          <%= render 'member_checkboxes', f: f, step: @step, method: :disabled %>
+          <legend class="form-question" id="disabled__legend">Who has a disability?<span class="form-card__optional">(optional)</span></legend>
+          <%= render 'member_checkboxes', f: f, step: @step, method: :disabled, legend_id: "disabled__legend" %>
         </fieldset>
       <% end %>
 
       <% if current_application.anyone_new_mom? %>
         <fieldset class="form-group">
-          <legend class="form-question">Who is pregnant or has been pregnant recently?<span class="form-card__optional">(optional)</span></legend>
-          <%= render 'member_checkboxes', f: f, step: @step, method: :new_mom %>
+          <legend class="form-question" id="pregnant__legend">Who is pregnant or has been pregnant recently?<span class="form-card__optional">(optional)</span></legend>
+          <%= render 'member_checkboxes', f: f, step: @step, method: :new_mom, legend_id: "pregnant__legend"  %>
         </fieldset>
       <% end %>
 
       <% if current_application.anyone_in_college? %>
         <fieldset class="form-group">
-          <legend class="form-question">Who is enrolled in college?<span class="form-card__optional">(optional)</span></legend>
-          <%= render 'member_checkboxes', f: f, step: @step, method: :in_college %>
+          <legend class="form-question" id="college__legend">Who is enrolled in college?<span class="form-card__optional">(optional)</span></legend>
+          <%= render 'member_checkboxes', f: f, step: @step, method: :in_college, legend_id: "college__legend"  %>
         </fieldset>
       <% end %>
 
       <% if current_application.anyone_living_elsewhere? %>
         <fieldset class="form-group">
-          <legend class="form-question">Who is temporarily living outside the home?<span class="form-card__optional">(optional)</span></legend>
-          <%= render 'member_checkboxes', f: f, step: @step, method: :living_elsewhere %>
+          <legend class="form-question" id="elsewhere__legend">Who is temporarily living outside the home?<span class="form-card__optional">(optional)</span></legend>
+          <%= render 'member_checkboxes', f: f, step: @step, method: :living_elsewhere, legend_id: "elsewhere__legend"  %>
         </fieldset>
       <% end %>
 

--- a/app/views/medicaid/contact_home_address/edit.html.erb
+++ b/app/views/medicaid/contact_home_address/edit.html.erb
@@ -16,7 +16,7 @@
 
       <%= f.mb_checkbox :mailing_address_same_as_residential_address,
         "This is the same as my mailing address",
-        { checked_value: "1", unchecked_value: "0" } %>
+        options: { checked_value: "1", unchecked_value: "0" } %>
 
       <%= render "medicaid/next_step" %>
     <% end %>

--- a/app/views/medicaid/expenses_alimony_member/edit.html.erb
+++ b/app/views/medicaid/expenses_alimony_member/edit.html.erb
@@ -16,13 +16,14 @@
 
 
       <fieldset class="form-group">
-        <legend class="sr-only">
+        <legend class="sr-only" id="support__legend">
           <%= t('medicaid.expenses_alimony_member.edit.title') %>
         </legend>
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox(:pay_child_support_alimony_arrears,
-                             member.display_name) %>
+                             member.display_name,
+                             legend_id: "support__legend") %>
           <% end %>
         <% end %>
         <%= f.mb_form_errors :child_support_alimony_arrears %>

--- a/app/views/medicaid/expenses_student_loan_member/edit.html.erb
+++ b/app/views/medicaid/expenses_student_loan_member/edit.html.erb
@@ -15,12 +15,12 @@
       method: :put do |f| %>
 
       <fieldset class="form-group">
-        <legend class="sr-only">
+        <legend class="sr-only" id="loan__legend">
           <%= t('medicaid.expenses_student_loan_member.edit.title') %>
         </legend>
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox(:pay_student_loan_interest, member.display_name) %>
+            <%= ff.mb_checkbox(:pay_student_loan_interest, member.display_name, legend_id: "loan__legend") %>
           <% end %>
         <% end %>
         <%= f.mb_form_errors :student_loan_interest %>

--- a/app/views/medicaid/health_disability_member/edit.html.erb
+++ b/app/views/medicaid/health_disability_member/edit.html.erb
@@ -16,12 +16,12 @@
 
 
       <fieldset class="form-group">
-        <legend class="sr-only">
+        <legend class="sr-only" id="disability__legend">
           <%= t('medicaid.health_disability_member.edit.title') %>
         </legend>
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox :disabled, member.display_name %>
+            <%= ff.mb_checkbox :disabled, member.display_name, legend_id: "disability__legend" %>
           <% end %>
         <% end %>
         <%= f.mb_form_errors :disabled %>

--- a/app/views/medicaid/health_pregnancy_member/edit.html.erb
+++ b/app/views/medicaid/health_pregnancy_member/edit.html.erb
@@ -18,7 +18,7 @@
       method: :put do |f| %>
 
       <fieldset class="form-group">
-        <legend class="sr-only">
+        <legend class="sr-only" id="pregnant__legend">
           <%= t("medicaid.health_pregnancy_member.edit.title") %>
         </legend>
         <% @step.members.each do |member| %>
@@ -26,11 +26,12 @@
             <%= ff.mb_checkbox(
               :new_mom,
               member.display_name,
-              { checked_value: "1", unchecked_value: "0" },
+              legend_id: "pregnant__legend",
+              options: { checked_value: "1", unchecked_value: "0" }
             ) %>
           <% end %>
         <% end %>
-        <%= f.mb_form_errors :recently_pregnanct %>
+        <%= f.mb_form_errors :recently_pregnancy %>
       </fieldset>
 
      <%= render "medicaid/next_step" %>

--- a/app/views/medicaid/income_other_income_member/edit.html.erb
+++ b/app/views/medicaid/income_other_income_member/edit.html.erb
@@ -14,7 +14,7 @@
       url: current_path,
       method: :put do |f| %>
       <fieldset class="form-group">
-        <legend class="sr-only">
+        <legend class="sr-only" id="income__legend">
           <%= t("medicaid.income_other_income_member.edit.title") %>
         </legend>
         <% @step.members.each do |member| %>
@@ -22,7 +22,8 @@
             <%= ff.mb_checkbox(
               :other_income,
               member.display_name,
-              { checked_value: "1", unchecked_value: "0" },
+              legend_id: "income__legend",
+              options: { checked_value: "1", unchecked_value: "0" },
             ) %>
           <% end %>
         <% end %>

--- a/app/views/medicaid/income_self_employment_member/edit.html.erb
+++ b/app/views/medicaid/income_self_employment_member/edit.html.erb
@@ -10,7 +10,7 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
         <fieldset class="form-group">
-          <legend class="sr-only">
+          <legend class="sr-only" id="self_employed__legend">
             <%= t("medicaid.income_self_employment_member.edit.title") %>
           </legend>
           <% @step.members.each do |member| %>
@@ -18,7 +18,8 @@
                   <%= ff.mb_checkbox(
                           :self_employed,
                           member.display_name,
-                          { checked_value: "1", unchecked_value: "0" },
+                          legend_id: "self_employed__legend",
+                          options: { checked_value: "1", unchecked_value: "0" }
                       ) %>
               <% end %>
           <% end %>

--- a/app/views/medicaid/insurance_current_member/edit.html.erb
+++ b/app/views/medicaid/insurance_current_member/edit.html.erb
@@ -17,7 +17,7 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
         <fieldset class="form-group">
-          <legend class="sr-only">
+          <legend class="sr-only" id="enrolled__legend">
             <%= t("medicaid.insurance_current_member.edit.title") %>
           </legend>
           <% @step.members.each do |member| %>
@@ -25,7 +25,8 @@
                 <%= ff.mb_checkbox(
                     :insured,
                     member.display_name,
-                    { checked_value: "1", unchecked_value: "0" },
+                    legend_id: "enrolled__legend",
+                    options: { checked_value: "1", unchecked_value: "0" },
                 ) %>
               <% end %>
           <% end %>

--- a/app/views/medicaid/insurance_needed/edit.html.erb
+++ b/app/views/medicaid/insurance_needed/edit.html.erb
@@ -14,7 +14,7 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <fieldset class="form-group">
-        <legend class="sr-only">
+        <legend class="sr-only" id="household__legend">
           <%= t("medicaid.insurance_needed.edit.title") %>
         </legend>
         <% @step.members.each do |member| %>
@@ -22,7 +22,8 @@
             <%= ff.mb_checkbox(
               :requesting_health_insurance,
               member.display_name,
-              { checked_value: "1", unchecked_value: "0" },
+              legend_id: "household__legend",
+              options: { checked_value: "1", unchecked_value: "0" },
             ) %>
           <% end %>
         <% end %>

--- a/app/views/medicaid/intro_caretaker_member/edit.html.erb
+++ b/app/views/medicaid/intro_caretaker_member/edit.html.erb
@@ -15,12 +15,15 @@
                  method: :put do |f| %>
 
         <fieldset class="form-group">
-          <legend class="sr-only">
+          <legend class="sr-only" id="caretaker__legend">
             <%= t("medicaid.intro_caretaker_member.edit.title") %>
           </legend>
           <% @step.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-                  <%= ff.mb_checkbox :caretaker_or_parent, member.display_name %>
+                  <%= ff.mb_checkbox :caretaker_or_parent,
+                                     member.display_name,
+                                     legend_id: "caretaker__legend"
+                  %>
               <% end %>
           <% end %>
           <%= f.mb_form_errors :caretaker_or_parent %>

--- a/app/views/medicaid/intro_citizen_member/edit.html.erb
+++ b/app/views/medicaid/intro_citizen_member/edit.html.erb
@@ -15,12 +15,12 @@
       method: :put do |f| %>
 
       <fieldset class="form-group">
-        <legend class="sr-only">
+        <legend class="sr-only" id="citizen__legend">
           <%= t("medicaid.intro_citizen_member.edit.title") %>
         </legend>
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox :citizen, member.display_name %>
+            <%= ff.mb_checkbox :citizen, member.display_name, legend_id: "citizen__legend" %>
           <% end %>
         <% end %>
         <%= f.mb_form_errors :citizen %>

--- a/app/views/medicaid/intro_college_member/edit.html.erb
+++ b/app/views/medicaid/intro_college_member/edit.html.erb
@@ -10,7 +10,7 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
         <fieldset class="form-group">
-          <legend class="sr-only">
+          <legend class="sr-only" id="college__legend">
             <%= t("medicaid.intro_college_member.edit.title") %>
           </legend>
           <% @step.members.each do |member| %>
@@ -18,7 +18,8 @@
                   <%= ff.mb_checkbox(
                     :in_college,
                     member.display_name,
-                    { checked_value: "1", unchecked_value: "0" },
+                    legend_id: "college__legend",
+                    options: { checked_value: "1", unchecked_value: "0" },
                   ) %>
               <% end %>
           <% end %>

--- a/app/views/medicaid/intro_marital_status_member/edit.html.erb
+++ b/app/views/medicaid/intro_marital_status_member/edit.html.erb
@@ -16,12 +16,12 @@
 
       <%= f.mb_form_errors :married %>
       <fieldset class="form-group">
-        <legend class="sr-only">
+        <legend class="sr-only" id="household__legend">
           <%= t("medicaid.intro_marital_status_member.edit.title") %>
         </legend>
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox :married, member.display_name %>
+            <%= ff.mb_checkbox :married, member.display_name, legend_id: "household__legend" %>
           <% end %>
         <% end %>
       </fieldset>

--- a/app/views/medicaid/tax_filing_with_household_members_member/edit.html.erb
+++ b/app/views/medicaid/tax_filing_with_household_members_member/edit.html.erb
@@ -15,12 +15,15 @@
                  method: :put do |f| %>
 
         <fieldset class="form-group">
-          <legend class="sr-only">
+          <legend class="sr-only" id="taxes__legend">
             <%= t("medicaid.tax_filing_with_household_members_member.edit.title") %>
           </legend>
           <% @step.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-                  <%= ff.mb_checkbox :filing_taxes_with_primary_member, member.display_name %>
+                  <%= ff.mb_checkbox :filing_taxes_with_primary_member,
+                                     member.display_name,
+                                     legend_id: "taxes__legend"
+                  %>
               <% end %>
           <% end %>
           <%= f.mb_form_errors :filing_taxes_with_primary_member %>

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -440,4 +440,60 @@ RSpec.describe MbFormBuilder do
       HTML
     end
   end
+
+  describe "#mb_checkbox" do
+    it "renders an accessible checkbox input" do
+      class SampleStep < Step
+        step_attributes(:read_tos)
+        validates_presence_of :read_tos
+      end
+
+      sample = SampleStep.new
+      sample.validate
+      form = MbFormBuilder.new("sample", sample, template, {})
+      output = form.mb_checkbox(
+        :read_tos,
+        "Confirm that you agree to Terms of Service",
+      )
+
+      expect(output).to be_html_safe
+
+      expect(output).to match_html <<-HTML
+        <label class="checkbox" id="sample_read_tos__label">
+          <input name="sample[read_tos]" type="hidden" value="0" />
+          <div class="field_with_errors">
+            <input aria-labelledby="sample_read_tos__errors sample_read_tos__label" type="checkbox" value="1" name="sample[read_tos]" id="sample_read_tos" />
+          </div>
+          Confirm that you agree to Terms of Service
+        </label>
+        <div class="text--error" id="sample_read_tos__errors">
+          <i class="icon-warning"></i> can't be blank
+        </div>
+      HTML
+    end
+
+    it "prefixes aria-labelledby with custom legend id" do
+      class SampleStep < Step
+        step_attributes(:read_tos)
+      end
+
+      sample = SampleStep.new
+      form = MbFormBuilder.new("sample", sample, template, {})
+      output = form.mb_checkbox(
+        :read_tos,
+        "Confirm that you agree to Terms of Service",
+        legend_id: "legend__label",
+      )
+
+      expect(output).to be_html_safe
+
+      expect(output).to match_html <<-HTML
+        <label class="checkbox" id="sample_read_tos__label">
+          <input name="sample[read_tos]" type="hidden" value="0" />
+          <input aria-labelledby="legend__label sample_read_tos__label" type="checkbox" value="1" name="sample[read_tos]" id="sample_read_tos" />
+          Confirm that you agree to Terms of Service
+        </label>
+      HTML
+    end
+  end
 end


### PR DESCRIPTION
* Adds `legend_id` option for use by aria-labelledby.
* Converts `options` to named argument.
* No support for help text, since we don't use it.

[Finishes #152814700]

Signed-off-by: Ben Golder <bgolder@codeforamerica.org>