### PR TITLE
Send blank PDF for SNAP apps if feature flag enabled.

### DIFF
--- a/app/models/dhs1171_pdf.rb
+++ b/app/models/dhs1171_pdf.rb
@@ -89,7 +89,7 @@ class Dhs1171Pdf
       VerificationDocument.new(
         url: document,
         benefit_application: snap_application,
-      ).file
+      ).output_file
     end.reject { |document| document.path.nil? }
   end
 

--- a/app/models/dhs1426_pdf.rb
+++ b/app/models/dhs1426_pdf.rb
@@ -154,7 +154,7 @@ class Dhs1426Pdf
       VerificationDocument.new(
         url: document,
         benefit_application: medicaid_application,
-      ).file
+      ).output_file
     end.reject { |document| document.path.nil? }
   end
 

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -82,7 +82,7 @@ class SnapApplication < ApplicationRecord
     @_pdf ||=
       if Feature.enabled?("NEW_FORM")
         ApplicationPdfAssembler.new(
-          snap_application: self,
+          benefit_application: self,
         ).run
       else
         Dhs1171Pdf.new(

--- a/app/models/verification_document.rb
+++ b/app/models/verification_document.rb
@@ -4,7 +4,11 @@ class VerificationDocument
     @benefit_application = benefit_application
   end
 
-  def file
+  def fill?
+    false
+  end
+
+  def output_file
     downloaded_document = RemoteDocument.new(url).download
     return if downloaded_document.nil?
     return downloaded_document.tempfile if downloaded_document.pdf?

--- a/app/pdf_components/assistance_application_form.rb
+++ b/app/pdf_components/assistance_application_form.rb
@@ -1,6 +1,10 @@
 class AssistanceApplicationForm
   include PdfAttributes
 
+  def fill?
+    true
+  end
+
   def initialize(benefit_application)
     @benefit_application = benefit_application
   end

--- a/app/pdf_components/coversheet.rb
+++ b/app/pdf_components/coversheet.rb
@@ -1,0 +1,9 @@
+class Coversheet
+  def fill?
+    false
+  end
+
+  def output_file
+    @_output_file ||= open("app/lib/pdfs/DHS_1171_cover_letter.pdf")
+  end
+end

--- a/app/services/application_pdf_assembler.rb
+++ b/app/services/application_pdf_assembler.rb
@@ -1,23 +1,30 @@
 class ApplicationPdfAssembler
-  def initialize(snap_application:)
-    @snap_application = snap_application
+  def initialize(benefit_application:)
+    @benefit_application = benefit_application
   end
 
   def run
-    PdfConcatenator.new(forms).run
+    PdfConcatenator.new(components).run
   end
 
-  attr_reader :snap_application
+  attr_reader :benefit_application
 
   private
 
-  def forms
+  def components
     [
-      AssistanceApplicationForm.new(snap_application),
-      # CommonApplicationAdditionalMembers.new(snap_application.members),
+      Coversheet.new,
+      AssistanceApplicationForm.new(benefit_application),
+      # CommonApplicationAdditionalMembers.new(benefit_application.members),
       # MedicaidSupplement.new(medicaid_application) if medicaid_application,
-      # FoodAssistanceSupplement.new(snap_application) if snap_application,
-      # VerificationPaperwork.new(snap_application.documents),
-    ]
+      # FoodAssistanceSupplement.new(benefit_application) if benefit_application,
+      verification_documents,
+    ].flatten
+  end
+
+  def verification_documents
+    benefit_application.documents.map do |document_url|
+      VerificationDocument.new(url: document_url, benefit_application: benefit_application)
+    end
   end
 end

--- a/app/services/pdf_concatenator.rb
+++ b/app/services/pdf_concatenator.rb
@@ -1,20 +1,23 @@
 class PdfConcatenator
-  def initialize(forms)
-    @forms = forms
+  def initialize(components)
+    @components = components
   end
 
-  attr_reader :forms
+  attr_reader :components
 
   def run
     final_output_file = Tempfile.new(["final_output", ".pdf"], "tmp/")
 
