### PR TITLE
Fix members dashboard (and others! and add tests!)

### DIFF
--- a/app/dashboards/driver_error_dashboard.rb
+++ b/app/dashboards/driver_error_dashboard.rb
@@ -2,7 +2,7 @@ require "administrate/base_dashboard"
 
 class DriverErrorDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
-    page_history: Field::String,
+    page_history: Field::String.with_options(searchable: false),
     snap_application: Field::HasOne,
     id: Field::Number,
     error_class: Field::String,

--- a/app/dashboards/medicaid_application_dashboard.rb
+++ b/app/dashboards/medicaid_application_dashboard.rb
@@ -34,7 +34,7 @@ class MedicaidApplicationDashboard < Administrate::BaseDashboard
     sms_consented: Field::Boolean,
     birthday: Field::DateTime,
     self_employment_expenses: Field::Number,
-    employed_monthly_income: Field::String,
+    employed_monthly_income: Field::String.with_options(searchable: false),
     anyone_in_college: Field::Boolean,
     flint_water_crisis: Field::Boolean,
     anyone_employed: Field::Boolean,
@@ -53,13 +53,13 @@ class MedicaidApplicationDashboard < Administrate::BaseDashboard
     signature: Field::String,
     signed_at: Field::DateTime,
     upload_paperwork: Field::Boolean,
-    paperwork: Field::String,
+    paperwork: Field::String.with_options(searchable: false),
     office_location: Field::String,
     mailing_address_same_as_residential_address: Field::Boolean,
     stable_housing: Field::Boolean,
     anyone_married: Field::Boolean,
     exports: Field::HasMany,
-    applied_before: Field::String,
+    applied_before: Field::String.with_options(searchable: false),
   }.freeze
 
   # COLLECTION_ATTRIBUTES

--- a/app/dashboards/member_dashboard.rb
+++ b/app/dashboards/member_dashboard.rb
@@ -111,6 +111,6 @@ class MemberDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how members are displayed
   # across all pages of the admin dashboard.
   def display_resource(member)
-    "#{member.first_name} #{member.last_name} (##{member.id})"
+    "#{member.first_name} #{member.last_name} (#{member.id})"
   end
 end

--- a/app/dashboards/member_dashboard.rb
+++ b/app/dashboards/member_dashboard.rb
@@ -16,7 +16,6 @@ class MemberDashboard < Administrate::BaseDashboard
     sex: Field::String,
     first_name: Field::String,
     last_name: Field::String,
-    display_name: Field::String,
     birthday: Field::DateTime,
     buy_food_with: Field::Boolean,
     relationship: Field::String,
@@ -44,7 +43,8 @@ class MemberDashboard < Administrate::BaseDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-    display_name
+    first_name
+    last_name
     employment_status
     employed_monthly_income
     self_employed_monthly_income
@@ -111,6 +111,6 @@ class MemberDashboard < Administrate::BaseDashboard
   # Overwrite this method to customize how members are displayed
   # across all pages of the admin dashboard.
   def display_resource(member)
-    member.display_name
+    "#{member.first_name} #{member.last_name} (##{member.id})"
   end
 end

--- a/app/dashboards/snap_application_dashboard.rb
+++ b/app/dashboards/snap_application_dashboard.rb
@@ -40,13 +40,13 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     monthly_medical_expenses: Field::String.with_options(searchable: false),
     office_location: Field::String,
     phone_number: Field::String,
-    property_tax_expense: Field::Number,
+    property_tax_expense: Field::Number.with_options(searchable: false),
     real_estate_income: Field::Boolean,
-    rent_expense: Field::Number,
+    rent_expense: Field::Number.with_options(searchable: false),
     signature: Field::String,
     signed_at: Field::DateTime,
     sms_consented: Field::Boolean,
-    total_money: Field::Number,
+    total_money: Field::Number.with_options(searchable: false),
     unstable_housing: Field::Boolean,
     updated_at: Field::DateTime,
     utility_cooling: Field::Boolean,
@@ -61,7 +61,7 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     employments: Field::HasMany,
     driver_errors: Field::HasMany,
     exports: Field::HasMany,
