### PR TITLE
Space buttons properly, add arrows, fix layouts

### DIFF
--- a/app/assets/stylesheets/michigan-benefits/organisms/_form-card.scss
+++ b/app/assets/stylesheets/michigan-benefits/organisms/_form-card.scss
@@ -19,7 +19,6 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  padding-top: $padding-med;
 
   @include media($mobile-up) {
     flex-direction: row;
@@ -29,7 +28,6 @@
 .form-card__button_right {
   display: flex;
   justify-content: flex-end;
-  padding-top: $padding-med;
 }
 
 .form-card__button_centered {

--- a/app/views/integrated/_next_step.html.erb
+++ b/app/views/integrated/_next_step.html.erb
@@ -1,5 +1,6 @@
 <footer class="form-card__button_right">
   <button class="button button--nav  button--cta button--full-mobile" type="submit">
     <%= local_assigns[:button_label].presence || "Continue" %>
+    <i class="button__icon icon-arrow_forward"></i>
   </button>
 </footer>

--- a/app/views/medicaid/contact_introduction/edit.html.erb
+++ b/app/views/medicaid/contact_introduction/edit.html.erb
@@ -18,9 +18,9 @@
     </p>
   </div>
 
-  <footer class="form-card__button_right">
+  <div class="form-card__button_right form-card__footer">
     <%= link_to next_path, class: "button button--nav  button--cta button--full-mobile" do %>
       Next
     <% end %>
-  </footer>
+  </div>
 </div>

--- a/app/views/medicaid/contact_social_security/edit.html.erb
+++ b/app/views/medicaid/contact_social_security/edit.html.erb
@@ -5,43 +5,45 @@
     <div class="form-card__title">Tell us your Social Security Number</div>
   </header>
 
-  <div class="form-card__content">
-    <%= form_for @step,
-      as: :step,
-      builder: MbFormBuilder,
-      url: current_path,
-      method: :put do |f| %>
+  <%= form_for @step,
+    as: :step,
+    builder: MbFormBuilder,
+    url: current_path,
+    method: :put do |f| %>
+    <div class="form-card__content">
 
-      <% @step.members.each do |member| %>
-        <div class="form-group">
-          <%= f.fields_for('members[]', member) do |ff| %>
-            <div class="household-member-group" data-member-name="<%= member.display_name %>">
+        <% @step.members.each do |member| %>
+          <div class="form-group">
+            <%= f.fields_for('members[]', member) do |ff| %>
+              <div class="household-member-group" data-member-name="<%= member.display_name %>">
 
-              <% if !single_member_household? -%>
-                <p class="text--section-header">
-                  <%= member.display_name %>
-                </p>
-              <% end -%>
+                <% if !single_member_household? -%>
+                  <p class="text--section-header">
+                    <%= member.display_name %>
+                  </p>
+                <% end -%>
 
-              <%= ff.mb_input_field :ssn,
-                "Social Security Number",
-                type: :tel,
-                options: { maxlength: 9 },
-                help_text: "If you don’t know it you can skip this"
-              %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
+                <%= ff.mb_input_field :ssn,
+                  "Social Security Number",
+                  type: :tel,
+                  options: { maxlength: 9 },
+                  help_text: "If you don’t know it you can skip this"
+                %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
 
-      <p class='text--secure'>
-        <i class='illustration illustration--safety'></i>
-        Social security numbers help ensure you receive the correct benefits.
-        MDHHS maintains strict security guidelines to protect the identities
-        of our residents.
-      </p>
+        <p class='text--secure'>
+          <i class='illustration illustration--safety'></i>
+          Social security numbers help ensure you receive the correct benefits.
+          MDHHS maintains strict security guidelines to protect the identities
+          of our residents.
+        </p>
+    </div>
 
+    <div class="form-card__footer">
       <%= render "medicaid/next_step" %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/medicaid/contact_ss_intro/edit.html.erb
+++ b/app/views/medicaid/contact_ss_intro/edit.html.erb
@@ -19,5 +19,7 @@
     </p>
   </div>
 
-  <%= render 'shared/yes_no_form', step: @step, field: :submit_ssn %>
+  <div class="form-card__footer">
+    <%= render 'shared/yes_no_form', step: @step, field: :submit_ssn %>
+  </div>
 </div>

--- a/app/views/medicaid/contact_text_messages/edit.html.erb
+++ b/app/views/medicaid/contact_text_messages/edit.html.erb
@@ -5,20 +5,22 @@
     <div class="form-card__title">What is the best number for you to receive text messages?</div>
   </header>
 
-  <div class="form-card__content">
-    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_phone_number_field :sms_phone_number,
-        "Phone number",
-        type: :tel,
-        autofocus: true,
-        options: { maxlength: 10 },
-        help_text: "No dashes or spaces (example: 5555555555).",
-        optional: true %>
+  <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+    <div class="form-card__content">
+        <%= f.mb_phone_number_field :sms_phone_number,
+          "Phone number",
+          type: :tel,
+          autofocus: true,
+          options: { maxlength: 10 },
+          help_text: "No dashes or spaces (example: 5555555555).",
+          optional: true %>
 
-      <%= f.mb_checkbox :sms_consented,
-        "I'd like to receive SMS reminders at key moments in the enrollment process." %>
+        <%= f.mb_checkbox :sms_consented,
+          "I'd like to receive SMS reminders at key moments in the enrollment process." %>
+    </div>
 
+    <div class="form-card__footer">
       <%= render "medicaid/next_step" %>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/medicaid/health_introduction/edit.html.erb
+++ b/app/views/medicaid/health_introduction/edit.html.erb
@@ -17,9 +17,9 @@
     coverage you need.
   </div>
 
-  <footer class="form-card__button_right">
+  <div class="form-card__button_right form-card__footer">
     <%= link_to next_path, class: "button button--nav  button--cta button--full-mobile" do %>
       Next
     <% end %>
-  </footer>
+  </div>
 </div>

--- a/app/views/medicaid/income_introduction/edit.html.erb
+++ b/app/views/medicaid/income_introduction/edit.html.erb
@@ -24,9 +24,9 @@
     </ul>
   </div>
 
-  <footer class="form-card__button_right">
+  <div class="form-card__button_right form-card__footer">
     <%= link_to next_path, class: "button button--nav  button--cta button--full-mobile" do %>
       Next
     <% end %>
-  </footer>
+  </div>
 </div>

--- a/app/views/medicaid/intro_name/edit.html.erb
+++ b/app/views/medicaid/intro_name/edit.html.erb
@@ -7,27 +7,30 @@
     <div class="form-card__title">Let’s start with some information about you</div>
   </header>
 
-  <div class="form-card__content">
-    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_input_field :first_name,
-        "What is your first name?",
-        autofocus: true %>
-      <%= f.mb_input_field :last_name, "What is your last name?" %>
-      <%= f.mb_radio_set :sex,
-        label_text: "What is your gender?",
-        collection: [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
-        help_text: "As it appears on official government documents",
-        layout: "inline" %>
-      <%= f.mb_date_select :birthday,
-        "Date of birth",
-        options: {
-          start_year: 1900,
-          end_year: Time.now.year,
-          default: Date.new(1990,1,15),
-          order: [:month, :day, :year],
-        } %>
+  <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+    <div class="form-card__content">
 
-        <%= render "medicaid/next_step" %>
-    <% end %>
-  </div>
+        <%= f.mb_input_field :first_name,
+          "What is your first name?",
+          autofocus: true %>
+        <%= f.mb_input_field :last_name, "What is your last name?" %>
+        <%= f.mb_radio_set :sex,
+          label_text: "What is your gender?",
+          collection: [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
+          help_text: "As it appears on official government documents",
+          layout: "inline" %>
+        <%= f.mb_date_select :birthday,
+          "Date of birth",
+          options: {
+            start_year: 1900,
+            end_year: Time.now.year,
+            default: Date.new(1990,1,15),
+            order: [:month, :day, :year],
+          } %>
+    </div>
+
+    <div class="form-card__footer">
+      <%= render "medicaid/next_step" %>
+    </div>
+  <% end %>
 </div>

--- a/app/views/medicaid/paperwork_and_legal_introduction/edit.html.erb
+++ b/app/views/medicaid/paperwork_and_legal_introduction/edit.html.erb
@@ -15,9 +15,9 @@
     </p>
   </div>
 
-  <footer class="form-card__button_right">
+  <div class="form-card__button_right form-card__footer">
     <%= link_to next_path, class: "button button--nav  button--cta button--full-mobile" do %>
       Next
     <% end %>
-  </footer>
+  </div>
 </div>

--- a/app/views/medicaid/tax_introduction/edit.html.erb
+++ b/app/views/medicaid/tax_introduction/edit.html.erb
@@ -23,9 +23,9 @@
     </ul>
   </div>
 
-  <footer class="form-card__button_right">
+  <div class="form-card__button_right form-card__footer">
     <%= link_to next_path, class: "button button--nav  button--cta button--full-mobile" do %>
       Next
     <% end %>
-  </footer>
+  </div>
 </div>

--- a/app/views/medicaid/welcome/edit.html.erb
+++ b/app/views/medicaid/welcome/edit.html.erb
@@ -15,8 +15,10 @@
     </p>
   </div>
 
-  <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-    <%= f.hidden_field :office_location, value: @step.office_location %>
-    <%= render "medicaid/next_step" %>
-  <% end %>
+  <div class="form-card__footer">
+    <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
+      <%= f.hidden_field :office_location, value: @step.office_location %>
+      <%= render "medicaid/next_step" %>
+    <% end %>
+  </div>
 </div>

--- a/app/views/shared/_yes_no_form.html.erb
+++ b/app/views/shared/_yes_no_form.html.erb
@@ -7,16 +7,19 @@
   <div class="form-card__content">
     <footer class="form-card__buttons">
       <%= f.hidden_field(field, class: 'boolean-answer') %>
+      <div>
+        <button
+          type="submit"
+          class="button button--nav button--full-mobile"
+          data-no> No </button>
+      </div>
 
-      <button
-        type="submit"
-        class="button button--nav button--full-mobile"
-        data-no> No </button>
-
-      <button
-        type="submit"
-        class="button button--nav button--cta button--full-mobile"
-        data-yes> Yes </button>
+      <div>
+        <button
+          type="submit"
+          class="button button--nav button--cta button--full-mobile"
+          data-yes> Yes </button>
+      </div>
     </footer>
   </div>
 


### PR DESCRIPTION
_Too much space_
![screen shot 2018-03-08 at 10 00 02 am](https://user-images.githubusercontent.com/451510/37167717-94acb3ec-22b7-11e8-98c1-dd7790058378.png)

_Just right_
![screen shot 2018-03-08 at 9 59 57 am](https://user-images.githubusercontent.com/451510/37167719-94c622a0-22b7-11e8-9c93-228613a869de.png)

Also fixes a bunch of pages in medicaid that broke with the newly-adjusted spacing, for example:

![screen shot 2018-03-08 at 11 26 22 am](https://user-images.githubusercontent.com/451510/37173444-755bc94a-22c8-11e8-8b82-29dbd8f64382.png)

![screen shot 2018-03-08 at 11 26 29 am](https://user-images.githubusercontent.com/451510/37173443-75417d1a-22c8-11e8-82b0-fa948d6a5d3a.png)