-    pdfs = forms.map do |form|
-      PdfForms.new.fill_form(
-        form.source_pdf_path,
-        form.output_file.path,
-        form.attributes,
-      )
-      form.output_file
+    pdfs = components.map do |component|
+      if component.fill?
+        PdfForms.new.fill_form(
+          component.source_pdf_path,
+          component.output_file.path,
+          component.attributes,
+        )
+      end
+
+      component.output_file
     end
 
     PdfForms::PdftkWrapper.new.cat(*pdfs, final_output_file.path)

--- a/spec/models/dhs1171_pdf_spec.rb
+++ b/spec/models/dhs1171_pdf_spec.rb
@@ -229,7 +229,7 @@ RSpec.describe Dhs1171Pdf do
 
       let!(:temp_file) { temp_pdf_file }
       let(:verification_document) do
-        double("verification document", file: temp_file)
+        double("verification document", output_file: temp_file)
       end
 
       let(:document_path) { "http://example.com" }

--- a/spec/models/dhs1426_pdf_spec.rb
+++ b/spec/models/dhs1426_pdf_spec.rb
@@ -334,7 +334,7 @@ RSpec.describe Dhs1426Pdf do
     it "appends pages if there are verification documents" do
       paperwork_path = "http://example.com"
       verification_document = double
-      allow(verification_document).to receive(:file).and_return(
+      allow(verification_document).to receive(:output_file).and_return(
         temp_pdf_file,
       )
       medicaid_application =

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe SnapApplication do
         app = build(:snap_application)
 
         fake_pdf_builder = double(run: "I am fake. It's OK")
-        allow(ApplicationPdfAssembler).to receive(:new).with(snap_application: app).
+        allow(ApplicationPdfAssembler).to receive(:new).with(benefit_application: app).
           and_return(fake_pdf_builder)
 
         with_modified_env NEW_FORM_ENABLED: "true" do

--- a/spec/models/verification_document_spec.rb
+++ b/spec/models/verification_document_spec.rb
@@ -3,7 +3,23 @@ require "rails_helper"
 describe VerificationDocument do
   include PdfHelper
 
-  describe "#file" do
+  describe "pdf component" do
+    let(:subject) do
+      VerificationDocument.new(url: "nowhere.com", benefit_application: "nothing")
+    end
+
+    it_should_behave_like "pdf component"
+  end
+
+  describe "#fill?" do
+    it "returns false" do
+      document = VerificationDocument.new(url: "nowhere.com", benefit_application: "nothing")
+
+      expect(document.fill?).to be_falsey
+    end
+  end
+
+  describe "#output_file" do
     context "files are png/jpg format" do
       it "returns a pdf tempfile" do
         snap_application = create(:snap_application, :with_member)
@@ -21,8 +37,8 @@ describe VerificationDocument do
           benefit_application: snap_application,
         )
 
-        expect(document.file).to be_a(Tempfile)
-        expect(pdf?(document.file.path)).to eq true
+        expect(document.output_file).to be_a(Tempfile)
+        expect(pdf?(document.output_file.path)).to eq true
       end
     end
 
@@ -41,8 +57,8 @@ describe VerificationDocument do
           benefit_application: snap_application,
         )
 
-        expect(document.file).to be_a(Tempfile)
-        expect(pdf?(document.file.path)).to eq true
+        expect(document.output_file).to be_a(Tempfile)
+        expect(pdf?(document.output_file.path)).to eq true
       end
     end
 
@@ -56,7 +72,7 @@ describe VerificationDocument do
           benefit_application: "snap application",
         )
 
-        expect(document.file).to be_nil
+        expect(document.output_file).to be_nil
       end
     end
 
@@ -80,8 +96,8 @@ describe VerificationDocument do
           benefit_application: medicaid_application,
         )
 
-        expect(document.file).to be_a(Tempfile)
-        expect(pdf?(document.file.path)).to eq true
+        expect(document.output_file).to be_a(Tempfile)
+        expect(pdf?(document.output_file.path)).to eq true
       end
     end
 

--- a/spec/pdf_components/assistance_application_form_spec.rb
+++ b/spec/pdf_components/assistance_application_form_spec.rb
@@ -1,9 +1,25 @@
 require "spec_helper"
 require_relative "../../app/models/concerns/pdf_attributes"
+require_relative "../support/shared_examples/pdf_component"
 require_relative "../../app/models/null_address"
-require_relative "../../app/forms/assistance_application_form"
+require_relative "../../app/pdf_components/assistance_application_form"
 
 RSpec.describe AssistanceApplicationForm do
