### PR TITLE
Don’t fill in shelter expenses when user enters $0

### DIFF
--- a/app/models/snap_application_attributes.rb
+++ b/app/models/snap_application_attributes.rb
@@ -85,11 +85,11 @@ class SnapApplicationAttributes
         mortgage_expense: mortgage_expense,
         mortgage_expense_interval: bool_to_checkbox(mortgage_expense.present?),
         property_tax_expense_yes:
-          bool_to_checkbox(snap_application.property_tax_expense.present?),
+          bool_to_checkbox(annual_property_tax_expense.present?),
         annual_property_tax_expense: annual_property_tax_expense,
         annual_insurance_expense: annual_insurance_expense,
         insurance_expense_yes:
-          bool_to_checkbox(snap_application.insurance_expense.present?),
+          bool_to_checkbox(annual_insurance_expense.present?),
         utility_electricity:
           bool_to_checkbox(snap_application.utility_electrity?),
         utility_water_sewer:
@@ -243,44 +243,44 @@ class SnapApplicationAttributes
   end
 
   def annual_property_tax_expense
-    if snap_application.property_tax_expense
+    if nil_if_zero(snap_application.property_tax_expense)
       snap_application.property_tax_expense * 12
     end
   end
 
   def annual_insurance_expense
-    if snap_application.insurance_expense
+    if nil_if_zero(snap_application.insurance_expense)
       snap_application.insurance_expense * 12
     end
   end
 
   def rent_expense_yes
     if !homeowner?
-      bool_to_checkbox(snap_application.rent_expense.present?)
+      bool_to_checkbox(rent_expense.present?)
     end
   end
 
   def mortgage_expense_yes
     if homeowner?
-      bool_to_checkbox(snap_application.rent_expense.present?)
+      bool_to_checkbox(mortgage_expense.present?)
     end
   end
 
   def rent_expense
     if !homeowner?
-      snap_application.rent_expense
+      nil_if_zero(snap_application.rent_expense)
     end
   end
 
   def mortgage_expense
     if homeowner?
-      snap_application.rent_expense
+      nil_if_zero(snap_application.rent_expense)
     end
   end
 
   def homeowner?
-    snap_application.insurance_expense.present? ||
-      snap_application.property_tax_expense.present?
+    nil_if_zero(snap_application.insurance_expense).present? ||
+      nil_if_zero(snap_application.property_tax_expense).present?
   end
 
   def residential_or_homeless
@@ -295,5 +295,9 @@ class SnapApplicationAttributes
     [address.street_address, address.street_address_2].
       reject(&:blank?).
       join(", ")
+  end
+
+  def nil_if_zero(value)
+    value&.zero? ? nil : value
   end
 end

--- a/spec/models/snap_application_attributes_spec.rb
+++ b/spec/models/snap_application_attributes_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe SnapApplicationAttributes do
         financial_accounts: [:four_oh_one_k],
         phone_number: "2222222222",
         rent_expense: 100,
+        property_tax_expense: 0,
+        insurance_expense: 0,
         stable_housing: false,
         authorized_representative: true,
         authorized_representative_name: "aBenny",


### PR DESCRIPTION
* Users are naturally entering $0 for rent/mortgage, property tax, and insurance
* On the 1171 PDF, we should not check those boxes nor fill in those fields when $0 is entered

[#154774358]