### PR TITLE
 Add `/numbers` dashboard with MichiganBenefits stats

### DIFF
--- a/app/controllers/stats/numbers_controller.rb
+++ b/app/controllers/stats/numbers_controller.rb
@@ -1,5 +1,10 @@
 module Stats
   class NumbersController < ApplicationController
+    http_basic_authenticate_with(
+      name: Rails.application.secrets.basic_auth_user,
+      password: Rails.application.secrets.basic_auth_password
+    )
+
     def index
       @snap_count = SnapApplication.count
       @medicaid_count = MedicaidApplication.count

--- a/app/controllers/stats/numbers_controller.rb
+++ b/app/controllers/stats/numbers_controller.rb
@@ -1,0 +1,10 @@
+module Stats
+  class NumbersController < ApplicationController
+    def index
+      @snap_count = SnapApplication.count
+      @medicaid_count = MedicaidApplication.count
+
+      render :index
+    end
+  end
+end

--- a/app/views/stats/numbers/index.html.erb
+++ b/app/views/stats/numbers/index.html.erb
@@ -1,0 +1,21 @@
+<% content_for :template_name, "Numbers"  %>
+
+<section class="slab">
+  <div class="grid grid-padded">
+    <h1>MichiganBenefits Numbers</h1>
+
+    <div id="total-snap-applications" class="grid__item width-one-half">
+      <div class="card">
+        <h4>Total Completed SNAP Applications</h4>
+        <p class="big-number"><%= @snap_count %></p>
+      </div>
+    </div>
+
+    <div id="total-medicaid-applications" class="grid__item width-one-half">
+      <div class="card">
+        <h4>Total Completed Medicaid Applications</h4>
+        <p class="big-number"><%= @medicaid_count %></p>
+      </div>
+    </div>
+  </div>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,8 @@ Rails.application.routes.draw do
     resource :file_preview, only: %i[show]
   end
 
+  resources :numbers, module: :stats, only: %i[index]
+
   resource :resource, only: %i[show]
   resource :sessions, only: %i[new destroy] do
     collection do

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -23,6 +23,8 @@ from_environment: &deployable_settings
   aws_region: <%= ENV.fetch("AWS_REGION", ENV["BUCKETEER_REGION"]) %>
   opencagedata_api_key: <%= ENV.fetch("OPEN_CAGE_DATA_API_KEY", ENV["OPEN_CAGE_DATA_API_KEY"]) %>
   slack_api_token: <%= ENV.fetch("SLACK_API_TOKEN", ENV["SLACK_API_TOKEN"]) %>
+  basic_auth_user: <%= ENV.fetch("BASIC_AUTH_USER", ENV["BASIC_AUTH_USER"]) %>
+  basic_auth_password: <%= ENV.fetch("BASIC_AUTH_PASSWORD", ENV["BASIC_AUTH_PASSWORD"]) %>
 
 development:
   <<: *deployable_settings
@@ -30,6 +32,8 @@ development:
   secret_key_for_driver_application: 'This is a key that is 256 bits!!'
   secret_key_for_ssn_encryption: 'This is a key that is 256 bits!!'
   shubox_js_id: '4711fd96-9be2-46d5-8fb9-6eef6fd24a4b'
+  basic_auth_user: 'user'
+  basic_auth_password: 'password'
 
 test:
   secret_key_base: a4601e0fb037b7d1ed534a5d5dd114f47b753c9945757ebe0f9fedff98d41b12741f7dd631e0d9a69cd518623384d871b0387ec5645ccccbbb5d9336ff1cf800
@@ -40,6 +44,8 @@ test:
   twilio_account_sid: 'bbbb1111'
   twilio_auth_token: 'aaaa0000'
   opencagedata_api_key: 'aaaaaaaaaabbbbbbbbbbbbbb'
+  basic_auth_user: 'user'
+  basic_auth_password: 'password'
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/spec/features/numbers_dashboard_spec.rb
+++ b/spec/features/numbers_dashboard_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.feature "viewing Numbers dashboard" do
+  before do
+    create_list(:snap_application, 3, :signed)
+    create_list(:medicaid_application, 2, :signed)
+  end
+
+  scenario "viewing total SNAP and Medicaid apps submitted" do
+    visit numbers_path
+
+    within "#total-snap-applications" do
+      expect(page).to have_content("Total Completed SNAP Applications")
+      expect(page).to have_content("3")
+    end
+
+    within "#total-medicaid-applications" do
+      expect(page).to have_content("Total Completed Medicaid Applications")
+      expect(page).to have_content("2")
+    end
+  end
+end

--- a/spec/features/numbers_dashboard_spec.rb
+++ b/spec/features/numbers_dashboard_spec.rb
@@ -4,6 +4,8 @@ RSpec.feature "viewing Numbers dashboard" do
   before do
     create_list(:snap_application, 3, :signed)
     create_list(:medicaid_application, 2, :signed)
+
+    login_with_basic_auth
   end
 
   scenario "viewing total SNAP and Medicaid apps submitted" do

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -53,5 +53,12 @@ module FeatureHelper
     end
   end
 
+  def login_with_basic_auth
+    page.driver.browser.basic_authorize(
+      Rails.application.secrets.basic_auth_user,
+      Rails.application.secrets.basic_auth_password
+    )
+  end
+
   alias on_pages on_page
 end


### PR DESCRIPTION
We built our own dashboard (older GCF-style) after talking a bit with Lou. This solution was quicker and easier (and cheaper!) than Geckoboard since currently all of our data is located inside our application.

User + password info in LastPass. Used same info for staging + production since it's non-sensitive data.