### PR TITLE
Add basic integration test for SNAP flow that checks for PDF attachment

### DIFF
--- a/app/lib/pdf_builder.rb
+++ b/app/lib/pdf_builder.rb
@@ -1,6 +1,6 @@
 class PdfBuilder
-  def initialize(file_paths:, output_file:)
-    @file_paths = file_paths
+  def initialize(files:, output_file:)
+    @files = files
     @output_file = output_file
   end
 
@@ -12,7 +12,7 @@ class PdfBuilder
 
   private
 
-  attr_accessor :output_file, :file_paths
+  attr_accessor :output_file, :files
 
   def conjoin_files
     system(
@@ -23,6 +23,6 @@ class PdfBuilder
   end
 
   def paths_to_pdfs
-    file_paths.join(" ")
+    files.map(&:path).join(" ")
   end
 end

--- a/app/models/remote_document.rb
+++ b/app/models/remote_document.rb
@@ -3,7 +3,7 @@ class RemoteDocument
 
   def initialize(url)
     @url = url
-    @tempfile = Tempfile.new.tap(&:binmode)
+    @tempfile = Tempfile.new.binmode
   end
 
   def download
@@ -39,7 +39,8 @@ class RemoteDocument
 
   def file_type
     @_file_type ||= FileMagic.open(:mime) do |fm|
-      fm.file(tempfile.tap(&:rewind).path, true)
+      tempfile.rewind
+      fm.file(tempfile.path, true)
     end
   end
 

--- a/app/models/snap_application_extra_member_pdf.rb
+++ b/app/models/snap_application_extra_member_pdf.rb
@@ -33,21 +33,16 @@ class SnapApplicationExtraMemberPdf
     end
 
     add_footer(pdf)
-    pdf.render_file(file_path)
-    file_path
+    pdf.render_file(temp_file.path)
+    temp_file
   end
 
   private
 
   attr_reader :members, :attributes_class, :title
 
-  def file_path
-    "tmp/#{filename}.pdf"
-  end
-
-  def filename
-    @filename ||=
-      "#{SecureRandom.hex}#{Time.now.strftime('%Y%m%d%H%M%S%L')}"
+  def temp_file
+    @_temp_file ||= Tempfile.new(["snap-extra-member", ".pdf"], "tmp/")
   end
 
   def add_footer(pdf)

--- a/spec/features/admin_dashboard_medicaid_applications_spec.rb
+++ b/spec/features/admin_dashboard_medicaid_applications_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature "Admin viewing medicaid applications dashboard", type: :feature do
     expect(current_path).to eq(
       "/admin/medicaid_applications/#{application.id}/pdf",
     )
-    temp_pdf = write_response_to_temp_file
+    temp_pdf = write_raw_pdf_to_temp_file(source: page.source)
     results = filled_in_values(file: temp_pdf)
     expect(results.values).to include("Christa Tester")
   end

--- a/spec/features/admin_dashboard_medicaid_applications_spec.rb
+++ b/spec/features/admin_dashboard_medicaid_applications_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require_relative "../support/pdf_helper"
 
 RSpec.feature "Admin viewing medicaid applications dashboard", type: :feature do
   include PdfHelper
@@ -40,7 +39,7 @@ RSpec.feature "Admin viewing medicaid applications dashboard", type: :feature do
       "/admin/medicaid_applications/#{application.id}/pdf",
     )
     temp_pdf = write_raw_pdf_to_temp_file(source: page.source)
-    results = filled_in_values(file: temp_pdf)
+    results = filled_in_values(temp_pdf)
     expect(results.values).to include("Christa Tester")
   end
 end

--- a/spec/features/snap_application_with_maximum_info_spec.rb
+++ b/spec/features/snap_application_with_maximum_info_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 feature "SNAP application with maximum info" do
+  include PdfHelper
+
   scenario "successfully submits application", :js do
     visit root_path
     within(".slab--hero") { proceed_with "Apply for FAP" }
@@ -192,11 +194,22 @@ accounts?",
     expect(page).to have_text(
       "Your application has been sent to your email inbox",
     )
+
+    emails = ActionMailer::Base.deliveries
+    expect(emails.count).to eq(2)
+    expect(emails.first.attachments.count).to eq(1)
+    expect(emails.second.attachments.count).to eq(1)
+
+    raw_application_pdf = emails.first.attachments.first.body.raw_source
+    temp_file = write_raw_pdf_to_temp_file(source: raw_application_pdf)
+    pdf_values = filled_in_values(file: temp_file.path)
+
+    expect(pdf_values["primary_member_full_name"]).to include("Jessie Tester")
   end
 
   def upload_documents
-    add_document_photo "https://example.com/images/drivers_license.jpg"
-    add_document_photo "https://example.com/images/proof_of_income.jpg"
+    add_document_photo "https://example.com/images/image_1.jpg"
+    add_document_photo "https://example.com/images/image_2.jpg"
   end
 
   def add_document_photo(url)

--- a/spec/features/snap_application_with_maximum_info_spec.rb
+++ b/spec/features/snap_application_with_maximum_info_spec.rb
@@ -202,7 +202,7 @@ accounts?",
 
     raw_application_pdf = emails.first.attachments.first.body.raw_source
     temp_file = write_raw_pdf_to_temp_file(source: raw_application_pdf)
-    pdf_values = filled_in_values(file: temp_file.path)
+    pdf_values = filled_in_values(temp_file.path)
 
     expect(pdf_values["primary_member_full_name"]).to include("Jessie Tester")
   end