+  describe "pdf component" do
+    let(:subject) do
+      AssistanceApplicationForm.new(double("fake application"))
+    end
+
+    it_should_behave_like "pdf component"
+  end
+
+  describe "#fill?" do
+    it "responds to fill? and returns true" do
+      form = AssistanceApplicationForm.new(double("fake application"))
+      expect(form.fill?).to be_truthy
+    end
+  end
+
   describe "#attributes" do
     let(:residential_address) { NullAddress.new }
     let(:mailing_address) { NullAddress.new }

--- a/spec/pdf_components/coversheet_spec.rb
+++ b/spec/pdf_components/coversheet_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+require_relative "../../app/pdf_components/coversheet"
+require_relative "../support/shared_examples/pdf_component"
+
+describe Coversheet do
+  let(:subject) do
+    Coversheet.new
+  end
+
+  describe "pdf component" do
+    it_should_behave_like "pdf component"
+  end
+
+  describe "#fill?" do
+    it "returns false" do
+      expect(subject.fill?).to be_falsey
+    end
+  end
+
+  describe "#output_file" do
+    it "returns a pdf file object" do
+      expect(subject.output_file).to be_instance_of(File)
+    end
+  end
+end

--- a/spec/services/application_pdf_assembler_spec.rb
+++ b/spec/services/application_pdf_assembler_spec.rb
@@ -1,15 +1,71 @@
-require "rails_helper"
+require "spec_helper"
+require_relative "../../app/services/application_pdf_assembler"
+require_relative "../../app/services/pdf_concatenator"
+require_relative "../../app/pdf_components/coversheet"
+require_relative "../../app/models/concerns/pdf_attributes"
+require_relative "../../app/pdf_components/assistance_application_form"
+require_relative "../../app/models/verification_document"
 
 RSpec.describe ApplicationPdfAssembler do
-  it "calls PdfBuilder with coversheet and PDF configurations" do
-    fake_application = double("application")
-    fake_application_form = double("application form")
-    fake_concatenator = double("concatenator", run: "concatenator output")
+  context "SNAP application with no verification documents" do
+    it "returns a PDF that includes the assistance application form and verification documents" do
+      fake_application = double("snap application", documents: [])
 
-    allow(AssistanceApplicationForm).to receive(:new).with(fake_application) { fake_application_form }
-    allow(PdfConcatenator).to receive(:new).with([fake_application_form]) { fake_concatenator }
+      fake_coversheet = double("coversheet")
+      expect(Coversheet).to receive(:new).and_return(fake_coversheet)
 
-    pdf_composer = ApplicationPdfAssembler.new(snap_application: fake_application)
-    expect(pdf_composer.run).to eq("concatenator output")
+      fake_application_form = double("application form")
+      expect(AssistanceApplicationForm).to receive(:new).with(fake_application).and_return(fake_application_form)
+
+      fake_complete_pdf = double("complete pdf")
+      fake_pdf_concatenator = double("pdf concatenator")
+
+      expected_components = [fake_coversheet, fake_application_form]
+
+      expect(PdfConcatenator).to receive(:new).with(expected_components).and_return(fake_pdf_concatenator)
+
+      expect(fake_pdf_concatenator).to receive(:run).and_return(fake_complete_pdf)
+      result = ApplicationPdfAssembler.new(benefit_application: fake_application).run
+      expect(result).to be(fake_complete_pdf)
+    end
+  end
+
+  context "SNAP application with verification documents" do
+    it "returns a PDF that includes the assistance application form and verification documents" do
+      fake_application = double("snap application",
+                                documents: ["example.com/images/test1.jpg", "example.com/images/test2.png"])
+
+      fake_coversheet = double("coversheet")
+      expect(Coversheet).to receive(:new).and_return(fake_coversheet)
+
+      fake_application_form = double("application form")
+      expect(AssistanceApplicationForm).to receive(:new).with(fake_application).and_return(fake_application_form)
+
+      fake_verification_doc1 = double("fake doc 1")
+      fake_verification_doc2 = double("fake doc 2")
+
+      expect(VerificationDocument).to receive(:new).
+        with(url: "example.com/images/test1.jpg", benefit_application: fake_application).
+        and_return(fake_verification_doc1)
+      expect(VerificationDocument).to receive(:new).
+        with(url: "example.com/images/test2.png", benefit_application: fake_application).
+        and_return(fake_verification_doc2)
+
+      fake_complete_pdf = double("complete pdf")
+      fake_pdf_concatenator = double("pdf concatenator")
+
+      expected_components = [
+        fake_coversheet,
+        fake_application_form,
+        fake_verification_doc1,
+        fake_verification_doc2,
+      ]
+
+      expect(PdfConcatenator).to receive(:new).with(expected_components).and_return(fake_pdf_concatenator)
+
+      expect(fake_pdf_concatenator).to receive(:run).and_return(fake_complete_pdf)
+      result = ApplicationPdfAssembler.new(benefit_application: fake_application).run
+      expect(result).to be(fake_complete_pdf)
+    end
   end
 end

