### PR TITLE
Only report on signed applications during daily summary

### DIFF
--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -11,6 +11,8 @@ class MedicaidApplication < ApplicationRecord
 
   has_many :addresses, as: :benefit_application, dependent: :destroy
 
+  scope :signed, -> { where.not(signed_at: nil) }
+
   attribute :ssn
   attr_encrypted(
     :ssn,

--- a/lib/summarizer/application_summary.rb
+++ b/lib/summarizer/application_summary.rb
@@ -3,8 +3,13 @@ module Summarizer
     def initialize(datetime, timezone)
       @date = datetime.in_time_zone(timezone)
       date_range = @date.beginning_of_day..@date.end_of_day
-      @snap_applications = SnapApplication.where(created_at: date_range)
-      @medicaid_applications = MedicaidApplication.where(created_at: date_range)
+
+      @snap_applications = SnapApplication.
+        where(created_at: date_range).
+        signed
+      @medicaid_applications = MedicaidApplication.
+        where(created_at: date_range).
+        signed
     end
 
     def daily_summary

--- a/spec/factories/medicaid_applications.rb
+++ b/spec/factories/medicaid_applications.rb
@@ -2,6 +2,14 @@ FactoryBot.define do
   factory :medicaid_application do
     michigan_resident true
 
+    trait :signed do
+      signed_at Time.now
+    end
+
+    trait :unsigned do
+      signed_at nil
+    end
+
     trait :with_member do
       after :create do |app|
         create(:member, benefit_application: app)

--- a/spec/factories/snap_applications.rb
+++ b/spec/factories/snap_applications.rb
@@ -2,8 +2,16 @@ FactoryBot.define do
   factory :snap_application do
     email "test@example.com"
     signature "Mr. RJD2"
-    signed_at Date.current
     mailing_address_same_as_residential_address false
+    signed
+
+    trait :signed do
+      signed_at Time.now
+    end
+
+    trait :unsigned do
+      signed_at nil
+    end
 
     trait :with_member do
       after :create do |app|

--- a/spec/lib/summarizer/application_summary_spec.rb
+++ b/spec/lib/summarizer/application_summary_spec.rb
@@ -5,12 +5,13 @@ RSpec.describe Summarizer::ApplicationSummary do
   describe "#run" do
     it "returns a summary of daily applications for date and timezone" do
       date = DateTime.new(2017, 12, 1, 0, 0)
-      create_list(:snap_application, 2, created_at: date)
-      create(:medicaid_application, created_at: date)
 
-      create(:snap_application, created_at: date - 1.day)
-      create(:snap_application, created_at: date + 21.hours)
-      create(:medicaid_application, created_at: date + 1.day)
+      create_list(:snap_application, 2, :signed, created_at: date)
+      create(:medicaid_application, :signed, created_at: date)
+
+      create(:snap_application, :signed, created_at: date - 1.day)
+      create(:snap_application, :signed, created_at: date + 21.hours)
+      create(:medicaid_application, :signed, created_at: date + 1.day)
 
       text = Summarizer::ApplicationSummary.new(
         date,
@@ -19,6 +20,24 @@ RSpec.describe Summarizer::ApplicationSummary do
 
       expect(text).to eq(
         "On Fri, Dec 01, we processed 2 SNAP and 1 Medicaid applications.",
+      )
+    end
+
+    it "only includes signed applications" do
+      date = DateTime.new(2017, 12, 1, 12, 0)
+
+      create(:snap_application, :unsigned, created_at: date)
+      create(:snap_application, :signed, created_at: date)
+      create(:medicaid_application, :unsigned, created_at: date)
+      create(:medicaid_application, :signed, created_at: date)
+
+      text = Summarizer::ApplicationSummary.new(
+        date,
+        "America/New_York",
+      ).daily_summary
+
+      expect(text).to eq(
+        "On Fri, Dec 01, we processed 1 SNAP and 1 Medicaid applications.",
       )
     end
   end

--- a/spec/models/medicaid_application_spec.rb
+++ b/spec/models/medicaid_application_spec.rb
@@ -9,6 +9,19 @@ RSpec.describe MedicaidApplication do
     it_should_behave_like "common benefit application"
   end
 
+  describe "scopes" do
+    describe ".signed" do
+      it "returns applications that have been signed" do
+        signed_application = create(:medicaid_application, signed_at: Time.now)
+        create(:medicaid_application, signed_at: nil)
+
+        signed_applications = MedicaidApplication.signed
+        expect(signed_applications.count).to eq(1)
+        expect(signed_applications.first).to eq(signed_application)
+      end
+    end
+  end
+
   describe "#members" do
     it "returns them created_at ascending order" do
       old_member = build(:member, created_at: 1.year.ago)


### PR DESCRIPTION
Previously for our Slack daily summary, we just included any applications that had been initiated during the day. This scopes that reporting to only *signed* applications.