### PR TITLE
Refactor 'member_attributes' and 'application_attributes'

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -91,10 +91,19 @@ class FormsController < ApplicationController
   end
 
   def member_params
-    form_params.except(*form_class.application_attributes)
+    filter_params(form_class.member_attributes)
   end
 
   def application_params
-    form_params.slice(*form_class.application_attributes)
+    filter_params(form_class.application_attributes)
+  end
+
+  def filter_params(attributes)
+    return unless attributes.present?
+    form_params.select do |key, _|
+      attributes.any? do |attr|
+        key.match(/^#{attr}(\(.+\))?\z/) # Match single and multi-attribute keys
+      end
+    end
   end
 end

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -1,0 +1,37 @@
+class Form
+  include ActiveModel::Model
+  include ActiveModel::AttributeAssignment
+  include ActiveModel::Validations::Callbacks
+
+  class_attribute :attribute_names
+
+  class <<self
+    def set_application_attributes(*application_attributes)
+      @application_attributes = application_attributes
+      form_attributes(application_attributes)
+    end
+
+    def set_member_attributes(*member_attributes)
+      @member_attributes = member_attributes
+      form_attributes(member_attributes)
+    end
+
+    def application_attributes
+      @application_attributes || []
+    end
+
+    def member_attributes
+      @member_attributes || []
+    end
+
+    private
+
+    def form_attributes(attribute_names)
+      self.attribute_names = (self.application_attributes + self.member_attributes)
+
+      attribute_strings = attribute_names.map(&:to_s)
+
+      attr_accessor(*attribute_strings)
+    end
+  end
+end

--- a/app/forms/introduce_yourself_form.rb
+++ b/app/forms/introduce_yourself_form.rb
@@ -1,20 +1,14 @@
-class IntroduceYourselfForm < Step
+class IntroduceYourselfForm < Form
   include MultiparameterAttributeAssignment
 
-  def self.application_attributes
-    [:previously_received_assistance]
-  end
+  set_application_attributes(:previously_received_assistance)
 
-  def self.member_attributes
-    %i[
-      first_name
-      last_name
-      birthday
-      sex
-    ]
-  end
-
-  form_attributes(*(member_attributes + application_attributes))
+  set_member_attributes(
+    :first_name,
+    :last_name,
+    :birthday,
+    :sex,
+  )
 
   validates :first_name,
     presence: { message: "Make sure to provide a first name" }

--- a/app/forms/living_situation_form.rb
+++ b/app/forms/living_situation_form.rb
@@ -1,9 +1,5 @@
-class LivingSituationForm < Step
-  def self.application_attributes
-    [:living_situation]
-  end
-
-  form_attributes(*application_attributes)
+class LivingSituationForm < Form
+  set_application_attributes(:living_situation)
 
   validates :living_situation, inclusion: {
     in: %w(stable_address temporary_address homeless),

--- a/app/forms/reside_in_state_form.rb
+++ b/app/forms/reside_in_state_form.rb
@@ -1,5 +1,5 @@
-class ResideInStateForm < Step
-  form_attributes(
+class ResideInStateForm < Form
+  set_application_attributes(
     :resides_in_state,
   )
 end

--- a/app/steps/step.rb
+++ b/app/steps/step.rb
@@ -15,7 +15,5 @@ class Step
 
       attr_accessor(*attribute_strings)
     end
-
-    alias_method :form_attributes, :step_attributes
   end
 end

--- a/spec/forms/form_spec.rb
+++ b/spec/forms/form_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Form do
+  describe ".application_attributes" do
+    it "defaults to an empty array" do
+      class TestFormOne < Form; end
+      expect(TestFormOne.application_attributes).to eq([])
+    end
+
+    it "creates a getter that returns passed in attributes as keys" do
+      Form.set_application_attributes(:foo, :bar)
+
+      expect(Form.application_attributes).to match_array(
+        %i[
+          foo
+          bar
+        ],
+      )
+    end
+  end
+
+  describe ".member_attributes" do
+    it "defaults to an empty array" do
+      class TestFormTwo < Form; end
+
+      expect(TestFormTwo.member_attributes).to eq([])
+    end
+
+    it "creates a getter that returns passed in attributes as keys" do
+      Form.set_member_attributes(:foo, :bar)
+
+      expect(Form.member_attributes).to match_array(
+        %i[
+          foo
+          bar
+        ],
+      )
+    end
+  end
+
+  describe ".attribute_names" do
+    it "returns what is set by application and member attributes" do
+      Form.set_application_attributes(:foo)
+      Form.set_member_attributes(:bar)
+
+      expect(Form.attribute_names).to match_array(%i[foo bar])
+    end
+  end
+end

--- a/spec/steps/step_spec.rb
+++ b/spec/steps/step_spec.rb
@@ -28,16 +28,6 @@ RSpec.describe Step, type: :model do
       expect(TestStep.new.methods).to include(*expected_methods)
     end
 
-    it "aliases step_attributes as form_attributes" do
-      class TestStep < Step
-        form_attributes(:foo, :bar)
-      end
-
-      expected_methods = %i[foo foo= bar bar=]
-
-      expect(TestStep.new.methods).to include(*expected_methods)
-    end
-
     it "exposes attribute names on the class" do
       class TestStep < Step
         step_attributes(:foo, :bar)


### PR DESCRIPTION
Creates new 'form' class (based off of 'step') that uses a combination of simple 'member_attributes' and 'application_attributes' to construct one set of common form attributes. Getters for these methods can then be used to filter params as appropriate for their respective models.

For now, 'member_attributes' and 'application_attributes' only accept keys or strings as attributes, unlike 'step_attributes' method, which accepts hashes. We can add this in later as we need it.

[#155522274]

Note: this is step one of the feature (have more on my local machine that I'll push to a WIP on another branch), but thought it'd be useful to get your thoughts sooner rather than later!