### PR TITLE
Add 'Application Submitted' step that sends application via email

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -42,6 +42,10 @@ class FormsController < ApplicationController
     section_path(previous_step.to_param, params) if previous_step
   end
 
+  def first_step_path
+    before_you_start_sections_path
+  end
+
   def self.form_class
     (controller_name + "_form").classify.constantize
   end
@@ -72,10 +76,6 @@ class FormsController < ApplicationController
     if current_application.blank?
       redirect_to first_step_path
     end
-  end
-
-  def first_step_path
-    before_you_start_sections_path
   end
 
   def form_attrs

--- a/app/controllers/integrated/application_submitted_controller.rb
+++ b/app/controllers/integrated/application_submitted_controller.rb
@@ -1,0 +1,33 @@
+module Integrated
+  class ApplicationSubmittedController < FormsController
+    before_action :ensure_application_present,
+      :send_email,
+      :clear_current_application,
+      only: :edit
+
+    def form_class
+      NullStep
+    end
+
+    def previous_path(*_args)
+      nil
+    end
+
+    def next_path
+      first_step_path
+    end
+
+    private
+
+    def send_email
+      Integrated::ExportFactory.create(
+        destination: :office_email,
+        benefit_application: current_application,
+      )
+    end
+
+    def clear_current_application
+      session[:current_application_id] = nil
+    end
+  end
+end

--- a/app/forms/form_navigation.rb
+++ b/app/forms/form_navigation.rb
@@ -4,6 +4,7 @@ class FormNavigation
       Integrated::BeforeYouStartController,
       Integrated::IntroduceYourselfController,
       Integrated::BenefitsIntroController,
+      Integrated::ApplicationSubmittedController,
     ],
   }.freeze
 

--- a/app/jobs/integrated/office_email_application_job.rb
+++ b/app/jobs/integrated/office_email_application_job.rb
@@ -1,0 +1,18 @@
+module Integrated
+  class OfficeEmailApplicationJob < ApplicationJob
+    def perform(export:)
+      export.execute do |integrated_application, logger|
+        ApplicationMailer.office_integrated_application_notification(
+          application_pdf: integrated_application.pdf,
+          recipient_email: integrated_application.receiving_office_email,
+          applicant_name: integrated_application.primary_member.display_name,
+        ).deliver
+
+        logger.info(
+          "Emailed to #{integrated_application.receiving_office_email} "\
+          "for FAP + Medicaid Client #{integrated_application.id}",
+        )
+      end
+    end
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -42,6 +42,21 @@ class ApplicationMailer < ActionMailer::Base
     )
   end
 
