### PR TITLE
Differentiate member name

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,8 +12,8 @@ task :brakeman do
   sh "brakeman"
 end
 
-Rails.application.load_tasks
-
 task default: %w(lint:autocorrect bundler:audit brakeman spec)
+
+Rails.application.load_tasks
 
 task "db:schema:dump": "strong_migrations:alphabetize_columns"

--- a/app/assets/stylesheets/molecules/_form-molecules.scss
+++ b/app/assets/stylesheets/molecules/_form-molecules.scss
@@ -79,10 +79,10 @@
     margin-top: -1em;
     margin-bottom: 1em;
   }
+}
 
-  &:last-of-type {
-    margin-bottom: 0;
-  }
+fieldset.form-group {
+  margin-bottom: 2em;
 }
 
 .form-group--error {
@@ -153,7 +153,7 @@
 }
 
 .question-with-follow-up__question {
-  .form-group {
+  .form-group, fieldset.form-group {
     margin-bottom: 1em;
   }
 }
@@ -176,11 +176,6 @@
     border-right: 2px solid $form-color-border;
     padding-left: $site-margins*2;
   }
-
-  .form-group:last-of-type {
-    margin-bottom: 0;
-  }
-
 
   &:before {
     @include triangle(top, $color: $form-color-border, $size: 12px);
@@ -208,7 +203,7 @@
 }
 
 .feedback-survey__form {
-  .form-group {
+  .form-group, fieldset.form-group {
     margin-bottom: 1em;
   }
 

--- a/app/assets/stylesheets/organisms/_form-card.scss
+++ b/app/assets/stylesheets/organisms/_form-card.scss
@@ -16,9 +16,6 @@
     margin-top: .5em;
     padding-bottom: 2em;
   }
-  .form-group {
-    margin-bottom: 3em;
-  }
 }
 
 .form-card__header {

--- a/app/controllers/medicaid/contact_social_security_controller.rb
+++ b/app/controllers/medicaid/contact_social_security_controller.rb
@@ -11,7 +11,7 @@ module Medicaid
     end
 
     def member_attrs
-      %i[ssn birthday]
+      %i[ssn]
     end
 
     def members

--- a/app/controllers/medicaid/contact_ss_dob_controller.rb
+++ b/app/controllers/medicaid/contact_ss_dob_controller.rb
@@ -1,4 +1,0 @@
-module Medicaid
-  class ContactSsDobController < MedicaidStepsController
-  end
-end

--- a/app/controllers/medicaid/contact_ss_intro_controller.rb
+++ b/app/controllers/medicaid/contact_ss_intro_controller.rb
@@ -1,0 +1,4 @@
+module Medicaid
+  class ContactSsIntroController < MedicaidStepsController
+  end
+end

--- a/app/controllers/medicaid/intro_household_member_controller.rb
+++ b/app/controllers/medicaid/intro_household_member_controller.rb
@@ -1,14 +1,7 @@
 module Medicaid
   class IntroHouseholdMemberController < MedicaidStepsController
-    def update
-      @step = step_class.new(step_params)
-
-      if @step.valid?
-        member.update!(step_params)
-        redirect_to next_path
-      else
-        render :edit
-      end
+    def update_application
+      member.update!(step_params)
     end
 
     private
@@ -22,6 +15,7 @@ module Medicaid
         first_name: member.first_name,
         last_name: member.last_name,
         sex: member.sex,
+        birthday: member.birthday,
       }
     end
 

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -116,7 +116,7 @@ class Member < ApplicationRecord
   end
 
   def display_name
-    "#{first_name.upcase_first} #{last_name.upcase_first}"
+    @_display_name ||= generate_unique_display_name
   end
 
   def self.filing_taxes
@@ -206,6 +206,24 @@ class Member < ApplicationRecord
   end
 
   private
