### PR TITLE
Ask if user has applied before

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -86,9 +86,27 @@ var yesNoButtons = (function () {
   }
 })()
 
+var yesNoEnumButtons = (function () {
+  var yne = {
+    init: function () {
+      $('[data-enum-no]').on('click', function () {
+        $('input.boolean-answer').val('no')
+      })
+
+      $('[data-enum-yes]').on('click', function () {
+        $('input.boolean-answer').val('yes')
+      })
+    }
+  }
+  return {
+    init: yne.init
+  }
+})()
+
 $(document).ready(function () {
   radioSelector.init()
   checkboxSelector.init()
   textWell.init()
   yesNoButtons.init()
+  yesNoEnumButtons.init()
 })

--- a/app/controllers/introduction_applied_before_controller.rb
+++ b/app/controllers/introduction_applied_before_controller.rb
@@ -1,0 +1,1 @@
+class IntroductionAppliedBeforeController < SnapStepsController; end

--- a/app/controllers/medicaid/intro_applied_before_controller.rb
+++ b/app/controllers/medicaid/intro_applied_before_controller.rb
@@ -1,0 +1,3 @@
+module Medicaid
+  class IntroAppliedBeforeController < MedicaidStepsController; end
+end

--- a/app/dashboards/medicaid_application_dashboard.rb
+++ b/app/dashboards/medicaid_application_dashboard.rb
@@ -59,6 +59,7 @@ class MedicaidApplicationDashboard < Administrate::BaseDashboard
     stable_housing: Field::Boolean,
     anyone_married: Field::Boolean,
     exports: Field::HasMany,
+    applied_before: Field::String,
   }.freeze
 
   # COLLECTION_ATTRIBUTES
@@ -87,6 +88,7 @@ class MedicaidApplicationDashboard < Administrate::BaseDashboard
     created_at
     updated_at
     submit_ssn
+    applied_before
     homeless
     reliable_mail_address
     need_medical_expense_help_3_months

--- a/app/dashboards/snap_application_dashboard.rb
+++ b/app/dashboards/snap_application_dashboard.rb
@@ -61,6 +61,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     employments: Field::HasMany,
     driver_errors: Field::HasMany,
     exports: Field::HasMany,
+    applied_before: Field::String,
   }.freeze
   # rubocop:enable LineLength
 
@@ -88,6 +89,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     documents
     phone_number
     sms_consented
+    applied_before
     consent_to_terms
     mailing_address_same_as_residential_address
     unstable_housing

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -2,6 +2,8 @@ class MedicaidApplication < ApplicationRecord
   include Submittable
   include CommonBenefitApplication
 
+  enum applied_before: { unfilled: 0, yes: 1, no: 2 }, _prefix: :applied_before
+
   has_many(
     :members,
     -> { order(created_at: :asc) },

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -23,6 +23,8 @@ class SnapApplication < ApplicationRecord
     alimony
   ].freeze
 
+  enum applied_before: { unfilled: 0, yes: 1, no: 2 }, _prefix: :applied_before
+
   validate :care_expenses_values
   validate :medical_expenses_values
   validate :court_ordered_expenses_values

--- a/app/steps/introduction_applied_before.rb
+++ b/app/steps/introduction_applied_before.rb
@@ -1,0 +1,3 @@
+class IntroductionAppliedBefore < Step
+  step_attributes(:applied_before)
+end

--- a/app/steps/medicaid/intro_applied_before.rb
+++ b/app/steps/medicaid/intro_applied_before.rb
@@ -1,0 +1,5 @@
+module Medicaid
+  class IntroAppliedBefore < Step
+    step_attributes(:applied_before)
+  end
+end

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -6,6 +6,7 @@ module Medicaid
         Medicaid::IntroLocationController,
         Medicaid::IntroLocationHelpController,
         Medicaid::IntroNameController,
