### PR TITLE
Correct incorrect citizen reporting

### DIFF
--- a/app/controllers/household_more_info_controller.rb
+++ b/app/controllers/household_more_info_controller.rb
@@ -4,12 +4,26 @@ class HouseholdMoreInfoController < SnapStepsController
   def update_application
     super
 
-    current_application.members.each do |member|
-      member.update!(member_attrs)
+    if single_member_household?
+      current_application.primary_member.update!(member_attrs)
+    else
+      current_application.members.each do |member|
+        member.update!(multi_member_attrs)
+      end
     end
   end
 
   def member_attrs
+    {
+      citizen: step_params[:everyone_a_citizen],
+      disabled: step_params[:anyone_disabled],
+      new_mom: step_params[:anyone_new_mom],
+      in_college: step_params[:anyone_in_college],
+      living_elsewhere: step_params[:anyone_living_elsewhere],
+    }
+  end
+
+  def multi_member_attrs
     construct_positive_attributes("citizen").
       merge(construct_negative_attributes("disabled")).
       merge(construct_negative_attributes("new_mom")).

--- a/app/controllers/household_more_info_controller.rb
+++ b/app/controllers/household_more_info_controller.rb
@@ -1,2 +1,35 @@
 class HouseholdMoreInfoController < SnapStepsController
+  private
+
+  def update_application
+    super
+
+    current_application.members.each do |member|
+      member.update!(member_attrs)
+    end
+  end
+
+  def member_attrs
+    construct_positive_attributes("citizen").
+      merge(construct_negative_attributes("disabled")).
+      merge(construct_negative_attributes("new_mom")).
+      merge(construct_negative_attributes("in_college")).
+      merge(construct_negative_attributes("living_elsewhere"))
+  end
+
+  def construct_positive_attributes(key)
+    construct_attributes("everyone_a_#{key}", key, "true")
+  end
+
+  def construct_negative_attributes(key)
+    construct_attributes("anyone_#{key}", key, "false")
+  end
+
+  def construct_attributes(application_attr, member_attr, value)
+    if step_params[application_attr.to_sym] == value
+      { member_attr.to_sym => step_params[application_attr.to_sym] }
+    else
+      {}
+    end
+  end
 end

--- a/app/controllers/household_more_info_per_member_controller.rb
+++ b/app/controllers/household_more_info_per_member_controller.rb
@@ -1,5 +1,39 @@
 class HouseholdMoreInfoPerMemberController < ManyMemberStepsController
+  def update
+    assign_household_member_attributes
+
+    if step.valid?
+      ActiveRecord::Base.transaction { step.members.each(&:save!) }
+      update_application
+      redirect_to next_path
+    else
+      render :edit
+    end
+  end
+
   private
+
+  def update_application
+    current_application.update!(application_attrs)
+  end
+
+  def application_attrs
+    {}.tap do |attributes|
+      attributes[:everyone_a_citizen] = true if all_members(:citizen?)
+      attributes[:anyone_disabled] = false if no_members(:disabled?)
+      attributes[:anyone_new_mom] = false if no_members(:new_mom?)
+      attributes[:anyone_in_college] = false if no_members(:in_college?)
+      attributes[:anyone_living_elsewhere] = false if no_members(:living_elsewhere?)
+    end
+  end
+
+  def all_members(attribute)
+    current_application.members.all? { |m| m.public_send(attribute) }
+  end
+
+  def no_members(attribute)
+    current_application.members.all? { |m| !m.public_send(attribute) }
+  end
 
   def member_attrs
     %i[citizen disabled new_mom in_college living_elsewhere]

--- a/app/controllers/medicaid_steps_controller.rb
+++ b/app/controllers/medicaid_steps_controller.rb
@@ -13,14 +13,6 @@ class MedicaidStepsController < StepsController
     session[:medicaid_application_id]
   end
 
-  def single_member_household?
-    current_application.members_count == 1
-  end
-
-  def multi_member_household?
-    current_application.members_count > 1
-  end
-
   def step_navigation
     @step_navigation ||= Medicaid::StepNavigation.new(self)
   end