+  def office_integrated_application_notification(
+    application_pdf:,
+    recipient_email:,
+    applicant_name:
+  )
+    attachments[attachment_name(applicant_name, "1171")] = application_pdf.read
+
+    mail(
+      from: %("Michigan Benefits" <hello@#{ENV['EMAIL_DOMAIN']}>),
+      to: recipient_email,
+      subject: "A new 1171 from #{applicant_name} was submitted!",
+      template_name: "office_integrated_application_notification",
+    )
+  end
+
   private
 
   def subject(office_location, applicant_name)

--- a/app/models/common_application.rb
+++ b/app/models/common_application.rb
@@ -1,11 +1,16 @@
 class CommonApplication < ApplicationRecord
   include CommonBenefitApplication
+  include Submittable
 
   has_many :members, class_name: "HouseholdMember", foreign_key: "common_application_id"
 
   def pdf
     @_pdf ||= ApplicationPdfAssembler.new(benefit_application: self).run
   end
+
+  def residential_zip; end
+
+  def office_location; end
 
   def documents
     []

--- a/app/models/integrated/export_factory.rb
+++ b/app/models/integrated/export_factory.rb
@@ -1,0 +1,28 @@
+module Integrated
+  class ExportFactory
+    DELAY_THRESHOLD = 30
+
+    def self.create(params)
+      new.create(params)
+    end
+
+    def create(params)
+      enqueue(Export.create(params))
+    end
+
+    def enqueue(export)
+      export.transaction do
+        export.save!
+        case export.destination
+        when :office_email
+          Integrated::OfficeEmailApplicationJob.perform_later(export: export)
+        else
+          raise UnknownExportTypeError, export.destination
+        end
+        export.transition_to(new_status: :queued)
+      end
+    end
+
+    class UnknownExportTypeError < StandardError; end
+  end
+end

--- a/app/views/application_mailer/office_integrated_application_notification.html.erb
+++ b/app/views/application_mailer/office_integrated_application_notification.html.erb
@@ -1,0 +1,19 @@
+<p>
+  Hello Genesee County staff!
+</p>
+
+<p>
+  A new application for FAP and Medicaid was just completed online. Attached you’ll find a new 1171, completed using the Digital Assister.
+</p>
+
+<p>
+  Thank you as always for your feedback on this new process. Let us know what is working, and what can be improved! Reach out with ideas or issues anytime by replying to this email.
+</p>
+
+<p>
+  Best,
+  <br>
+  Alan Williams (Code for America) & Lena Selzer (Civilla)
+  <br>
+  <%= root_url %>
+</p>

--- a/app/views/application_mailer/office_medicaid_application_notification.html.erb
+++ b/app/views/application_mailer/office_medicaid_application_notification.html.erb
@@ -3,7 +3,7 @@ Hello Genesee County staff!
 </p>
 
 <p>
-A new application for Medicaid was just completed online. Attached you’ll find a new 1426, completed using the Digital Assister. This person is not present at your office.
+A new application for Medicaid was just completed online. Attached you’ll find a new 1426, completed using the Digital Assister.
 </p>
 
 <p>

--- a/app/views/integrated/application_submitted/edit.html.erb
+++ b/app/views/integrated/application_submitted/edit.html.erb
@@ -1,0 +1,11 @@
+<% content_for :header_title, "Application Submitted" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <h1 class="form-card__title">Congratulations</h1>
+  </header>
+
+  <div class="form-card__content">
+    <p>You have submitted an application for Food Assistance and Medicaid.</p>
+  </div>
+</div>

--- a/spec/controllers/integrated/application_submitted_controller_spec.rb
+++ b/spec/controllers/integrated/application_submitted_controller_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe Integrated::ApplicationSubmittedController do
+  describe "edit" do
+    before do
+      allow(Integrated::ExportFactory).to receive(:create)
+    end
+
+    context "with a current application" do
+      it "queues an email with the application" do
+        current_app = create(:common_application)
+        session[:current_application_id] = current_app.id
+
+        get :edit
+
+        expect(Integrated::ExportFactory).to have_received(:create).
+          with(destination: :office_email, benefit_application: current_app)
+      end
+
+      it "clears current application from session" do
+        current_app = create(:common_application)
+        session[:current_application_id] = current_app.id
+
+        get :edit
+
+        expect(session[:current_application_id]).to be_nil
+      end
+    end
+
+    context "without a current application" do
+      it "redirects to first step path without sending email" do
+        get :edit
+
+        expect(response).to redirect_to(controller.first_step_path)
+        expect(Integrated::ExportFactory).to_not have_received(:create)
+      end
+    end
+  end
+
+  describe ".previous_path" do
+    it "returns nil" do
+      expect(controller.previous_path("foo")).to be_nil
+    end
+  end
+
+  describe ".next_path" do
+    it "returns the first step path" do
+      expect(controller.next_path).to eq(controller.first_step_path)
+    end
+  end
+end

--- a/spec/factories/exports.rb
+++ b/spec/factories/exports.rb
@@ -24,5 +24,13 @@ FactoryBot.define do
     trait :failed do
       status :failed
     end
+
+    trait :medicaid_application do
+      benefit_application { create(:medicaid_application) }
+    end
+
+    trait :common_application do
+      benefit_application { create(:common_application) }
+    end
   end
 end

--- a/spec/features/integrated_application_with_multiple_members_spec.rb
+++ b/spec/features/integrated_application_with_multiple_members_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.feature "Integrated application" do
+  include PdfHelper
+
   scenario "with multiple members", :js do
     visit before_you_start_sections_path
 
@@ -40,5 +42,19 @@ RSpec.feature "Integrated application" do
 
       proceed_with "Continue"
     end
+
+    on_page "Application Submitted" do
+      expect(page).to have_content(
+        "Congratulations",
+      )
+    end
+
+    emails = ActionMailer::Base.deliveries
+
+    raw_application_pdf = emails.last.attachments.first.body.raw_source
+    temp_file = write_raw_pdf_to_temp_file(source: raw_application_pdf)
+    pdf_values = filled_in_values(temp_file.path)
+
+    expect(pdf_values["legal_name"]).to include("Jessie Tester")
   end
 end

--- a/spec/features/snap_application_with_maximum_info_spec.rb
+++ b/spec/features/snap_application_with_maximum_info_spec.rb
@@ -260,9 +260,6 @@ accounts?",
     )
 
     emails = ActionMailer::Base.deliveries