--- a/spec/lib/pdf_builder_spec.rb
+++ b/spec/lib/pdf_builder_spec.rb
@@ -9,7 +9,7 @@ describe PdfBuilder do
         second_pdf = File.open("spec/fixtures/test_pdf.pdf")
 
         pdf = PdfBuilder.new(
-          file_paths: [pdf.path, second_pdf.path],
+          files: [pdf, second_pdf],
           output_file: output_file,
         ).pdf
 

--- a/spec/models/dhs1426_pdf_spec.rb
+++ b/spec/models/dhs1426_pdf_spec.rb
@@ -1,5 +1,4 @@
 require "rails_helper"
-require_relative "../support/pdf_helper"
 
 RSpec.describe Dhs1426Pdf do
   include PdfHelper
@@ -245,7 +244,7 @@ RSpec.describe Dhs1426Pdf do
         medicaid_application: medicaid_application,
       ).completed_file
 
-      result = filled_in_values(file: file.path)
+      result = filled_in_values(file.path)
 
       [
         expected_client_data,
@@ -314,7 +313,7 @@ RSpec.describe Dhs1426Pdf do
 
       file = Dhs1426Pdf.new(medicaid_application: medicaid_application).
         completed_file
-      result = filled_in_values(file: file.path)
+      result = filled_in_values(file.path)
       expect(result["primary_member_full_name"]).to include("Primera")
       expect(result["second_member_full_name"]).to include("Segunda")
       expect(result["1.second_member_full_name"]).to include("Tercera")
@@ -336,7 +335,7 @@ RSpec.describe Dhs1426Pdf do
       paperwork_path = "http://example.com"
       verification_document = double
       allow(verification_document).to receive(:file).and_return(
-        File.open("spec/fixtures/test_pdf.pdf"),
+        temp_pdf_file,
       )
       medicaid_application =
         create(:medicaid_application, :with_member, paperwork: [paperwork_path])

--- a/spec/models/verification_document_spec.rb
+++ b/spec/models/verification_document_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 describe VerificationDocument do
+  include PdfHelper
+
   describe "#file" do
     context "files are png/jpg format" do
       it "returns a pdf tempfile" do
@@ -86,12 +88,6 @@ describe VerificationDocument do
     def temp_image_file
       Tempfile.new(["image", ".jpg"]).tap do |f|
         f.write(File.read("spec/fixtures/image.jpg"))
-      end.tap(&:rewind)
-    end
-
-    def temp_pdf_file
-      Tempfile.new(["doc", ".pdf"]).tap do |f|
-        f.write(File.read("spec/fixtures/test_pdf.pdf"))
       end.tap(&:rewind)
     end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,17 @@ RSpec.configure do |config|
     DatabaseCleaner.start
   end
 
+  config.before :all, type: :feature do
+    stub_request(:get, /example\.com\/images/).
+      to_return(File.new("spec/fixtures/test_remote_image.jpg"))
+
+    Delayed::Worker.delay_jobs = false
+  end
+
+  config.after :each, type: feature do
+    ActionMailer::Base.deliveries.clear
+  end
+
   config.after(:each) do
     DatabaseCleaner.clean
     FakeTwilioClient.clear!

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -40,7 +40,7 @@ RSpec.configure do |config|
     Delayed::Worker.delay_jobs = false
   end
 
-  config.after :each, type: feature do
+  config.after :each, type: :feature do
     ActionMailer::Base.deliveries.clear
   end
 

--- a/spec/support/pdf_helper.rb
+++ b/spec/support/pdf_helper.rb
@@ -1,6 +1,6 @@
 module PdfHelper
-  def filled_in_values(file:)
-    filled_in_fields = pdftk.get_fields(file)
+  def filled_in_values(file_path)
+    filled_in_fields = pdftk.get_fields(file_path)
 
     filled_in_fields.each_with_object({}) do |field, hash|
       hash[field.name] = field.value
@@ -15,5 +15,11 @@ module PdfHelper
     temp_pdf = Tempfile.new("pdf", encoding: "ascii-8bit")
     temp_pdf << source
     temp_pdf
+  end
+
+  def temp_pdf_file
+    Tempfile.new(["doc", ".pdf"]).tap do |f|
+      f.write(File.read("spec/fixtures/test_pdf.pdf"))
+    end.tap(&:rewind)
   end
 end

--- a/spec/support/pdf_helper.rb
+++ b/spec/support/pdf_helper.rb
@@ -11,9 +11,9 @@ module PdfHelper
     @_pdftk ||= PdfForms.new
   end
 
-  def write_response_to_temp_file
-    temp_pdf = Tempfile.new("pdf")
-    temp_pdf << page.source.force_encoding("UTF-8")
+  def write_raw_pdf_to_temp_file(source:)
+    temp_pdf = Tempfile.new("pdf", encoding: "ascii-8bit")
+    temp_pdf << source
     temp_pdf
   end
 end


### PR DESCRIPTION
So, I was trying to write a simple integration test that would reproduce what we're seeing locally (application PDF generation failing if there are 2 or more documents uploaded). This *didn't* do that, but seemed like it could still be useful, so wanted to push up.

This does a few things:
* Forces Delayed Jobs to complete in tests. They were hanging around before
* Stubs out requests to example.com/images for our feature specs (done only when we generate a PDF, needed because we're executing delayed jobs in specs)
* Clears out ActionMailer::Base.deliveries (needed because we're executing delayed jobs in specs, and testing the number of deliveries made on a request)

I'd be interested in discussing how we want to treat PDFs in these integration tests. Right now I just tested enough to guarantee the PDF wasn't bunk.