+
+  def generate_unique_display_name
+    other_members = benefit_application.members - [self]
+    other_member_names = other_members.map do |m|
+      formatted_name(m.first_name, m.last_name)
+    end
+    my_name = formatted_name(first_name, last_name)
+
+    if other_member_names.include?(my_name)
+      my_name + " (#{birthday.strftime('%-m/%-d/%Y')})"
+    else
+      my_name
+    end
+  end
+
+  def formatted_name(first_name, last_name)
+    "#{first_name.upcase_first} #{last_name.upcase_first}"
+  end
 
   def receiving_income?
     employed? ||

--- a/app/steps/medicaid/contact_ss_intro.rb
+++ b/app/steps/medicaid/contact_ss_intro.rb
@@ -1,5 +1,5 @@
 module Medicaid
-  class ContactSsDob < Step
+  class ContactSsIntro < Step
     step_attributes(:submit_ssn)
   end
 end

--- a/app/steps/medicaid/intro_household_member.rb
+++ b/app/steps/medicaid/intro_household_member.rb
@@ -1,9 +1,31 @@
 module Medicaid
   class IntroHouseholdMember < Step
+    include MultiparameterAttributeAssignment
+
     step_attributes(
       :first_name,
       :last_name,
       :sex,
+      :birthday,
     )
+
+    validates :first_name,
+      presence: { message: "Make sure to provide a first name" }
+
+    validates :last_name,
+      presence: { message: "Make sure to provide a last name" }
+
+    validates :sex, inclusion: {
+      in: %w(male female),
+      message: "Make sure to answer this question",
+    }
+
+    validates :birthday,
+      presence: { message: "Make sure to provide a birthday" }
+
+    # https://github.com/rails/rails/pull/8189#issuecomment-10329403
+    def class_for_attribute(attr)
+      return Date if attr == "birthday"
+    end
   end
 end

--- a/app/steps/medicaid/intro_name.rb
+++ b/app/steps/medicaid/intro_name.rb
@@ -1,9 +1,12 @@
 module Medicaid
   class IntroName < Step
+    include MultiparameterAttributeAssignment
+
     step_attributes(
       :first_name,
       :last_name,
       :sex,
+      :birthday,
     )
 
     validates :first_name,
@@ -16,5 +19,13 @@ module Medicaid
       in: %w(male female),
       message: "Make sure to answer this question",
     }
+
+    validates :birthday,
+      presence: { message: "Make sure to provide a birthday" }
+
+    # https://github.com/rails/rails/pull/8189#issuecomment-10329403
+    def class_for_attribute(attr)
+      return Date if attr == "birthday"
+    end
   end
 end

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -74,7 +74,7 @@ module Medicaid
         Medicaid::ContactPhoneController,
         Medicaid::ContactTextMessagesController,
         Medicaid::ContactEmailController,
