### PR TITLE
Ask applicant whether they are a Michigan resident

### DIFF
--- a/app/controllers/integrated/reside_in_state_controller.rb
+++ b/app/controllers/integrated/reside_in_state_controller.rb
@@ -1,0 +1,11 @@
+module Integrated
+  class ResideInStateController < FormsController
+    def update_models
+      if current_application.navigator.present?
+        current_application.navigator.update(form_params)
+      else
+        current_application.create_navigator(form_params)
+      end
+    end
+  end
+end

--- a/app/controllers/integrated/reside_out_of_state_controller.rb
+++ b/app/controllers/integrated/reside_out_of_state_controller.rb
@@ -1,0 +1,11 @@
+module Integrated
+  class ResideOutOfStateController < FormsController
+    def self.skip?(application)
+      application.navigator.resides_in_state?
+    end
+
+    def form_class
+      NullStep
+    end
+  end
+end

--- a/app/forms/form_navigation.rb
+++ b/app/forms/form_navigation.rb
@@ -3,6 +3,8 @@ class FormNavigation
     "Introduction" => [
       Integrated::BeforeYouStartController,
       Integrated::IntroduceYourselfController,
+      Integrated::ResideInStateController,
+      Integrated::ResideOutOfStateController,
       Integrated::BenefitsIntroController,
       Integrated::ApplicationSubmittedController,
     ],

--- a/app/forms/reside_in_state_form.rb
+++ b/app/forms/reside_in_state_form.rb
@@ -1,0 +1,5 @@
+class ResideInStateForm < Step
+  form_attributes(
+    :resides_in_state,
+  )
+end

--- a/app/models/application_navigator.rb
+++ b/app/models/application_navigator.rb
@@ -1,0 +1,3 @@
+class ApplicationNavigator < ApplicationRecord
+  belongs_to :common_application
+end

--- a/app/models/common_application.rb
+++ b/app/models/common_application.rb
@@ -2,7 +2,15 @@ class CommonApplication < ApplicationRecord
   include CommonBenefitApplication
   include Submittable
 
-  has_many :members, class_name: "HouseholdMember", foreign_key: "common_application_id"
+  has_one :navigator,
+    class_name: "ApplicationNavigator",
+    foreign_key: "common_application_id",
+    dependent: :destroy
+
+  has_many :members,
+    class_name: "HouseholdMember",
+    foreign_key: "common_application_id",
+    dependent: :destroy
 
   def pdf
     @_pdf ||= ApplicationPdfAssembler.new(benefit_application: self).run

--- a/app/views/integrated/_yes_no_form.html.erb
+++ b/app/views/integrated/_yes_no_form.html.erb
@@ -1,0 +1,35 @@
+<div class="form-card__content">
+  <footer class="form-card__buttons">
+    <%= form_for form,
+      as: :form,
+      builder: MbFormBuilder,
+      url: current_path,
+      method: :put,
+      namespace: "no" do |f| %>
+
+      <%= f.hidden_field field, value: false %>
+
+      <button
+        type="submit"
+        class="button button--nav button--full-mobile">
+          No
+      </button>
+    <% end %>
+
+    <%= form_for form,
+      as: :form,
+      builder: MbFormBuilder,
+      url: current_path,
+      method: :put,
+      namespace: "yes" do |f| %>
+
+      <%= f.hidden_field field, value: true %>
+
+      <button
+        type="submit"
+        class="button button--nav button--cta button--full-mobile">
+          Yes
+      </button>
+    <% end %>
+  </footer>
+</div>

--- a/app/views/integrated/reside_in_state/edit.html.erb
+++ b/app/views/integrated/reside_in_state/edit.html.erb
@@ -1,0 +1,15 @@
+<% content_for :header_title, "Introduction" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <h1 class="form-card__title">Do you currently reside in Michigan?</h1>
+
+    <p class="text--help text--centered">
+      If not, we’ll help point you in the right direction. However, this
+      application for health coverage is specifically for current residents of
+      Michigan.
+    </p>
+  </header>
+
+  <%= render "integrated/yes_no_form", form: @form, field: :resides_in_state %>
+</div>

--- a/app/views/integrated/reside_out_of_state/edit.html.erb
+++ b/app/views/integrated/reside_out_of_state/edit.html.erb
@@ -1,0 +1,16 @@
+<% content_for :header_title, "Introduction" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">Visit Healthcare.gov to apply for health coverage.</div>
+    <p class="text--help text--centered">
+      This site is for Michigan residents only. To apply for coverage in your state:
+    </p>
+  </header>
+
+  <footer class="form-card__button_centered">
+    <a href="https://www.healthcare.gov/medicaid-chip/getting-medicaid-chip/" class="button button--nav  button--cta button--full-mobile">
+      Visit Healthcare.gov
+    </a>
+  </footer>
+</div>