--- a/app/controllers/stats/numbers_controller.rb
+++ b/app/controllers/stats/numbers_controller.rb
@@ -2,7 +2,7 @@ module Stats
   class NumbersController < ApplicationController
     http_basic_authenticate_with(
       name: Rails.application.secrets.basic_auth_user,
-      password: Rails.application.secrets.basic_auth_password
+      password: Rails.application.secrets.basic_auth_password,
     )
 
     def index

--- a/app/controllers/steps_controller.rb
+++ b/app/controllers/steps_controller.rb
@@ -85,6 +85,14 @@ class StepsController < ApplicationController
 
   # Probably don't redefine me
 
+  def single_member_household?
+    current_application.members_count == 1
+  end
+
+  def multi_member_household?
+    current_application.members_count > 1
+  end
+
   def step_params
     params.fetch(:step, {}).permit(*step_attrs)
   end

--- a/app/views/household_more_info_per_member/edit.html.erb
+++ b/app/views/household_more_info_per_member/edit.html.erb
@@ -13,7 +13,6 @@
         <fieldset class="form-group">
           <legend class="form-question" id="citizen__legend">
             <%= t("snap.household_more_info_per_member.edit.prompt") %>
-            <span class="form-card__optional">(optional)</span>
           </legend>
           <% @step.members.each do |member| %>
             <%= f.fields_for('members[]', member) do |ff| %>
@@ -30,28 +29,28 @@
 
       <% if current_application.anyone_disabled? %>
         <fieldset class="form-group">
-          <legend class="form-question" id="disabled__legend">Who has a disability?<span class="form-card__optional">(optional)</span></legend>
+          <legend class="form-question" id="disabled__legend">Who has a disability?</legend>
           <%= render 'member_checkboxes', f: f, step: @step, method: :disabled, legend_id: "disabled__legend" %>
         </fieldset>
       <% end %>
 
       <% if current_application.anyone_new_mom? %>
         <fieldset class="form-group">
-          <legend class="form-question" id="pregnant__legend">Who is pregnant or has been pregnant recently?<span class="form-card__optional">(optional)</span></legend>
+          <legend class="form-question" id="pregnant__legend">Who is pregnant or has been pregnant recently?</legend>
           <%= render 'member_checkboxes', f: f, step: @step, method: :new_mom, legend_id: "pregnant__legend"  %>
         </fieldset>
       <% end %>
 
       <% if current_application.anyone_in_college? %>
         <fieldset class="form-group">
-          <legend class="form-question" id="college__legend">Who is enrolled in college?<span class="form-card__optional">(optional)</span></legend>
+          <legend class="form-question" id="college__legend">Who is enrolled in college?</legend>
           <%= render 'member_checkboxes', f: f, step: @step, method: :in_college, legend_id: "college__legend"  %>
         </fieldset>
       <% end %>
 
       <% if current_application.anyone_living_elsewhere? %>
         <fieldset class="form-group">
-          <legend class="form-question" id="elsewhere__legend">Who is temporarily living outside the home?<span class="form-card__optional">(optional)</span></legend>
+          <legend class="form-question" id="elsewhere__legend">Who is temporarily living outside the home?</legend>
           <%= render 'member_checkboxes', f: f, step: @step, method: :living_elsewhere, legend_id: "elsewhere__legend"  %>
         </fieldset>
       <% end %>

--- a/spec/controllers/household_more_info_controller_spec.rb
+++ b/spec/controllers/household_more_info_controller_spec.rb
@@ -49,242 +49,201 @@ RSpec.describe HouseholdMoreInfoController do
         expect(snap_application.anyone_living_elsewhere).to eq(false)
       end
 
-      context "everyone is a citizen" do
-        let(:params) do
-          valid_params.deep_merge(step: { everyone_a_citizen: "true" })
+      context "multi-member household" do
+        let(:members) { build_list(:member, 2) }
+        let(:snap_application) do
+          create(:snap_application, members: members)
         end
 
-        it "updates each member to reflect citizenship" do
-          members = build_list(:member, 2)
-
-          snap_application = create(
-            :snap_application,
-            members: members,
-          )
+        before do
           session[:snap_application_id] = snap_application.id
 
           put :update, params: params
 
           members.each(&:reload)
+        end
 
