### PR TITLE
Redirect user after `/success` if they try to access page without app

### DIFF
--- a/app/controllers/skip_send_applications_controller.rb
+++ b/app/controllers/skip_send_applications_controller.rb
@@ -1,6 +1,11 @@
 class SkipSendApplicationsController < SnapStepsController
   def create
-    flash[:notice] = "Your application has been submitted."
+    flash[:notice] = if current_application.present?
+                       "Your application has been submitted."
+                     else
+                       "Sorry, you can't access that page."
+                     end
+
     redirect_to after_submit_path
   end
 end

--- a/app/controllers/snap_steps_controller.rb
+++ b/app/controllers/snap_steps_controller.rb
@@ -20,7 +20,7 @@ class SnapStepsController < StepsController
   end
 
   def after_submit_path
-    if current_application.office_location.present?
+    if current_application&.office_location.present?
       public_send("#{current_application.office_location}_path", anchor: "fold")
     else
       root_path(anchor: "fold")

--- a/spec/controllers/skip_send_applications_controller_spec.rb
+++ b/spec/controllers/skip_send_applications_controller_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe SkipSendApplicationsController do
+  describe "#create" do
+    context "without current application" do
+      let(:current_app) { create(:snap_application) }
+      before { session[:snap_application_id] = current_app.id }
+
+      it "redirects to home page with sorry message" do
+        post :create
+
+        expect(response).to redirect_to(root_path(anchor: "fold"))
+        expect(flash[:notice]).to include("submitted")
+      end
+    end
+
+    context "with current application" do
+      it "redirects to home page with success message" do
+        post :create
+
+        expect(response).to redirect_to(root_path(anchor: "fold"))
+        expect(flash[:notice]).to include("Sorry")
+      end
+    end
+  end
+end

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -9,11 +9,14 @@ RSpec.describe SuccessController do
       and_return(run_double)
   end
 
+  let(:attributes) { { email: "test@example.com" } }
+  let(:current_app) { create(:snap_application, attributes: attributes) }
+
   describe "#edit" do
     it "assigns the attributes to the step" do
       get :edit
 
-      expect(step.email).to eq "test@example.com"
+      expect(assigns(:step).email).to eq "test@example.com"
     end
 
     it "emails the snap application to the office" do
@@ -181,17 +184,5 @@ RSpec.describe SuccessController do
         expect(response).to render_template(:edit)
       end
     end
-  end
-
-  def step
-    @_step ||= assigns(:step)
-  end
-
-  def attributes
-    { email: "test@example.com" }
-  end
-
-  def current_app
-    @_current_app ||= create(:snap_application, attributes)
   end
 end


### PR DESCRIPTION
Previously, if a user submitted a SNAP application and clicked 'back' after hitting the homepage, they would receive an error if they clicked on 'skip this step'. This commit addresses that by redirecting the user if there isn't a current application when they click 'skip this step', and adds a helpful flash message to let them know they've been redirected to the start of the application.

[Finishes #154097480]
https://www.pivotaltracker.com/story/show/154097480