-    applied_before: Field::String,
+    applied_before: Field::String.with_options(searchable: false),
   }.freeze
   # rubocop:enable LineLength
 

--- a/spec/features/admin_dashboard_driver_errors_spec.rb
+++ b/spec/features/admin_dashboard_driver_errors_spec.rb
@@ -8,6 +8,12 @@ RSpec.feature "Admin viewing driver errors dashboard", type: :feature do
     login_as(user)
   end
 
+  scenario "searching isn't broken", javascript: true do
+    visit admin_driver_errors_path(search: "asdf")
+
+    expect(page).to have_content("Driver Errors")
+  end
+
   scenario "show", javascript: true do
     driver_error = create(
       :driver_error,

--- a/spec/features/admin_dashboard_exports_spec.rb
+++ b/spec/features/admin_dashboard_exports_spec.rb
@@ -6,6 +6,12 @@ RSpec.feature "Admins can view exports" do
     login_as(user)
   end
 
+  scenario "searching isn't broken", javascript: true do
+    visit admin_exports_path(search: "asdf")
+
+    expect(page).to have_content("Exports")
+  end
+
   scenario "Exports are listed" do
     medicaid_application = build(:medicaid_application)
     snap_application = build(:snap_application)

--- a/spec/features/admin_dashboard_medicaid_applications_spec.rb
+++ b/spec/features/admin_dashboard_medicaid_applications_spec.rb
@@ -23,6 +23,12 @@ RSpec.feature "Admin viewing medicaid applications dashboard", type: :feature do
     expect(page).to have_content("Medicaid Application ##{application.id}")
   end
 
+  scenario "searching isn't broken", javascript: true do
+    visit admin_medicaid_applications_path(search: "asdf")
+
+    expect(page).to have_content("Medicaid Applications")
+  end
+
   scenario "downloads the 1426 PDF application", javascript: true do
     application = create(
       :medicaid_application,

--- a/spec/features/admin_dashboard_members_spec.rb
+++ b/spec/features/admin_dashboard_members_spec.rb
@@ -14,6 +14,12 @@ RSpec.feature "Admins can view members" do
     end
   end
 
+  scenario "searching isn't broken", javascript: true do
+    visit admin_members_path(search: "adsf")
+
+    expect(page).to have_content("Members")
+  end
+
   scenario "Members are listed" do
     benefit_application = build(:medicaid_application)
     john = create(
@@ -32,13 +38,13 @@ RSpec.feature "Admins can view members" do
     visit admin_members_path
 
     within "[data-url='#{admin_member_path(john)}']" do
-      expect(page).to have_content "John"
-      expect(page).to have_content "Doe"
+      expect(page).to have_content "john"
+      expect(page).to have_content "doe"
     end
 
     within "[data-url='#{admin_member_path(joe)}']" do
-      expect(page).to have_content "Joe"
-      expect(page).to have_content "Schmoe"
+      expect(page).to have_content "joe"
+      expect(page).to have_content "schmoe"
     end
   end
 end

--- a/spec/features/admin_dashboard_snap_applications_spec.rb
+++ b/spec/features/admin_dashboard_snap_applications_spec.rb
@@ -16,6 +16,12 @@ RSpec.feature "Submit snap application with minimal information" do
     expect(page).to have_content("Log in")
   end
 
+  scenario "searching isn't broken", javascript: true do
+    visit admin_root_path(search: "asdf")
+
+    expect(page).to have_content("Snap Applications")
+  end
+
   scenario "The stats are accurate", javascript: true do
     10.times { create(:snap_application, signed_at: nil) }
     1.times { create(:snap_application, :emailed_client, signed_at: nil) }


### PR DESCRIPTION
* Remove display_name from admin dashboard
Administrate was choking on 'display_name' on search on staging and production (not locally). We disable search, but decided to just use first name and last name in the dashboard instead.


* Add tests for Administrate search and fix other broken fields
Administrate search is easily and sneakily broken if certain fields incompatible with search aren't excluded. To fix this, I added a few simple sanity tests and corrected the offenders.

This should fix search on all the dashboards.