-          members.each do |member|
-            expect(member.citizen).to eq(true)
+        context "everyone is a citizen" do
+          let(:params) do
+            valid_params.deep_merge(step: { everyone_a_citizen: "true" })
+          end
+
+          it "updates each member to reflect citizenship" do
+            members.each do |member|
+              expect(member.citizen).to eq(true)
+            end
+          end
+        end
+
+        context "not everyone is a citizen" do
+          let(:params) do
+            valid_params.deep_merge(step: { everyone_a_citizen: "false" })
+          end
+
+          it "does not update the members" do
+            members.each do |member|
+              expect(member.citizen).to be_nil
+            end
+          end
+        end
+
+        context "no one is disabled" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_disabled: "false" })
+          end
+
+          it "updates each member to reflect no disability" do
+            members.each do |member|
+              expect(member.disabled).to eq(false)
+            end
+          end
+        end
+
+        context "someone is disabled" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_disabled: "true" })
+          end
+
+          it "does not update the members" do
+            members.each do |member|
+              expect(member.disabled).to be_nil
+            end
+          end
+        end
+
+        context "no one is new mother" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_new_mom: "false" })
+          end
+
+          it "updates each member to reflect that no one is a new mother" do
+            members.each do |member|
+              expect(member.new_mom).to eq(false)
+            end
+          end
+        end
+
+        context "someone is new mother" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_new_mom: "true" })
+          end
+
+          it "does not update the members" do
+            members.each do |member|
+              expect(member.new_mom).to be_nil
+            end
+          end
+        end
+
+        context "no one is in_college" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_in_college: "false" })
+          end
+
+          it "updates each member to reflect not in college" do
+            members.each do |member|
+              expect(member.in_college).to eq(false)
+            end
+          end
+        end
+
+        context "someone is in_college" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_in_college: "true" })
+          end
+
+          it "does not update the members" do
+            members.each do |member|
+              expect(member.in_college).to be_nil
+            end
+          end
+        end
+
+        context "no one is living_elsewhere" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_living_elsewhere: "false" })
+          end
+
+          it "updates each member to reflect not living elsewhere" do
+            members.each do |member|
+              expect(member.living_elsewhere).to eq(false)
+            end
+          end
+        end
+
+        context "someone is living_elsewhere" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_living_elsewhere: "true" })
+          end
+
+          it "does not update the members" do
+            members.each do |member|
+              expect(member.living_elsewhere).to be_nil
+            end
           end
         end
       end
 
-      context "not everyone is a citizen" do
-        let(:params) do
-          valid_params.deep_merge(step: { everyone_a_citizen: "false" })
+      context "single member household" do
+        let(:member) { build(:member) }
+        let(:snap_application) do
+          create(:snap_application, members: [member])
         end
 
-        it "does not update the members" do
-          members = build_list(:member, 2)
-
-          snap_application = create(
-            :snap_application,
-            members: members,
-          )
+        before do
           session[:snap_application_id] = snap_application.id
-
           put :update, params: params
 
-          members.each(&:reload)
+          member.reload
+        end
 
-          members.each do |member|
-            expect(member.citizen).to be_nil
+        context "not everyone is a citizen" do
+          let(:params) do
+            valid_params.deep_merge(step: { everyone_a_citizen: "false" })
+          end
+
+          it "updates the member as not a citizen" do
+            expect(member.citizen).to eq(false)
           end
         end
-      end
 
-      context "no one is disabled" do
-        let(:params) do
-          valid_params.deep_merge(step: { anyone_disabled: "false" })
-        end
+        context "someone is disabled" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_disabled: "true" })
+          end
 
-        it "updates each member to reflect no disability" do
-          members = build_list(:member, 2)
-
-          snap_application = create(
-            :snap_application,
-            members: members,
-          )
-          session[:snap_application_id] = snap_application.id
-
-          put :update, params: params
-
-          members.each(&:reload)
-
-          members.each do |member|
-            expect(member.disabled).to eq(false)
+          it "updates the member as disabled" do
+            expect(member.disabled).to eq(true)
           end
         end
-      end
 
-      context "someone is disabled" do
-        let(:params) do
-          valid_params.deep_merge(step: { anyone_disabled: "true" })
-        end
+        context "someone is new mother" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_new_mom: "true" })
+          end
 
-        it "does not update the members" do
-          members = build_list(:member, 2)
-
-          snap_application = create(
-            :snap_application,
-            members: members,
-          )
-          session[:snap_application_id] = snap_application.id
-
-          put :update, params: params
-
-          members.each(&:reload)
-
-          members.each do |member|
-            expect(member.disabled).to be_nil
+          it "updates the member as a new mom" do
+            expect(member.new_mom).to eq(true)
           end
         end