--- a/db/migrate/20180227221714_create_application_navigators.rb
+++ b/db/migrate/20180227221714_create_application_navigators.rb
@@ -1,0 +1,9 @@
+class CreateApplicationNavigators < ActiveRecord::Migration[5.1]
+  def change
+    create_table :application_navigators do |t|
+      t.references :common_application, index: true
+      t.boolean :resides_in_state, default: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222180237) do
+ActiveRecord::Schema.define(version: 20180227221714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,13 @@ ActiveRecord::Schema.define(version: 20180222180237) do
     t.index ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
   end
 
+  create_table "application_navigators", force: :cascade do |t|
+    t.bigint "common_application_id"
+    t.datetime "created_at", null: false
+    t.boolean "resides_in_state", default: true
+    t.datetime "updated_at", null: false
+    t.index ["common_application_id"], name: "index_application_navigators_on_common_application_id"
+  end
 
   create_table "common_applications", force: :cascade do |t|
     t.datetime "created_at", null: false

--- a/spec/controllers/integrated/reside_in_state_controller_spec.rb
+++ b/spec/controllers/integrated/reside_in_state_controller_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe Integrated::ResideInStateController do
+  describe "update" do
+    context "with valid params" do
+      let(:valid_params) do
+        {
+          form: {
+            resides_in_state: "true",
+          },
+        }
+      end
+
+      context "when navigator does not yet exist" do
+        it "creates navigator with correct attributes" do
+          current_app = create(:common_application)
+          session[:current_application_id] = current_app.id
+
+          put :update, params: valid_params
+
+          navigator = current_app.navigator.reload
+          expect(navigator.resides_in_state?).to eq(true)
+        end
+      end
+
+      context "when navigator already exists" do
+        it "updates navigator with attribute" do
+          navigator = create(:application_navigator, resides_in_state: false)
+          current_app = create(:common_application, navigator: navigator)
+          session[:current_application_id] = current_app.id
+
+          put :update, params: valid_params
+
+          navigator = current_app.navigator.reload
+          expect(navigator.resides_in_state?).to eq(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/integrated/reside_out_of_state_controller_spec.rb
+++ b/spec/controllers/integrated/reside_out_of_state_controller_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe Integrated::ResideOutOfStateController do
+  describe "skip?" do
+    context "when applicant is a resident of state" do
+      it "returns true" do
+        navigator = build(:application_navigator, resides_in_state: true)
+        application = create(:common_application, navigator: navigator)
+
+        skip_step = Integrated::ResideOutOfStateController.skip?(application)
+        expect(skip_step).to eq(true)
+      end
+    end
+
+    context "when applicant is resident of another state" do
+      it "returns false" do
+        navigator = build(:application_navigator, resides_in_state: false)
+        application = create(:common_application, navigator: navigator)
+
+        skip_step = Integrated::ResideOutOfStateController.skip?(application)
+        expect(skip_step).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/factories/application_navigators.rb
+++ b/spec/factories/application_navigators.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :application_navigator do
+  end
+end

--- a/spec/features/integrated_application_non_resident_spec.rb
+++ b/spec/features/integrated_application_non_resident_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Integrated application" do
   include PdfHelper
 
-  scenario "with multiple members", :js do
+  scenario "where applicant is not a resident", :js do
     visit before_you_start_sections_path
 
     on_page "Introduction" do
@@ -30,27 +30,11 @@ RSpec.feature "Integrated application" do
     on_page "Introduction" do
       expect(page).to have_content("Do you currently reside in Michigan?")
 
-      proceed_with "Yes"
+      proceed_with "No"
     end
 
     on_page "Introduction" do
-      expect(page).to have_content("Every family is different")
-
-      proceed_with "Continue"
+      expect(page).to have_content("Visit Healthcare.gov to apply for health coverage.")
     end
-
-    on_page "Application Submitted" do
-      expect(page).to have_content(
-        "Congratulations",
-      )
-    end
-
-    emails = ActionMailer::Base.deliveries
-
-    raw_application_pdf = emails.last.attachments.first.body.raw_source
-    temp_file = write_raw_pdf_to_temp_file(source: raw_application_pdf)
-    pdf_values = filled_in_values(temp_file.path)
-
-    expect(pdf_values["legal_name"]).to include("Jessie Tester")
   end
 end


### PR DESCRIPTION
And directs them to Healthcare.gov if they aren't.

Also creates 'ApplicationNavigator' object, which is intended to store application state and metadata. Should not be used to fill out final form. For now, we're trying out adding database defaults to direct application flow.

[#155521552]

Signed-off-by: Luigi Ray-Montanez <luigi@codeforamerica.org>