### PR TITLE
Block access to `/sections` and subpaths on production

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,14 +73,16 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :sections, controller: :forms, only: %i[index show] do
-    collection do
-      FormNavigation.all.each do |controller_class|
-        { get: :edit, put: :update }.each do |method, action|
-          match "/#{controller_class.to_param}",
-            action: action,
-            controller: controller_class.controller_path,
-            via: method
+  unless Rails.env.production?
+    resources :sections, controller: :forms, only: %i[index show] do
+      collection do
+        FormNavigation.all.each do |controller_class|
+          { get: :edit, put: :update }.each do |method, action|
+            match "/#{controller_class.to_param}",
+              action: action,
+              controller: controller_class.controller_path,
+              via: method
+          end
         end
       end
     end

--- a/spec/routing/forms_routing_spec.rb
+++ b/spec/routing/forms_routing_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe FormsController do
+  describe "in production" do
+    before do
+      allow(Rails).to receive(:env).
+        and_return(ActiveSupport::StringInquirer.new("production"))
+
+      MichiganBenefits::Application.reload_routes!
+    end
+
+    after do
+      allow(Rails).to receive(:env).and_call_original
+      MichiganBenefits::Application.reload_routes!
+    end
+
+    it "rejects sections path and subpaths" do
+      expect(get: "/sections").not_to be_routable
+      expect(get: "/sections/before-you-start").not_to be_routable
+    end
+  end
+end


### PR DESCRIPTION
Since we're actually submitting applications at this point but the flow isn't finished, let's entirely block access to the path in production to prevent potential fake sends.

The paths will still be accessible on staging, test, and development environments.

[Finishes #155633310]