### PR TITLE
Add brakeman to Circle CI after bundle-audit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ end
 
 group :development, :test do
   gem "awesome_print", require: false
+  gem "brakeman", require: false
   gem "bundler-audit"
   gem "climate_control"
   gem "codeclimate-test-reporter"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,7 @@ GEM
     bourbon (4.2.7)
       sass (~> 3.4)
       thor (~> 0.19)
+    brakeman (4.1.1)
     builder (3.2.3)
     bundler-audit (0.6.0)
       bundler (~> 1.2)
@@ -463,6 +464,7 @@ DEPENDENCIES
   aws-sdk (~> 2.10)
   axe-matchers
   bourbon (~> 4.2.0)
+  brakeman
   bundler-audit
   capybara
   climate_control

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,11 @@ task(:rubocop) do
   RuboCop::RakeTask.new
 end
 
-task default: %w(spec rubocop bundler:audit)
+task(:brakeman) do
+  sh "brakeman"
+end
+
+task default: %w(rubocop bundler:audit brakeman spec)
 
 Rails.application.load_tasks
 

--- a/circle.yml
+++ b/circle.yml
@@ -10,6 +10,7 @@ dependencies:
     - rm google-chrome.deb
   post:
     - bundle exec bundle-audit update && bundle exec bundle-audit check
+    - bundle exec brakeman
 
 test:
   override:

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,26 +1,26 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "9dbd16606d77f5894544b049241d32224b1363e2927c972701d97bb5e690c418",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "app/models/dhs1171_pdf.rb",
-      "line": 31,
-      "link": "http://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "system(((\"pdftk #{\"#{\"lib/pdfs\".freeze}/michigan_snap_fax_cover_letter.pdf\".freeze} #{filled_in_form.path} #{additional_pages}\" + \" cat output\") + \" #{complete_form_with_cover.path}\"))",
+      "warning_type": "Mass Assignment",
+      "warning_code": 70,
+      "fingerprint": "e75c62e0e7160bd72858bba33cda03a1d0a37bb08fc64c57d1c890bde59169a2",
+      "check_name": "MassAssignment",
+      "message": "Parameters should be whitelisted for mass assignment",
+      "file": "app/controllers/medicaid/amounts_income_controller.rb",
+      "line": 39,
+      "link": "https://brakemanscanner.org/docs/warning_types/mass_assignment/",
+      "code": "params.fetch(:step, {}).permit!",
       "render_path": null,
       "location": {
         "type": "method",
-        "class": "Dhs1171Pdf",
-        "method": "prepend_cover_sheet_to_completed_form"
+        "class": "Medicaid::AmountsIncomeController",
+        "method": "step_params"
       },
-      "user_input": "complete_form_with_cover.path",
+      "user_input": null,
       "confidence": "Medium",
       "note": ""
     }
   ],
-  "updated": "2017-08-28 14:35:58 -0700",
-  "brakeman_version": "3.7.0"
+  "updated": "2018-01-12 17:05:12 -0800",
+  "brakeman_version": "4.1.1"
 }


### PR DESCRIPTION
This adds brakeman to the Circle CI tasks, as a `post` after bundler-audit is run and before the tests are run.

https://www.pivotaltracker.com/story/show/154097597

[#154097597]