### PR TITLE
Add BeforeYouStart page that clears current_app

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -1,7 +1,7 @@
 class FormsController < ApplicationController
   layout "form"
 
-  before_action :ensure_application_present, only: %i[index]
+  before_action :ensure_application_present, only: %i[edit update]
 
   helper_method :application_title
 
@@ -60,7 +60,9 @@ class FormsController < ApplicationController
 
   # Override in subclasses
 
-  def existing_attributes; end
+  def existing_attributes
+    {}
+  end
 
   def update_models; end
 
@@ -73,7 +75,7 @@ class FormsController < ApplicationController
   end
 
   def first_step_path
-    introduce_yourself_sections_path
+    before_you_start_sections_path
   end
 
   def form_attrs

--- a/app/controllers/integrated/before_you_start_controller.rb
+++ b/app/controllers/integrated/before_you_start_controller.rb
@@ -1,0 +1,16 @@
+module Integrated
+  class BeforeYouStartController < FormsController
+    before_action :clear_current_application, only: :edit
+    skip_before_action :ensure_application_present
+
+    def form_class
+      NullStep
+    end
+
+    private
+
+    def clear_current_application
+      session[:current_application_id] = nil
+    end
+  end
+end

--- a/app/controllers/integrated/benefits_intro_controller.rb
+++ b/app/controllers/integrated/benefits_intro_controller.rb
@@ -3,9 +3,5 @@ module Integrated
     def form_class
       NullStep
     end
-
-    def edit
-      render :edit
-    end
   end
 end

--- a/app/controllers/integrated/introduce_yourself_controller.rb
+++ b/app/controllers/integrated/introduce_yourself_controller.rb
@@ -1,5 +1,7 @@
 module Integrated
   class IntroduceYourselfController < FormsController
+    skip_before_action :ensure_application_present
+
     def update_models
       if current_application
         current_application.primary_member.update(form_params)

--- a/app/forms/form_navigation.rb
+++ b/app/forms/form_navigation.rb
@@ -1,6 +1,7 @@
 class FormNavigation
   MAIN = {
     "Introduction" => [
+      Integrated::BeforeYouStartController,
       Integrated::IntroduceYourselfController,
       Integrated::BenefitsIntroController,
     ],

--- a/app/views/forms/index.html.erb
+++ b/app/views/forms/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :header_title, 'Navigation' %>
 <div class="slab">
-  <% FormNavigation.forms_with_groupings.each do |group_header, forms| %>
+  <% FormNavigation.form_controllers_with_groupings.each do |group_header, forms| %>
     <h3>
       <%= group_header %>
     </h3>

--- a/app/views/integrated/before_you_start/edit.html.erb
+++ b/app/views/integrated/before_you_start/edit.html.erb
@@ -1,0 +1,11 @@
+<% content_for :header_title, "Introduction" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <h1 class="form-card__title">Welcome</h1>
+  </header>
+
+  <div class="form-card__content">
+    <%= render "integrated/next_step_link" %>
+  </div>
+</div>

--- a/spec/controllers/forms_controller_inheritance_spec.rb
+++ b/spec/controllers/forms_controller_inheritance_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe FormsController do
+  controller do
+    def update
+      @test = "in update"
+      head :no_content
+    end
+
+    def edit
+      @test = "in edit"
+      head :no_content
+    end
+  end
+
+  describe "#edit" do
+    before do
+      routes.draw { get "edit" => "forms#edit" }
+    end
+
+    context "when there is a common application" do
+      it "renders the action as normal" do
+        session[:current_application_id] = create(:common_application).id
+
+        get "edit"
+
+        expect(assigns[:test]).to eq "in edit"
+      end
+    end
+
+    context "when there is no application under way" do
+      it "redirects to the specified path" do
+        session[:current_application_id] = nil
+
+        get "edit"
+
+        expect(response).to redirect_to(before_you_start_sections_path)
+      end
+    end
+  end
+
+  describe "#update" do
+    before do
+      routes.draw { get "update" => "forms#update" }
+    end
+
+    context "when there is a current application" do
+      it "renders the action as normal" do
+        session[:current_application_id] = create(:common_application).id
+
+        get "update"
+
+        expect(assigns[:test]).to eq "in update"
+      end
+    end
+
+    context "when there is no application under way" do
+      it "redirects to the specified path" do
+        session[:current_application_id] = nil
+
+        get "update"
+
+        expect(response).to redirect_to(before_you_start_sections_path)
+      end
+    end
+  end
+end

--- a/spec/controllers/forms_controller_spec.rb
+++ b/spec/controllers/forms_controller_spec.rb
@@ -12,14 +12,6 @@ RSpec.describe FormsController do
         expect(response).to render_template(:index)
       end
     end
-
-    context "no current application" do
-      it "redirects to the root path" do
-        get :index
-
-        expect(response).to redirect_to(introduce_yourself_sections_path)
-      end
-    end
   end
 
   describe ".skip?" do

--- a/spec/controllers/integrated/before_you_start_controller_spec.rb
+++ b/spec/controllers/integrated/before_you_start_controller_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe Integrated::BeforeYouStartController do
+  describe "edit" do
+    context "with a current application" do
+      it "clears current application from session" do
+        current_app = create(:common_application)
+        session[:current_application_id] = current_app.id
+
+        get :edit
+
+        expect(session[:current_application_id]).to be_nil
+      end
+    end
+
+    context "without a current application" do
+      it "renders edit" do
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/controllers/integrated/introduce_yourself_controller_spec.rb
+++ b/spec/controllers/integrated/introduce_yourself_controller_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe Integrated::IntroduceYourselfController do
         expect(form.first_name).to eq("Juan")
       end
     end
+
+    context "without a current application" do
+      it "renders edit" do
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
   end
 
   describe "update" do

--- a/spec/features/integrated_application_navigation_spec.rb
+++ b/spec/features/integrated_application_navigation_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+RSpec.feature "Integrated application" do
+  scenario "form navigation", :js do
+    visit sections_path
+
+    expect(page).to have_content("Navigation")
+  end
+end

--- a/spec/features/integrated_application_with_multiple_members_spec.rb
+++ b/spec/features/integrated_application_with_multiple_members_spec.rb
@@ -2,7 +2,13 @@ require "rails_helper"
 
 RSpec.feature "Integrated application" do
   scenario "with multiple members", :js do
-    visit introduce_yourself_sections_path
+    visit before_you_start_sections_path
+
+    on_page "Introduction" do
+      expect(page).to have_content("Welcome")
+
+      proceed_with "Continue"
+    end
 
     on_page "Introduction" do
       expect(page).to have_content("To start, please introduce yourself")


### PR DESCRIPTION
- Added small feature spec for form navigation page.
- Added default redirection if current_application is not present in
  session. Skip redirection on first two form controllers.

[Finishes #155523865]

Signed-off-by: Christa Hartsock <christa@codeforamerica.org>