+        Medicaid::IntroAppliedBeforeController,
         Medicaid::IntroHouseholdController,
         Medicaid::IntroMaritalStatusController,
         Medicaid::IntroMaritalStatusMemberController,

--- a/app/steps/step_navigation.rb
+++ b/app/steps/step_navigation.rb
@@ -10,6 +10,7 @@ class StepNavigation
     "Your Household" => [
       HouseholdIntroductionController,
       PersonalDetailController,
+      IntroductionAppliedBeforeController,
       HouseholdMembersOverviewController,
       HouseholdMoreInfoController,
       HouseholdMoreInfoPerMemberController,

--- a/app/views/introduction_applied_before/edit.html.erb
+++ b/app/views/introduction_applied_before/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :header_title, "Case Details" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Have you applied for benefits in Michigan before?
+    </div>
+    <p class="text--help text--centered">If you’ve applied before, you might be able to submit less paperwork.</p>
+  </header>
+
+  <%= render 'shared/yes_no_enum_form', step: @step, field: :applied_before %>
+</div>

--- a/app/views/medicaid/intro_applied_before/edit.html.erb
+++ b/app/views/medicaid/intro_applied_before/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :header_title, "Case Details" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Have you applied for benefits in Michigan before?
+    </div>
+    <p class="text--help text--centered">If you’ve applied before, you might be able to submit less paperwork.</p>
+  </header>
+
+  <%= render 'shared/yes_no_enum_form', step: @step, field: :applied_before %>
+</div>

--- a/app/views/shared/_yes_no_enum_form.html.erb
+++ b/app/views/shared/_yes_no_enum_form.html.erb
@@ -1,0 +1,23 @@
+<%= form_for step,
+  as: :step,
+  builder: MbFormBuilder,
+  url: current_path,
+  method: :put do |f| %>
+
+  <div class="form-card__content">
+    <footer class="form-card__buttons">
+      <%= f.hidden_field(field, class: 'boolean-answer') %>
+
+      <button
+        type="submit"
+        class="button button--nav button--full-mobile"
+        data-enum-no> No </button>
+
+      <button
+        type="submit"
+        class="button button--nav button--cta button--full-mobile"
+        data-enum-yes> Yes </button>
+    </footer>
+  </div>
+
+<% end %>

--- a/db/migrate/20180207201225_add_applied_before.rb
+++ b/db/migrate/20180207201225_add_applied_before.rb
@@ -1,0 +1,9 @@
+class AddAppliedBefore < ActiveRecord::Migration[5.1]
+  def change
+    add_column :snap_applications, :applied_before, :integer
+    change_column_default :snap_applications, :applied_before, from: nil, to: 0
+
+    add_column :medicaid_applications, :applied_before, :integer
+    change_column_default :medicaid_applications, :applied_before, from: nil, to: 0
+  end
+end

--- a/db/migrate/20180207230234_backfill_applied_before.rb
+++ b/db/migrate/20180207230234_backfill_applied_before.rb
@@ -1,0 +1,11 @@
+class BackfillAppliedBefore < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  class SnapApplication < ActiveRecord::Base; end
+  class MedicaidApplication < ActiveRecord::Base; end
+
+  def change
+    SnapApplication.in_batches.update_all(applied_before: 0)
+    MedicaidApplication.in_batches.update_all(applied_before: 0)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171214235857) do
+ActiveRecord::Schema.define(version: 20180207230234) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,7 @@ ActiveRecord::Schema.define(version: 20171214235857) do
     t.boolean "anyone_pay_child_support_alimony_arrears"
     t.boolean "anyone_pay_student_loan_interest"
     t.boolean "anyone_self_employed", default: false
+    t.integer "applied_before", default: 0
     t.boolean "consent_to_terms"
     t.datetime "created_at", null: false
     t.string "email"
@@ -232,6 +233,7 @@ ActiveRecord::Schema.define(version: 20171214235857) do
     t.boolean "anyone_in_college"
     t.boolean "anyone_living_elsewhere"
     t.boolean "anyone_new_mom"