-      end
 
-      context "no one is new mother" do
-        let(:params) do
-          valid_params.deep_merge(step: { anyone_new_mom: "false" })
-        end
+        context "someone is in_college" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_in_college: "true" })
+          end
 
-        it "updates each member to reflect that no one is a new mother" do
-          members = build_list(:member, 2)
-
-          snap_application = create(
-            :snap_application,
-            members: members,
-          )
-          session[:snap_application_id] = snap_application.id
-
-          put :update, params: params
-
-          members.each(&:reload)
-
-          members.each do |member|
-            expect(member.new_mom).to eq(false)
+          it "updates the member as in college" do
+            expect(member.in_college).to eq(true)
           end
         end
-      end
 
-      context "someone is new mother" do
-        let(:params) do
-          valid_params.deep_merge(step: { anyone_new_mom: "true" })
-        end
-
-        it "does not update the members" do
-          members = build_list(:member, 2)
-
-          snap_application = create(
-            :snap_application,
-            members: members,
-          )
-          session[:snap_application_id] = snap_application.id
-
-          put :update, params: params
-
-          members.each(&:reload)
-
-          members.each do |member|
-            expect(member.new_mom).to be_nil
+        context "someone is living_elsewhere" do
+          let(:params) do
+            valid_params.deep_merge(step: { anyone_living_elsewhere: "true" })
           end
-        end
-      end
 
-      context "no one is in_college" do
-        let(:params) do
-          valid_params.deep_merge(step: { anyone_in_college: "false" })
-        end
-
-        it "updates each member to reflect not in college" do
-          members = build_list(:member, 2)
-
-          snap_application = create(
-            :snap_application,
-            members: members,
-          )
-          session[:snap_application_id] = snap_application.id
-
-          put :update, params: params
-
-          members.each(&:reload)
-
-          members.each do |member|
-            expect(member.in_college).to eq(false)
-          end
-        end
-      end
-
-      context "someone is in_college" do
-        let(:params) do
-          valid_params.deep_merge(step: { anyone_in_college: "true" })
-        end
-
-        it "does not update the members" do
-          members = build_list(:member, 2)
-
-          snap_application = create(
-            :snap_application,
-            members: members,
-          )
-          session[:snap_application_id] = snap_application.id
-
-          put :update, params: params
-
-          members.each(&:reload)
-
-          members.each do |member|
-            expect(member.in_college).to be_nil
-          end
-        end
-      end
-
-      context "no one is living_elsewhere" do
-        let(:params) do
-          valid_params.deep_merge(step: { anyone_living_elsewhere: "false" })
-        end
-
-        it "updates each member to reflect not living elsewhere" do
-          members = build_list(:member, 2)
-
-          snap_application = create(
-            :snap_application,
-            members: members,
-          )
-          session[:snap_application_id] = snap_application.id
-
-          put :update, params: params
-
-          members.each(&:reload)
-
-          members.each do |member|
-            expect(member.living_elsewhere).to eq(false)
-          end
-        end
-      end
-
-      context "someone is living_elsewhere" do
-        let(:params) do
-          valid_params.deep_merge(step: { anyone_living_elsewhere: "true" })
-        end
-
-        it "does not update the members" do
-          members = build_list(:member, 2)
-
-          snap_application = create(
-            :snap_application,
-            members: members,
-          )
-          session[:snap_application_id] = snap_application.id
-
-          put :update, params: params
-
-          members.each(&:reload)
-
-          members.each do |member|
-            expect(member.living_elsewhere).to be_nil
+          it "updates the member as living elsewhere" do
+            expect(member.living_elsewhere).to eq(true)
           end
         end
       end

--- a/spec/controllers/household_more_info_controller_spec.rb
+++ b/spec/controllers/household_more_info_controller_spec.rb
@@ -1,15 +1,293 @@
 require "rails_helper"
 
 RSpec.describe HouseholdMoreInfoController do
-  let(:step) { assigns(:step) }
-  let(:invalid_params) { { step: { everyone_a_citizen: "" } } }
-  let(:step_class) { HouseholdMoreInfo }
+  describe "#update" do
+    context "invalid params" do
+      it "renders edit" do
+        snap_application = create(:snap_application)
+        session[:snap_application_id] = snap_application.id
 
