### PR TITLE
Ask if applicant has previously received benefits

### DIFF
--- a/app/controllers/integrated/introduce_yourself_controller.rb
+++ b/app/controllers/integrated/introduce_yourself_controller.rb
@@ -4,21 +4,30 @@ module Integrated
 
     def update_models
       if current_application
-        current_application.primary_member.update(form_params)
+        current_application.primary_member.update(member_params)
+        current_application.update(application_params)
       else
-        application = CommonApplication.create
-        application.members.create(form_params)
+        application = CommonApplication.create(application_params)
+        application.members.create(member_params)
         session[:current_application_id] = application.id
       end
     end
 
     private
 
+    def member_params
+      form_params.except(*form_class.application_attributes)
+    end
+
+    def application_params
+      form_params.slice(*form_class.application_attributes)
+    end
+
     def existing_attributes
       if current_application
-        HashWithIndifferentAccess.new(
-          current_application.primary_member.attributes,
-        )
+        attributes = current_application.attributes.
+          merge(current_application.primary_member.attributes)
+        HashWithIndifferentAccess.new(attributes)
       else
         {}
       end

--- a/app/forms/introduce_yourself_form.rb
+++ b/app/forms/introduce_yourself_form.rb
@@ -1,12 +1,20 @@
 class IntroduceYourselfForm < Step
   include MultiparameterAttributeAssignment
 
-  form_attributes(
-    :first_name,
-    :last_name,
-    :birthday,
-    :sex,
-  )
+  def self.application_attributes
+    [:previously_received_assistance]
+  end
+
+  def self.member_attributes
+    %i[
+      first_name
+      last_name
+      birthday
+      sex
+    ]
+  end
+
+  form_attributes(*(member_attributes + application_attributes))
 
   validates :first_name,
     presence: { message: "Make sure to provide a first name" }

--- a/app/models/common_application.rb
+++ b/app/models/common_application.rb
@@ -12,6 +12,9 @@ class CommonApplication < ApplicationRecord
     foreign_key: "common_application_id",
     dependent: :destroy
 
+  enum previously_received_assistance: { unfilled: 0, yes: 1, no: 2 },
+       _prefix: :previously_received_assistance
+
   def pdf
     @_pdf ||= ApplicationPdfAssembler.new(benefit_application: self).run
   end

--- a/app/models/concerns/pdf_attributes.rb
+++ b/app/models/concerns/pdf_attributes.rb
@@ -1,7 +1,4 @@
 module PdfAttributes
-  CIRCLED = "O".freeze
-  UNDERLINED = "------------".freeze
-
   def to_h
     attributes.
       reduce { |accum, attribute_hash| accum.merge(attribute_hash) }.
@@ -12,10 +9,6 @@ module PdfAttributes
     if statement
       "Yes"
     end
-  end
-
-  def circle_if_true(statement)
-    CIRCLED if statement
   end
 
   def yes_no(statement)

--- a/app/models/integrated/pdf_attributes.rb
+++ b/app/models/integrated/pdf_attributes.rb
@@ -1,0 +1,22 @@
+module Integrated
+  module PdfAttributes
+    CIRCLED = "O".freeze
+    UNDERLINED = "------------".freeze
+
+    def yes_no_or_unfilled(yes: nil, no: nil)
+      if yes
+        "Yes"
+      elsif no
+        "No"
+      end
+    end
+
+    def circle_if_true(statement)
+      CIRCLED if statement
+    end
+
+    def mmddyyyy_date(date)
+      date&.strftime("%m/%d/%Y")
+    end
+  end
+end

--- a/app/pdf_components/assistance_application_form.rb
+++ b/app/pdf_components/assistance_application_form.rb
@@ -1,5 +1,5 @@
 class AssistanceApplicationForm
-  include PdfAttributes
+  include Integrated::PdfAttributes
 
   def initialize(benefit_application)
     @benefit_application = benefit_application
@@ -30,6 +30,10 @@ class AssistanceApplicationForm
     {
       applying_for_food: "Yes",
       legal_name: benefit_application.display_name,
+      received_assistance: yes_no_or_unfilled(
+        yes: benefit_application.previously_received_assistance_yes?,
+        no: benefit_application.previously_received_assistance_no?,
+      ),
     }
   end
 
@@ -38,7 +42,7 @@ class AssistanceApplicationForm
       first_member_dob: mmddyyyy_date(benefit_application.primary_member.birthday),
       first_member_male: circle_if_true(benefit_application.primary_member.sex_male?),
       first_member_female: circle_if_true(benefit_application.primary_member.sex_female?),
-      first_member_requesting_food: PdfAttributes::UNDERLINED,
+      first_member_requesting_food: Integrated::PdfAttributes::UNDERLINED,
     }
   end
 end

--- a/app/views/integrated/introduce_yourself/edit.html.erb
+++ b/app/views/integrated/introduce_yourself/edit.html.erb
@@ -25,6 +25,11 @@
           help_text: "As it appears on your ID",
           layout: "inline" %>
 