+    t.integer "applied_before", default: 0
     t.boolean "authorized_representative"
     t.string "authorized_representative_name"
     t.string "care_expenses", default: [], array: true

--- a/spec/controllers/personal_detail_controller_spec.rb
+++ b/spec/controllers/personal_detail_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe PersonalDetailController do
           expect(current_app_member.send(key)).to eq(value)
         end
 
-        expect(response).to redirect_to("/steps/introduction-applied-before")
+        expect(response).to redirect_to(subject.next_path)
       end
     end
   end

--- a/spec/controllers/personal_detail_controller_spec.rb
+++ b/spec/controllers/personal_detail_controller_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe PersonalDetailController do
           expect(current_app_member.send(key)).to eq(value)
         end
 
-        expect(response).to redirect_to("/steps/household-members-overview")
+        expect(response).to redirect_to("/steps/introduction-applied-before")
       end
     end
   end

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -20,6 +20,11 @@ RSpec.feature "Medicaid app" do
       proceed_with "Next"
 
       expect(page).to have_content(
+        "Have you applied for benefits in Michigan before?",
+      )
+      proceed_with "Yes"
+
+      expect(page).to have_content(
         "Now tell us about any other people residing in your household.",
       )
       proceed_with "Next"

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -20,6 +20,11 @@ RSpec.feature "Medicaid app" do
       proceed_with "Next"
 
       expect(page).to have_content(
+        "Have you applied for benefits in Michigan before?",
+      )
+      proceed_with "No"
+
+      expect(page).to have_content(
         "Now tell us about any other people residing in your household.",
       )
       proceed_with "Next"

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -19,6 +19,8 @@ RSpec.feature "Medicaid app" do
       select_radio(question: "What is your gender?", answer: "Female")
       proceed_with "Next"
 
+      proceed_with "No"
+
       click_on "Add a member"
 
       fill_in "What is their first name?", with: "Christa"

--- a/spec/features/snap_application_with_maximum_info_spec.rb
+++ b/spec/features/snap_application_with_maximum_info_spec.rb
@@ -43,6 +43,13 @@ feature "SNAP application with maximum info" do
       proceed_with "Continue"
     end
 
+    on_page "Case Details" do
+      expect(page).to have_content(
+        "Have you applied for benefits in Michigan before?",
+      )
+      proceed_with "Yes"
+    end
+
     on_pages "Your Household" do
       click_on "Add a member"
 

--- a/spec/features/snap_application_with_minimal_info_spec.rb
+++ b/spec/features/snap_application_with_minimal_info_spec.rb
@@ -32,6 +32,13 @@ RSpec.feature "Submit application with minimal information" do
     select "Divorced", from: "What is your marital status?"
     proceed_with "Continue"
 
+    on_page "Case Details" do
+      expect(page).to have_content(
+        "Have you applied for benefits in Michigan before?",
+      )
+      proceed_with "No"
+    end
+
     on_page("Your Household") do
       proceed_with "Continue"
     end

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -8,6 +8,16 @@ RSpec.describe SnapApplication do
 
     it_should_behave_like "common benefit application"
   end
+
+  describe "enums" do
+    context "applied_before" do
+      it "should be 'unfilled' by default" do
+        app = build(:snap_application)
+        expect(app.applied_before_unfilled?).to be(true)
+      end
+    end
+  end
+
   describe "validations" do
     [
       [:care_expenses, SnapApplication::CARE_EXPENSES],


### PR DESCRIPTION
- Use enum for unfilled/yes/no.
- Used backfill recommendation via Strong Migrations
https://github.com/ankane/strong_migrations#adding-a-column-with-a-default-value
- Updated yes/no JavaScript to support the enum "yes"/"no" values

[Finishes #154901167]

Signed-off-by: Ben Golder <bgolder@codeforamerica.org>