-    expect(emails.count).to eq(2)
-    expect(emails.first.attachments.count).to eq(1)
-    expect(emails.second.attachments.count).to eq(1)
 
     raw_application_pdf = emails.first.attachments.first.body.raw_source
     temp_file = write_raw_pdf_to_temp_file(source: raw_application_pdf)

--- a/spec/jobs/integrated/office_email_application_job_spec.rb
+++ b/spec/jobs/integrated/office_email_application_job_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
-RSpec.describe Medicaid::OfficeEmailApplicationJob do
+RSpec.describe Integrated::OfficeEmailApplicationJob do
   describe "#perform" do
     it "sends an email" do
       tempfile = double("tempfile")
-      medicaid_application = double("medicaid_application",
+      integrated_application = instance_double(CommonApplication,
         id: 1,
         receiving_office_email: "official@stable.gov",
         primary_member: double("member", display_name: "Henry Horse"),
@@ -12,18 +12,18 @@ RSpec.describe Medicaid::OfficeEmailApplicationJob do
       export = double("export")
 
       allow(export).to receive(:execute).and_yield(
-        medicaid_application, double("logger").as_null_object
+        integrated_application, double("logger").as_null_object
       )
 
       fake_message = double("message", deliver: nil)
-      expect(ApplicationMailer).to receive(:office_medicaid_application_notification).
+      expect(ApplicationMailer).to receive(:office_integrated_application_notification).
         with(recipient_email: "official@stable.gov",
              applicant_name: "Henry Horse",
              application_pdf: tempfile) { fake_message }
 
       expect(fake_message).to receive(:deliver)
 
-      Medicaid::OfficeEmailApplicationJob.new.perform(export: export)
+      Integrated::OfficeEmailApplicationJob.new.perform(export: export)
     end
   end
 end

--- a/spec/mailers/application_mailer_spec.rb
+++ b/spec/mailers/application_mailer_spec.rb
@@ -130,4 +130,33 @@ RSpec.describe ApplicationMailer do
       end
     end
   end
+
+  describe ".office_integrated_application_notification" do
+    it "sets the correct headers" do
+      time = Time.utc(1999, 1, 1, 10, 5, 0)
+      Timecop.freeze(time) do
+        with_modified_env EMAIL_DOMAIN: "example.com" do
+          email = ApplicationMailer.office_integrated_application_notification(
+            application_pdf: application_pdf,
+            recipient_email: "user@example.com",
+            applicant_name: "Larry Lichen",
+          )
+
+          from_header = email.header.select do |header|
+            header.name == "From"
+          end.first.value
+
+          expect(from_header).to eq %("Michigan Benefits" <hello@example.com>)
+          expect(email.from).to eq(["hello@example.com"])
+          expect(email.to).to eq(["user@example.com"])
+          expect(email.subject).to eq(
+            "A new 1171 from Larry Lichen was submitted!",
+          )
+          expect(email.attachments[0].filename).to eq(
+            "1999-01-01 Larry Lichen 1171.pdf",
+          )
+        end
+      end
+    end
+  end
 end

--- a/spec/models/integrated/export_factory_spec.rb
+++ b/spec/models/integrated/export_factory_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Integrated::ExportFactory do
+  describe "#enqueue" do
+    it "sends email to office" do
+      allow(Integrated::OfficeEmailApplicationJob).to receive(:perform_later)
+      enqueuer = Integrated::ExportFactory.new
+      export = build(:export, :common_application, destination: :office_email)
+
+      enqueuer.enqueue(export)
+
+      expect(Integrated::OfficeEmailApplicationJob).
+        to have_received(:perform_later).
+        with(export: export)
+    end
+
+    it "transitions status" do
+      enqueuer = Integrated::ExportFactory.new
+      export = build(:export, :common_application, destination: :office_email)
+      enqueuer.enqueue(export)
+      expect(export.status).to eq :queued
+    end
+
+    it "persists the export if it hasn't been persisted yet" do
+      enqueuer = Integrated::ExportFactory.new
+      export = build(:export, :common_application, destination: :office_email)
+      enqueuer.enqueue(export)
+      expect(export).to be_persisted
+    end
+
+    it "raises an exception if export destination isn't supported" do
+      enqueuer = Integrated::ExportFactory.new
+      export = build(:export, :common_application, destination: :mi_bridges)
+
+      expect do
+        enqueuer.enqueue(export)
+      end.to raise_error(Integrated::ExportFactory::UnknownExportTypeError)
+    end
+  end
+end

--- a/spec/models/medicaid/export_factory_spec.rb
+++ b/spec/models/medicaid/export_factory_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Medicaid::ExportFactory do
     it "sends email to office" do
       allow(Medicaid::OfficeEmailApplicationJob).to receive(:perform_later)
       enqueuer = Medicaid::ExportFactory.new
-      export = build(:export, destination: :office_email)
+      export = build(:export, :medicaid_application, destination: :office_email)
 
       enqueuer.enqueue(export)
 
@@ -15,34 +15,17 @@ RSpec.describe Medicaid::ExportFactory do
     end
 
     it "transitions status" do
-      enqueuer = ExportFactory.new
-      export = build(:export)
+      enqueuer = Medicaid::ExportFactory.new
+      export = build(:export, :medicaid_application, destination: :office_email)
       enqueuer.enqueue(export)
       expect(export.status).to eq :queued
     end
 
     it "persists the export if it hasn't been persisted yet" do
-      enqueuer = ExportFactory.new
-      export = build(:export)
+      enqueuer = Medicaid::ExportFactory.new
+      export = build(:export, :medicaid_application, destination: :office_email)
       enqueuer.enqueue(export)
       expect(export).to be_persisted
-    end
-
-    it "raises an exception if the export isn't valid" do
-      allow(ClientEmailApplicationJob).to receive(:perform_later)
-      allow(SubmitApplicationViaMiBridgesJob).to receive(:perform_later)
-      enqueuer = ExportFactory.new
-
-      export = build(:export, destination: nil)
-
-      expect do
-        enqueuer.enqueue(export)
-      end.to raise_error(ActiveRecord::RecordInvalid)
-
-      expect(export).not_to be_persisted
-      expect(ClientEmailApplicationJob).not_to have_received(:perform_later)
-      expect(SubmitApplicationViaMiBridgesJob).
-        not_to have_received(:perform_later)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,6 +38,10 @@ RSpec.configure do |config|
     Delayed::Worker.delay_jobs = false
   end
 
+  config.after :all, type: :feature do
+    Delayed::Worker.delay_jobs = true
+  end
+
   config.after :each, type: :feature do
     ActionMailer::Base.deliveries.clear
   end


### PR DESCRIPTION
Disables back button and clears session once application has been submitted.

Also:
* Update some specs for ExportFactory that were testing the wrong class
* Stops draining workers after feature specs have been run
* Removes flaky delivery-checking in feature specs

[Finishes #154936523]

Signed-off-by: Luigi Ray-Montanez <luigi@codeforamerica.org>