-  before { session[:snap_application_id] = current_app.id }
+        put :update, params: {
+          step: {
+            everyone_a_citizen: nil,
+            anyone_disabled: nil,
+            anyone_new_mom: nil,
+            anyone_in_college: nil,
+            anyone_living_elsewhere: nil,
+          },
+        }
 
-  include_examples "step controller", "param validation"
+        expect(response).to render_template(:edit)
+      end
+    end
 
-  def current_app
-    @_current_app ||= create(:snap_application)
+    context "valid params" do
+      let(:valid_params) do
+        {
+          step: {
+            everyone_a_citizen: "false",
+            anyone_disabled: "false",
+            anyone_new_mom: "false",
+            anyone_in_college: "false",
+            anyone_living_elsewhere: "false",
+          },
+        }
+      end
+
+      it "updates the snap application" do
+        snap_application = create(:snap_application)
+        session[:snap_application_id] = snap_application.id
+
+        put :update, params: valid_params
+
+        snap_application.reload
+
+        expect(snap_application.everyone_a_citizen).to eq(false)
+        expect(snap_application.anyone_disabled).to eq(false)
+        expect(snap_application.anyone_new_mom).to eq(false)
+        expect(snap_application.anyone_in_college).to eq(false)
+        expect(snap_application.anyone_living_elsewhere).to eq(false)
+      end
+
+      context "everyone is a citizen" do
+        let(:params) do
+          valid_params.deep_merge(step: { everyone_a_citizen: "true" })
+        end
+
+        it "updates each member to reflect citizenship" do
+          members = build_list(:member, 2)
+
+          snap_application = create(
+            :snap_application,
+            members: members,
+          )
+          session[:snap_application_id] = snap_application.id
+
+          put :update, params: params
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.citizen).to eq(true)
+          end
+        end
+      end
+
+      context "not everyone is a citizen" do
+        let(:params) do
+          valid_params.deep_merge(step: { everyone_a_citizen: "false" })
+        end
+
+        it "does not update the members" do
+          members = build_list(:member, 2)
+
+          snap_application = create(
+            :snap_application,
+            members: members,
+          )
+          session[:snap_application_id] = snap_application.id
+
+          put :update, params: params
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.citizen).to be_nil
+          end
+        end
+      end
+
+      context "no one is disabled" do
+        let(:params) do
+          valid_params.deep_merge(step: { anyone_disabled: "false" })
+        end
+
+        it "updates each member to reflect no disability" do
+          members = build_list(:member, 2)
+
+          snap_application = create(
+            :snap_application,
+            members: members,
+          )
+          session[:snap_application_id] = snap_application.id
+
+          put :update, params: params
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.disabled).to eq(false)
+          end
+        end
+      end
+
+      context "someone is disabled" do
+        let(:params) do
+          valid_params.deep_merge(step: { anyone_disabled: "true" })
+        end
+
+        it "does not update the members" do
+          members = build_list(:member, 2)
+
+          snap_application = create(
+            :snap_application,
+            members: members,
+          )
+          session[:snap_application_id] = snap_application.id
+
+          put :update, params: params
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.disabled).to be_nil
+          end
+        end
+      end
+
+      context "no one is new mother" do
+        let(:params) do
+          valid_params.deep_merge(step: { anyone_new_mom: "false" })
+        end
+
+        it "updates each member to reflect that no one is a new mother" do
+          members = build_list(:member, 2)
+
+          snap_application = create(
+            :snap_application,
+            members: members,
+          )
+          session[:snap_application_id] = snap_application.id
+
+          put :update, params: params
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.new_mom).to eq(false)
+          end
+        end
+      end
+
+      context "someone is new mother" do
+        let(:params) do
+          valid_params.deep_merge(step: { anyone_new_mom: "true" })
+        end
+
+        it "does not update the members" do
+          members = build_list(:member, 2)
+
+          snap_application = create(
+            :snap_application,
+            members: members,
+          )
+          session[:snap_application_id] = snap_application.id
+
+          put :update, params: params
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.new_mom).to be_nil
+          end
+        end
+      end
+
+      context "no one is in_college" do
+        let(:params) do
+          valid_params.deep_merge(step: { anyone_in_college: "false" })
+        end
+
+        it "updates each member to reflect not in college" do
+          members = build_list(:member, 2)
+
+          snap_application = create(
+            :snap_application,
+            members: members,
+          )
+          session[:snap_application_id] = snap_application.id
+
+          put :update, params: params
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.in_college).to eq(false)
+          end
+        end
+      end
+
+      context "someone is in_college" do
+        let(:params) do
+          valid_params.deep_merge(step: { anyone_in_college: "true" })
+        end
+
+        it "does not update the members" do
+          members = build_list(:member, 2)
+
+          snap_application = create(
+            :snap_application,
+            members: members,
+          )
+          session[:snap_application_id] = snap_application.id
+
+          put :update, params: params
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.in_college).to be_nil
+          end
+        end
+      end
+
+      context "no one is living_elsewhere" do
+        let(:params) do
+          valid_params.deep_merge(step: { anyone_living_elsewhere: "false" })
+        end
+
+        it "updates each member to reflect not living elsewhere" do
+          members = build_list(:member, 2)
+
+          snap_application = create(
+            :snap_application,
+            members: members,
+          )
+          session[:snap_application_id] = snap_application.id
+
+          put :update, params: params
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.living_elsewhere).to eq(false)
+          end
+        end
+      end
+
+      context "someone is living_elsewhere" do
+        let(:params) do
+          valid_params.deep_merge(step: { anyone_living_elsewhere: "true" })
+        end
+
+        it "does not update the members" do
+          members = build_list(:member, 2)
+
+          snap_application = create(
+            :snap_application,
+            members: members,
+          )
+          session[:snap_application_id] = snap_application.id
+
+          put :update, params: params
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.living_elsewhere).to be_nil
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/household_more_info_per_member_controller_spec.rb
+++ b/spec/controllers/household_more_info_per_member_controller_spec.rb
@@ -1,9 +1,16 @@
 require "rails_helper"
 
 RSpec.describe HouseholdMoreInfoPerMemberController do
