### PR TITLE
Namespace rubocop in Rakefile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development, :test do
   gem "pry-byebug"
   gem "rspec-rails"
   gem "rspec_junit_formatter"
+  gem "rubocop", require: false
   gem "rubocop-rspec", require: false
   gem "simplecov"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       selectize-rails (~> 0.6)
     afm (0.2.2)
     arel (8.0.0)
-    ast (2.3.0)
+    ast (2.4.0)
     attr_encrypted (3.0.3)
       encryptor (~> 3.0.0)
     auto_strip_attributes (2.2.0)
@@ -994,6 +994,7 @@ DEPENDENCIES
   route_downcaser
   rspec-rails
   rspec_junit_formatter
+  rubocop
   rubocop-rspec
   ruby-filemagic
   sass-rails

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,19 @@
 require_relative "config/application"
-require "rubocop/rake_task"
 
-RuboCop::RakeTask.new
+namespace :lint do
+  task :autocorrect do
+    require "rubocop/rake_task"
+    RuboCop::RakeTask.new
+    Rake::Task["rubocop:auto_correct"].execute
+  end
+end
 
-task(:brakeman) do
+task :brakeman do
   sh "brakeman"
 end
 
-task default: %w(rubocop:auto_correct bundler:audit brakeman spec)
-
 Rails.application.load_tasks
+
+task default: %w(lint:autocorrect bundler:audit brakeman spec)
 
 task "db:schema:dump": "strong_migrations:alphabetize_columns"


### PR DESCRIPTION
Recently we began requiring rubocop's rake task when loading the Rakefile (without calling a specific rake task). Because we only required rubocop in test and development environments, using any Rake task in production or staging would break. We saw this on Circle CI when doing staging deploys.

To fix, we now only require 'rubocop/rake_task' when our own `lint:autocorrect` is called. Because rubcop doesn't give a clear way to do this and also call its autocorrect sub-Rake task, we manually call it with `Rake::Task["rubocop:auto_correct"].execute`.