--- a/spec/services/pdf_concatenator_spec.rb
+++ b/spec/services/pdf_concatenator_spec.rb
@@ -4,20 +4,30 @@ RSpec.describe PdfConcatenator do
   include PdfHelper
 
   describe "#run" do
-    it "generates the form PDFs and concatenates the resulting files" do
+    it "fills PDFs and concatenates the resulting files" do
       form_one = double("form one",
-         source_pdf_path: "spec/fixtures/test_fillable_pdf.pdf",
-         output_file: Tempfile.new,
-         attributes: { anyone_buys_food_separately_names: "Luigi Tester" })
+                        fill?: true,
+                        source_pdf_path: "spec/fixtures/test_fillable_pdf.pdf",
+                        output_file: Tempfile.new,
+                        attributes: { anyone_buys_food_separately_names: "Luigi Tester" })
 
       form_two = double("form two",
-        source_pdf_path: "spec/fixtures/test_fillable_pdf_2.pdf",
-        output_file: Tempfile.new,
-        attributes: { anyone_caretaker_names: "Christa Tester" })
+                        fill?: true,
+                        source_pdf_path: "spec/fixtures/test_fillable_pdf_2.pdf",
+                        output_file: Tempfile.new,
+                        attributes: { anyone_caretaker_names: "Christa Tester" })
 
-      output_file = PdfConcatenator.new([form_one, form_two]).run
+      verification_doc_one = double("verification doc 1",
+                                    fill?: false,
+                                    output_file: open("spec/fixtures/test_remote_pdf.pdf"))
+
+      verification_doc_two = double("verification doc 1",
+                                    fill?: false,
+                                    output_file: open("spec/fixtures/test_remote_pdf.pdf"))
+
+      output_file = PdfConcatenator.new([form_one, form_two, verification_doc_one, verification_doc_two]).run
       expect(output_file).to be_a(Tempfile)
-      expect(PDF::Reader.new(output_file).page_count).to eq 2
+      expect(PDF::Reader.new(output_file).page_count).to eq 4
 
       result = filled_in_values(output_file.path)
       expect(result["anyone_buys_food_separately_names"]).to eq "Luigi Tester"

--- a/spec/support/shared_examples/pdf_component.rb
+++ b/spec/support/shared_examples/pdf_component.rb
@@ -1,0 +1,13 @@
+RSpec.shared_examples "pdf component" do
+  describe "#fill?" do
+    it "should return a Boolean" do
+      expect(subject.fill?).to be(true).or be(false)
+    end
+  end
+
+  describe "#output_file" do
+    it "should respond with no arguments" do
+      expect(subject).to respond_to(:output_file).with(0).arguments
+    end
+  end
+end


### PR DESCRIPTION
For SNAP applications, if `NEW_FORM_ENABLED` is `true`, we build a barely-filled AssistanceApplicationForm with attached coversheet and verification documents. This will be included in office or applicant emails and downloadable in the admin.

Anything being assembled by the `ApplicationPdfAssembler` should implement a "pdf component" interface (described in a `spec/support/shared_examples/pdf_component`). `PdfConcatenator` will call the `.fill?` method to determine if the component needs to be filled, and will call `.output_file` to retrieve the file object associated with the component.

We updated some existing objects to implement the pdf component interface (`.fill?` and `.output_file`)

[Finishes #154566400]

Signed-off-by: Ben Golder <bgolder@codeforamerica.org>