-  let(:step) { assigns(:step) }
+  let(:snap_application) do
+    create(:snap_application, members: [member_one, member_two])
+  end
 
-  before { session[:snap_application_id] = current_app.id }
+  let(:member_one) { build(:member) }
+  let(:member_two) { build(:member) }
+
+  before do
+    session[:snap_application_id] = snap_application.id
+  end
 
   describe "#update" do
     context "when valid" do
@@ -23,18 +30,114 @@ RSpec.describe HouseholdMoreInfoPerMemberController do
         expect(member_two.reload).to be_in_college
       end
     end
-  end
 
-  def current_app
-    @_current_app ||=
-      create(:snap_application, members: [member_one, member_two])
-  end
+    context "when no members selected" do
+      context "for disabled" do
+        it "updates anyone_disabled on the application" do
+          snap_application.update(anyone_disabled: true)
 
-  def member_one
-    @_member_one ||= build(:member, disabled: nil)
-  end
+          params = {
+            step: {
+              members: {
+                member_one.id => { disabled: "0" },
+                member_two.id => { disabled: "0" },
+              },
+            },
+          }
 
-  def member_two
-    @_member_two ||= build(:member, in_college: false)
+          put :update, params: params
+
+          snap_application.reload
+
+          expect(snap_application.anyone_disabled).to eq(false)
+        end
+      end
+
+      context "for new mom" do
+        it "updates anyone_new_mom on the application" do
+          snap_application.update(anyone_new_mom: true)
+
+          params = {
+            step: {
+              members: {
+                member_one.id => { new_mom: "0" },
+                member_two.id => { new_mom: "0" },
+              },
+            },
+          }
+
+          put :update, params: params
+
+          snap_application.reload
+
+          expect(snap_application.anyone_new_mom).to eq(false)
+        end
+      end
+
+      context "for college" do
+        it "updates anyone_in college on the application" do
+          snap_application.update(anyone_in_college: true)
+
+          params = {
+            step: {
+              members: {
+                member_one.id => { in_college: "0" },
+                member_two.id => { in_college: "0" },
+              },
+            },
+          }
+
+          put :update, params: params
+
+          snap_application.reload
+
+          expect(snap_application.anyone_in_college).to eq(false)
+        end
+      end
+
+      context "living elsewhere" do
+        it "updates anyone_living_elsewhere on the application" do
+          snap_application.update(anyone_living_elsewhere: true)
+
+          params = {
+            step: {
+              members: {
+                member_one.id => { living_elsewhere: "0" },
+                member_two.id => { living_elsewhere: "0" },
+              },
+            },
+          }
+
+          put :update, params: params
+
+          snap_application.reload
+
+          expect(snap_application.anyone_living_elsewhere).to eq(false)
+        end
+      end
+    end
+
+    context "when all members selected" do
+      context "for citizenship" do
+        it "updates everyone_a_citizen on the application" do
+          snap_application.update(everyone_a_citizen: false)
+
+          params = {
+            step: {
+              members: {
+                member_one.id => { citizen: "1" },
+                member_two.id => { citizen: "1" },
+              },
+            },
+          }
+
+          put :update, params: params
+
+          snap_application.reload
+
+          expect(snap_application.everyone_a_citizen).to eq(true)
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/medicaid/intro_citizen_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_citizen_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Medicaid::IntroCitizenController, type: :controller do
   end
 
   describe "#update" do
