### PR TITLE
Avoid marking applications as homeless when stable_housing is nil.

### DIFF
--- a/app/models/concerns/common_benefit_application.rb
+++ b/app/models/concerns/common_benefit_application.rb
@@ -27,7 +27,11 @@ module CommonBenefitApplication
     addresses.where(mailing: true).first || NullAddress.new
   end
 
+  def stable_housing?
+    stable_housing == true || stable_housing == nil
+  end
+
   def unstable_housing?
-    !stable_housing?
+    stable_housing == false
   end
 end

--- a/spec/support/shared_examples/common_benefit_application.rb
+++ b/spec/support/shared_examples/common_benefit_application.rb
@@ -144,5 +144,39 @@ RSpec.shared_examples "common benefit application" do
         expect(subject.unstable_housing?).to eq(true)
       end
     end
+
+    context "when stable_housing is nil" do
+      it "returns false" do
+        subject.stable_housing = nil
+
+        expect(subject.unstable_housing?).to eq(false)
+      end
+    end
+  end
+
+  describe "#stable_housing?" do
+    context "when stable_housing is true" do
+      it "returns true" do
+        subject.stable_housing = true
+
+        expect(subject.stable_housing?).to eq(true)
+      end
+    end
+
+    context "when stable_housing is false" do
+      it "returns false" do
+        subject.stable_housing = false
+
+        expect(subject.stable_housing?).to eq(false)
+      end
+    end
+
+    context "when stable_housing is nil" do
+      it "returns true" do
+        subject.stable_housing = nil
+
+        expect(subject.stable_housing?).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
* On Medicaid applications, stable_housing might be nil.
* Rewrite stable_housing? to be true when it’s nil.
* Correct unstable_housing? to return false only on boolean false.

[#154776068]