-        Medicaid::ContactSsDobController,
+        Medicaid::ContactSsIntroController,
         Medicaid::ContactSocialSecurityController,
       ],
       "Legal" => [

--- a/app/views/medicaid/contact_social_security/edit.html.erb
+++ b/app/views/medicaid/contact_social_security/edit.html.erb
@@ -2,7 +2,7 @@
 
 <div class="form-card">
   <header class="form-card__header">
-    <div class="form-card__title">Tell us your Social Security Number and Date of Birth</div>
+    <div class="form-card__title">Tell us your Social Security Number</div>
   </header>
 
   <div class="form-card__content">
@@ -29,15 +29,6 @@
                 options: { maxlength: 9 },
                 help_text: "If you don’t know it you can skip this"
               %>
-
-              <%= ff.mb_date_select :birthday,
-                "Date of birth",
-                options: {
-                  start_year: 1900,
-                  end_year: Time.now.year,
-                  default: Date.new(1990,1,15),
-                  order: [:month, :day, :year],
-                } %>
             </div>
           <% end %>
         </div>

--- a/app/views/medicaid/contact_ss_intro/edit.html.erb
+++ b/app/views/medicaid/contact_ss_intro/edit.html.erb
@@ -3,7 +3,7 @@
 <div class="form-card">
   <header class="form-card__header">
     <div class="form-card__title">
-      <%= t("medicaid.contact_ss_dob.edit.title",
+      <%= t("medicaid.contact_ss_intro.edit.title",
             count: current_application.members_count) %>
     </div>
     <p class="text--help text--centered">

--- a/app/views/medicaid/intro_household_member/edit.html.erb
+++ b/app/views/medicaid/intro_household_member/edit.html.erb
@@ -8,14 +8,22 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <%= f.mb_input_field :first_name,
-        "What is their first name?",
-        autofocus: true %>
+      "What is their first name?",
+      autofocus: true %>
       <%= f.mb_input_field :last_name, "What is their last name?" %>
       <%= f.mb_radio_set :sex,
         label_text: "What is their gender?",
         collection: [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
         help_text: "As it appears on official government documents",
         layout: "inline" %>
+      <%= f.mb_date_select :birthday,
+        "Date of birth",
+        options: {
+          start_year: 1900,
+          end_year: Time.now.year,
+          default: Date.new(1990,1,15),
+          order: [:month, :day, :year],
+        } %>
 
       <%= render "medicaid/next_step" %>
     <% end %>

--- a/app/views/medicaid/intro_name/edit.html.erb
+++ b/app/views/medicaid/intro_name/edit.html.erb
@@ -18,7 +18,16 @@
         collection: [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
         help_text: "As it appears on official government documents",
         layout: "inline" %>
-      <%= render "medicaid/next_step" %>
+      <%= f.mb_date_select :birthday,
+        "Date of birth",
+        options: {
+          start_year: 1900,
+          end_year: Time.now.year,
+          default: Date.new(1990,1,15),
+          order: [:month, :day, :year],
+        } %>
+
+        <%= render "medicaid/next_step" %>
     <% end %>
   </div>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,18 +147,16 @@ en:
         title:
           one: Do you pay student loan interest?
           other: Does anyone in your household pay student loan interest?
-    contact_ss_dob:
+    contact_ss_intro:
       edit:
         title:
           one:
-            Provide your Social Security Number and Date of Birth if
-            you’re ready
+            Provide your Social Security Number if you’re ready
           other:
-            Provide the Social Security Numbers and Dates of Birth for your
-            household members if you’re ready
+            Provide the Social Security Numbers for your household members if you’re ready
     contact_social_security:
       edit:
-        title: Tell us your Social Security Number and Date of Birth
+        title: Tell us your Social Security Number
     amounts_income:
       edit:
         title:

--- a/spec/controllers/medicaid/contact_social_security_controller_spec.rb
+++ b/spec/controllers/medicaid/contact_social_security_controller_spec.rb
@@ -49,4 +49,40 @@ RSpec.describe Medicaid::ContactSocialSecurityController do
       end
     end
   end
+
+  describe "#update" do
+    it "updates each member's SSN" do
+      member_one = build(:member, requesting_health_insurance: true)
+      member_two = build(:member, requesting_health_insurance: true)
+      medicaid_application = create(
+        :medicaid_application,
+        members: [
+          member_one,
+          member_two,
+        ],
+      )
+      session[:medicaid_application_id] = medicaid_application.id
+
+      put(
+        :update,
+        params: {
+          step: {
+            members: {
+              member_one.id => {
+                ssn: "123456789",
+              },
+              member_two.id => {
+                ssn: "111222333",
+              },
+            },
+          },
+        },
+      )
+      member_one.reload
+      member_two.reload
+
+      expect(member_one.ssn).to eq("123456789")
+      expect(member_two.ssn).to eq("111222333")
+    end
+  end
 end

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -199,14 +199,12 @@ RSpec.feature "Medicaid app" do
       proceed_with "Next"
 
       expect(page).to have_content(
-        "Provide your Social Security Number and Date of Birth if you’re ready",
+        "Provide your Social Security Number if you’re ready",
       )
       proceed_with "Yes"
 
       fill_in "Social Security Number", with: "999900000"
-      select "September"
-      select "17"
-      select "1980"
+
       proceed_with "Next"
     end
 

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -142,7 +142,7 @@ RSpec.feature "Medicaid app" do
       proceed_with "Next"
 
       expect(page).to have_content(
-        "Provide your Social Security Number and Date of Birth if you’re ready",
+        "Provide your Social Security Number if you’re ready",
       )
       proceed_with "No"
     end

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -24,6 +24,9 @@ RSpec.feature "Medicaid app" do
       fill_in "What is their first name?", with: "Christa"
       fill_in "What is their last name?", with: "Tester"
       select_radio(question: "What is their gender?", answer: "Female")
+      select "December"
+      select "25"
+      select "1987"
       proceed_with "Next"
 
       click_on "Add a member"
@@ -31,6 +34,9 @@ RSpec.feature "Medicaid app" do
       fill_in "What is their first name?", with: "Joel"
       fill_in "What is their last name?", with: "Tester"
       select_radio(question: "What is their gender?", answer: "Male")
+      select "September"
+      select "17"
+      select "1980"
       proceed_with "Next"
     end
 
@@ -430,7 +436,7 @@ RSpec.feature "Medicaid app" do
 
     on_page "Contact Information & Followup" do
       expect(page).to have_content(
-        "Provide the Social Security Numbers and Dates of Birth "\
+        "Provide the Social Security Numbers "\
         "for your household members if you’re ready",
       )
       proceed_with "Yes"
@@ -438,10 +444,10 @@ RSpec.feature "Medicaid app" do
 
     on_page "Contact Information & Followup" do
       expect(page).to have_content(
-        "Tell us your Social Security Number and Date of Birth",
+        "Tell us your Social Security Number",
       )
-      enter_dob_and_ssn(display_name: "Jessie Tester", ssn: "123456789")
-      enter_dob_and_ssn(display_name: "Christa Tester", ssn: "011100000")
+      enter_ssn(display_name: "Jessie Tester", ssn: "123456789")
+      enter_ssn(display_name: "Christa Tester", ssn: "011100000")
 
       proceed_with "Next"
     end

--- a/spec/models/employed_member_attributes_spec.rb
+++ b/spec/models/employed_member_attributes_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe EmployedMemberAttributes do
         employed_hours_per_week: 20,
         employed_pay_quantity: 100,
         employed_pay_interval: "Weekly",
+        benefit_application: build(:snap_application),
       )
 
       position = "second"

--- a/spec/models/extra_member_attributes_spec.rb
+++ b/spec/models/extra_member_attributes_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ExtraMemberAttributes do
         birthday: DateTime.parse("June 20, 1900"),
         relationship: nil,
         requesting_food_assistance: true,
+        benefit_application: build(:snap_application),
       )
 
       array = ExtraMemberAttributes.new(member: member).to_a

--- a/spec/models/medicaid_application_member_attributes_spec.rb
+++ b/spec/models/medicaid_application_member_attributes_spec.rb
@@ -3,9 +3,8 @@ require "rails_helper"
 RSpec.describe MedicaidApplicationMemberAttributes do
   describe "#to_h" do
     it "returns the member attributes as a hash" do
-      medicaid_application = create(:medicaid_application)
-      member = build(
-        :member,
+      medicaid_application = build(:medicaid_application)
+      member = create(:member,
         first_name: "First",
         last_name: "Last",
         birthday: Date.new(1991, 10, 18),
@@ -13,7 +12,6 @@ RSpec.describe MedicaidApplicationMemberAttributes do
         married: true,
         caretaker_or_parent: true,
         in_college: true,
-        spouse: build(:member, first_name: "Candy", last_name: "Crush"),
         ssn: "111223333",
         new_mom: true,
         requesting_health_insurance: true,
@@ -48,8 +46,14 @@ RSpec.describe MedicaidApplicationMemberAttributes do
         child_support_alimony_arrears_expenses: 100,
         pay_student_loan_interest: true,
         student_loan_interest_expenses: 70,
-        benefit_application: medicaid_application,
-      )
+        benefit_application: medicaid_application)
+
+      spouse = build(:member,
+                     first_name: "Candy",
+                     last_name: "Crush",
+                     benefit_application: medicaid_application)
+
+      member.update(spouse: spouse)
 
       result = MedicaidApplicationMemberAttributes.new(
         member: member,

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -248,9 +248,62 @@ RSpec.describe Member do
   end
 
   describe "#display_name" do
-    it "combines first name and last name" do
-      member = Member.new(first_name: "anneFace", last_name: "mcDog")
-      expect(member.display_name).to eq("AnneFace McDog")
+    it "only generates the display name once" do
+      member = build(:member)
+      create(
+        :medicaid_application,
+        members: [member],
+      )
+
+      expect(member.display_name).to be(member.display_name)
+    end
+
+    context "I have a unique first and last name for my household" do
+      it "combines first name and last name" do
+        member_one = build(:member, first_name: "anne", last_name: "mcDog")
+        member_two = build(:member, first_name: "sophie", last_name: "grey")
+        create(
+          :medicaid_application,
+          members: [member_one, member_two],
+        )
+
+        expect(member_one.display_name).to eq("Anne McDog")
+        expect(member_two.display_name).to eq("Sophie Grey")
+      end
+    end
+
+    context "I have same first name but different last name than someone my household" do
+      it "combines first name and last name" do
+        member_one = build(:member, first_name: "anne", last_name: "mcDog")
+        member_two = build(:member, first_name: "anne", last_name: "grey")
+        create(
+          :medicaid_application,
+          members: [member_one, member_two],
+        )
+
+        expect(member_one.display_name).to eq("Anne McDog")
+        expect(member_two.display_name).to eq("Anne Grey")
+      end
+    end
+
+    context "I have same first and last name as someone in my household" do
+      it "combines first name and last name, plus date of birth" do
+        member_one = build(:member,
+                           first_name: "anne",
+                           last_name: "mcDog",
+                           birthday: Date.new(1980, 1, 2))
+        member_two = build(:member,
+                           first_name: "Anne",
+                           last_name: "McDog",
+                           birthday: Date.new(1990, 3, 14))
+        create(
+          :medicaid_application,
+          members: [member_one, member_two],
+        )
+
+        expect(member_one.display_name).to eq("Anne McDog (1/2/1980)")
+        expect(member_two.display_name).to eq("Anne McDog (3/14/1990)")
+      end
     end
   end
 

--- a/spec/models/self_employed_member_attributes_spec.rb
+++ b/spec/models/self_employed_member_attributes_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe SelfEmployedMemberAttributes do
         self_employed_profession: "Lampshade shaper",
         self_employed_monthly_income: 100,
         self_employed_monthly_expenses: 50,
+        benefit_application: build(:snap_application),
       )
 
       position = "first"

--- a/spec/models/snap_application_member_attributes_spec.rb
+++ b/spec/models/snap_application_member_attributes_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe SnapApplicationMemberAttributes do
         new_mom: true,
         in_college: true,
         requesting_food_assistance: true,
+        benefit_application: build(:snap_application),
       )
       position = "primary"
 
@@ -55,6 +56,7 @@ RSpec.describe SnapApplicationMemberAttributes do
       it "does not error" do
         member = build(
           :member,
+          benefit_application: build(:snap_application),
           ssn: nil,
         )
         position = "anything"

--- a/spec/support/medicaid_application_form_helper.rb
+++ b/spec/support/medicaid_application_form_helper.rb
@@ -1,9 +1,6 @@
 module MedicaidApplicationFormHelper
-  def enter_dob_and_ssn(display_name:, ssn:)
+  def enter_ssn(display_name:, ssn:)
     within(".household-member-group[data-member-name='#{display_name}']") do
-      select("January")
-      select("1")
-      select("1969")
       fill_in "Social Security Number", with: ssn
     end
   end


### PR DESCRIPTION
When household has members with same name, use DOB to differentiate  …
* Moves birthday collection to when we register each member (rather than with SSN in Medicaid flow)
* Memoize display name generation on member to reduce database calls
* Fixes styling small styling bug releated to fieldset vs div and pseudoselectors

[#153798110]