-    context "multi member househoold" do
+    context "multi member household" do
       context "everyone a citizen" do
         it "updates the members" do
           members = build_list(:member, 2)
@@ -19,7 +19,7 @@ RSpec.describe Medicaid::IntroCitizenController, type: :controller do
           )
           session[:medicaid_application_id] = medicaid_application.id
 
-          put :update, params: { step: { everyone_a_citizen: true } }
+          put :update, params: { step: { everyone_a_citizen: "true" } }
 
           members.each(&:reload)
 
@@ -41,7 +41,7 @@ RSpec.describe Medicaid::IntroCitizenController, type: :controller do
           )
           session[:medicaid_application_id] = medicaid_application.id
 
-          put :update, params: { step: { everyone_a_citizen: true } }
+          put :update, params: { step: { everyone_a_citizen: "true" } }
 
           member.reload
 

--- a/spec/controllers/medicaid/intro_citizen_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_citizen_controller_spec.rb
@@ -28,6 +28,26 @@ RSpec.describe Medicaid::IntroCitizenController, type: :controller do
           end
         end
       end
+
+      context "not everyone is a citizen" do
+        it "does not update the members" do
+          members = build_list(:member, 2)
+
+          medicaid_application = create(
+            :medicaid_application,
+            members: members,
+          )
+          session[:medicaid_application_id] = medicaid_application.id
+
+          put :update, params: { step: { everyone_a_citizen: "false" } }
+
+          members.each(&:reload)
+
+          members.each do |member|
+            expect(member.citizen).to eq(nil)
+          end
+        end
+      end
     end
 
     context "single member household" do

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -56,7 +56,7 @@ module FeatureHelper
   def login_with_basic_auth
     page.driver.browser.basic_authorize(
       Rails.application.secrets.basic_auth_user,
-      Rails.application.secrets.basic_auth_password
+      Rails.application.secrets.basic_auth_password,
     )
   end
 


### PR DESCRIPTION
Previously in this step on the SNAP flow, when the client selected "everyone is a citizen", we only marked that on the application and didn't update individual members. As a result, when we fill in the PDF, the members were never marked as citizens on the PDF, because we only fill it out based on the member.

This PR fixes that by updating members-> citizen to true when 'everyone_a_citizen' is selected.

This PR also addresses the negative of that problem on the same step, which happens when someone marks 'anyone_blank' as false. Right now we aren't updating the members (as a result, the value for that field is nil). This PR marks those fields as false instead.

Lastly, we now update 'everyone_a_citizen' and similar fields to their proper values based on actual reported members (for example, we update to `true` if all members are selected, and `anyone_in_college` to `false` if no members are selected).

A problem: right now this says canonically that if e.g. no members are marked as disabled that there are no disabled members in the household. But, we specifically say that member selection is optional. Screenshot below.

![screen shot 2018-01-30 at 2 07 44 pm](https://user-images.githubusercontent.com/3675092/35594219-325b34a0-05c7-11e8-9524-f320925f71e3.png)

What do we want to do? It seems like there could be intentionally irreconcilable data, but we have no way of knowing whether that conflict is intentional (person just hasn't indicated who is disabled) or the result of user confusion (they would have gone back to mark that no one in household was disabled if given the chance).