+        <%= f.mb_radio_set :previously_received_assistance,
+          label_text: "Have you received assistance in Michigan in the past (or currently)?",
+          collection: [{ value: :yes, label: "Yes" }, { value: :no, label: "No" }],
+          layout: "inline" %>
+
       <%= render "integrated/next_step" %>
     <% end %>
   </div>

--- a/db/migrate/20180228001545_add_previously_received_assistance_to_common_application.rb
+++ b/db/migrate/20180228001545_add_previously_received_assistance_to_common_application.rb
@@ -1,0 +1,10 @@
+class AddPreviouslyReceivedAssistanceToCommonApplication < ActiveRecord::Migration[5.1]
+  def change
+    add_column :common_applications, :previously_received_assistance, :integer
+    change_column_null :common_applications, :previously_received_assistance, false, 0
+    change_column_default :common_applications, :previously_received_assistance, from: nil, to: 0
+
+    change_column_null :household_members, :sex, false, 0
+    change_column_default :household_members, :sex, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180227221714) do
+ActiveRecord::Schema.define(version: 20180228001545) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 20180227221714) do
 
   create_table "common_applications", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "previously_received_assistance", default: 0, null: false
     t.datetime "updated_at", null: false
   end
 
@@ -146,7 +147,7 @@ ActiveRecord::Schema.define(version: 20180227221714) do
     t.datetime "created_at", null: false
     t.string "first_name"
     t.string "last_name"
-    t.integer "sex"
+    t.integer "sex", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["common_application_id"], name: "index_household_members_on_common_application_id"
   end

--- a/spec/controllers/integrated/introduce_yourself_controller_spec.rb
+++ b/spec/controllers/integrated/introduce_yourself_controller_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Integrated::IntroduceYourselfController do
     context "with a current application" do
       it "assigns existing attributes" do
         current_app = create(:common_application,
+          previously_received_assistance: "yes",
           members: [build(:household_member, first_name: "Juan")])
         session[:current_application_id] = current_app.id
 
@@ -13,6 +14,7 @@ RSpec.describe Integrated::IntroduceYourselfController do
         form = assigns(:form)
 
         expect(form.first_name).to eq("Juan")
+        expect(form.previously_received_assistance).to eq("yes")
       end
     end
 
@@ -36,6 +38,7 @@ RSpec.describe Integrated::IntroduceYourselfController do
             "birthday(2i)" => "1",
             "birthday(1i)" => "1950",
             sex: "male",
+            previously_received_assistance: "yes",
           },
         }
       end
@@ -47,6 +50,8 @@ RSpec.describe Integrated::IntroduceYourselfController do
           current_app = CommonApplication.find(session[:current_application_id])
 
           primary_member = current_app.primary_member
+
+          expect(current_app.previously_received_assistance).to eq("yes")
           expect(primary_member.first_name).to eq("Gary")
           expect(primary_member.last_name).to eq("McTester")
           expect(primary_member.sex).to eq("male")
@@ -63,7 +68,10 @@ RSpec.describe Integrated::IntroduceYourselfController do
 
           put :update, params: valid_params
 
+          current_app.reload
+
           expect(current_app.primary_member.first_name).to eq("Gary")
+          expect(current_app.previously_received_assistance).to eq("yes")
         end
       end
     end

--- a/spec/features/integrated_application_with_multiple_members_spec.rb
+++ b/spec/features/integrated_application_with_multiple_members_spec.rb
@@ -24,6 +24,11 @@ RSpec.feature "Integrated application" do
 
       select_radio(question: "What's your sex?", answer: "Female")
 
+      select_radio(
+        question: "Have you received assistance in Michigan in the past (or currently)?",
+        answer: "Yes",
+      )
+
       proceed_with "Continue"
     end
 

--- a/spec/pdf_components/assistance_application_form_spec.rb
+++ b/spec/pdf_components/assistance_application_form_spec.rb
@@ -31,6 +31,8 @@ RSpec.describe AssistanceApplicationForm do
     let(:common_application) do
       instance_double("common_application",
         display_name: "Octopus Cuttlefish",
+        previously_received_assistance_yes?: true,
+        previously_received_assistance_no?: false,
         primary_member: primary_member)
     end
 
@@ -42,15 +44,16 @@ RSpec.describe AssistanceApplicationForm do
       it "defaults to requesting food" do
         expect(subject).to include(
           applying_for_food: "Yes",
-          first_member_requesting_food: PdfAttributes::UNDERLINED,
+          first_member_requesting_food: Integrated::PdfAttributes::UNDERLINED,
         )
       end
 
       it "returns a hash with basic information" do
         expect(subject).to include(
           legal_name: "Octopus Cuttlefish",
+          received_assistance: "Yes",
           first_member_dob: "10/18/1991",
-          first_member_male: PdfAttributes::CIRCLED,
+          first_member_male: Integrated::PdfAttributes::CIRCLED,
           first_member_female: nil,
         )
       end


### PR DESCRIPTION
* Creates special Integrated::PdfAttributes for filling out the new 1171 (old was getting messy, and there's not a ton of overlap with the existing PdfAttributes class)
* Creates database defaults for enums, and sets them to 'unfilled'
* Fills out PDF radio only if field has been answered

[Finishes #155532806]