### PR TITLE
Choose household members requesting food assistance.

### DIFF
--- a/app/controllers/integrated/food_assistance_controller.rb
+++ b/app/controllers/integrated/food_assistance_controller.rb
@@ -1,0 +1,37 @@
+module Integrated
+  class FoodAssistanceController < FormsController
+    def self.skip?(current_application)
+      if current_application.members.count == 1 || current_application.unstable_housing?
+        current_application.members.each { |member| member.update(requesting_food: "yes") }
+        true
+      else
+        false
+      end
+    end
+
+    def edit
+      if members.first.requesting_food_unfilled?
+        members.first.update(requesting_food: "yes")
+      end
+      @form = form_class.new(members: members)
+    end
+
+    def update_models
+      members.each do |member|
+        attrs = params.dig(:form, :members, member.to_param)
+        member.assign_attributes(attrs.permit(form_class.member_attributes))
+      end
+      ActiveRecord::Base.transaction { members.each(&:save!) }
+    end
+
+    private
+
+    def members
+      @_members ||= current_application.members
+    end
+
+    def form_params
+      params.fetch(:form, {}).permit(members: {})
+    end
+  end
+end

--- a/app/forms/food_assistance_form.rb
+++ b/app/forms/food_assistance_form.rb
@@ -1,0 +1,4 @@
+class FoodAssistanceForm < Form
+  set_application_attributes(:members)
+  set_member_attributes(:requesting_food)
+end

--- a/app/forms/form_navigation.rb
+++ b/app/forms/form_navigation.rb
@@ -8,6 +8,7 @@ class FormNavigation
       Integrated::LivingSituationController,
       Integrated::BenefitsIntroController,
       Integrated::HouseholdMembersOverviewController,
+      Integrated::FoodAssistanceController,
       Integrated::ApplicationSubmittedController,
     ],
   }.freeze

--- a/app/models/common_application.rb
+++ b/app/models/common_application.rb
@@ -18,6 +18,10 @@ class CommonApplication < ApplicationRecord
 
   enum living_situation: { unknown_living_situation: 0, stable_address: 1, temporary_address: 2, homeless: 3 }
 
+  def unstable_housing?
+    temporary_address? || homeless?
+  end
+
   def pdf
     @_pdf ||= ApplicationPdfAssembler.new(benefit_application: self).run
   end

--- a/app/models/household_member.rb
+++ b/app/models/household_member.rb
@@ -15,6 +15,8 @@ class HouseholdMember < ApplicationRecord
     other_relation: 8,
   }, _prefix: :is
 
+  enum requesting_food: { unfilled: 0, yes: 1, no: 2 }, _prefix: :requesting_food
+
   RELATIONSHIP_LABELS_AND_KEYS = [
     ["Choose one", "unknown_relation"],
     ["Roommate", "roommate"],

--- a/app/models/integrated/pdf_attributes.rb
+++ b/app/models/integrated/pdf_attributes.rb
@@ -11,6 +11,10 @@ module Integrated
       end
     end
 
+    def underline_if_true(statement)
+      UNDERLINED if statement
+    end
+
     def circle_if_true(statement)
       CIRCLED if statement
     end

--- a/app/pdf_components/assistance_application_form.rb
+++ b/app/pdf_components/assistance_application_form.rb
@@ -53,7 +53,7 @@ class AssistanceApplicationForm
       hash[:"#{prefix}dob"] = mmddyyyy_date(member.birthday)
       hash[:"#{prefix}male"] = circle_if_true(member.sex_male?)
       hash[:"#{prefix}female"] = circle_if_true(member.sex_female?)
-      hash[:"#{prefix}requesting_food"] = Integrated::PdfAttributes::UNDERLINED
+      hash[:"#{prefix}requesting_food"] = underline_if_true(member.requesting_food_yes?)
     end
     if benefit_application.members.count > 5
       hash[:household_added_notes] = "Yes"
@@ -63,7 +63,9 @@ class AssistanceApplicationForm
         hash[:notes] += "Legal name: #{extra_member.display_name}, "
         hash[:notes] += "Sex: #{extra_member.sex.titleize}, "
         hash[:notes] += "DOB: #{mmddyyyy_date(extra_member.birthday)}, "
-        hash[:notes] += "Applying for: Food\n"
+        if extra_member.requesting_food_yes?
+          hash[:notes] += "Applying for: Food\n"
+        end
       end
     end
     hash

--- a/app/views/integrated/food_assistance/edit.html.erb
+++ b/app/views/integrated/food_assistance/edit.html.erb
@@ -1,0 +1,29 @@
+<% content_for :header_title, "Your Household" %>
+
+<% content_for :form_card_header do %>
+  <h1 class="form-card__title">
+    Who do you want to include on your Food Assistance application?
+  </h1>
+
+  <p class="text--help text--centered">
+    Below is a list of the people you currently live with. Choose who needs Food Assistance.
+  </p>
+<% end %>
+
+<% content_for :form_card_body do %>
+  <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
+    <fieldset class="input-group">
+      <legend class="sr-only" id="requesting_food__legend">
+        Choose who needs Food Assistance.
+      </legend>
+      <% @form.members.each do |member| %>
+        <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
+          <%= ff.mb_checkbox :requesting_food,
+                             member.display_name,
+                             legend_id: "requesting_food__legend",
+                             options: { checked_value: "yes", unchecked_value: "no" } %>
+        <% end %>
+      <% end %>
+    </fieldset>
+  <% end %>
+<% end %>

--- a/db/migrate/20180308214556_add_requesting_food_to_household_member.rb
+++ b/db/migrate/20180308214556_add_requesting_food_to_household_member.rb
@@ -1,0 +1,6 @@
+class AddRequestingFoodToHouseholdMember < ActiveRecord::Migration[5.1]
+  def change
+    add_column :household_members, :requesting_food, :integer
+    change_column_default :household_members, :requesting_food, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180305192048) do
+ActiveRecord::Schema.define(version: 20180308214556) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -149,6 +149,7 @@ ActiveRecord::Schema.define(version: 20180305192048) do
     t.string "first_name"
     t.string "last_name"
     t.integer "relationship", default: 0
+    t.integer "requesting_food", default: 0
     t.integer "sex", default: 0, null: false
     t.datetime "updated_at", null: false
     t.index ["common_application_id"], name: "index_household_members_on_common_application_id"

--- a/spec/controllers/integrated/food_assistance_controller_spec.rb
+++ b/spec/controllers/integrated/food_assistance_controller_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe Integrated::FoodAssistanceController do
+  describe "#skip?" do
+    context "when housing is stable" do
+      context "for single member household" do
+        it "returns true" do
+          application = create(:common_application,
+            living_situation: "stable_address",
+            members: [
+              build(:household_member),
+            ])
+          expect(described_class.skip?(application)).to eq(true)
+          expect(application.primary_member.requesting_food_yes?).to be_truthy
+        end
+      end
+
+      context "for multi-member household" do
+        it "returns false" do
+          application = create(:common_application,
+            living_situation: "stable_address",
+            members: [
+              build(:household_member),
+              build(:household_member),
+            ])
+          expect(described_class.skip?(application)).to eq(false)
+        end
+      end
+    end
+
+    context "when housing is unstable" do
+      it "returns true" do
+        application = create(:common_application,
+          living_situation: "temporary_address",
+          members: [
+            build(:household_member),
+            build(:household_member),
+          ])
+        expect(described_class.skip?(application)).to eq(true)
+        application.reload
+        expect(application.members[0].requesting_food_yes?).to be_truthy
+        expect(application.members[1].requesting_food_yes?).to be_truthy
+      end
+    end
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      it "marks members as requesting food" do
+        current_app = create(:common_application,
+                             members: [create(:household_member), create(:household_member)])
+        session[:current_application_id] = current_app.id
+
+        member1 = current_app.members[0]
+        member2 = current_app.members[1]
+
+        valid_params = {
+          form: {
+            members: {
+              member1.id => { "requesting_food" => "yes" },
+              member2.id => { "requesting_food" => "no" },
+            },
+          },
+        }
+
+        put :update, params: valid_params
+
+        current_app.reload
+
+        expect(current_app.primary_member.requesting_food_yes?).to be_truthy
+        expect(current_app.members[1].requesting_food_no?).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/features/integrated_application_with_multiple_members_spec.rb
+++ b/spec/features/integrated_application_with_multiple_members_spec.rb
@@ -46,7 +46,7 @@ RSpec.feature "Integrated application" do
 
       select_radio(
         question: "What's your current living situation?",
-        answer: "Temporary address",
+        answer: "Stable address",
       )
 
       proceed_with "Continue"
@@ -60,8 +60,9 @@ RSpec.feature "Integrated application" do
 
     on_page "Your Household" do
       expect(page).to have_content(
-        "Who do you want to include on your Food Assistance application?",
+        "Who do you currently live with?",
       )
+      expect(page).to have_content("Jessie Tester (that’s you!)")
 
       click_on "Add a member"
     end
@@ -124,13 +125,27 @@ RSpec.feature "Integrated application" do
 
       on_page "Your Household" do
         expect(page).to have_content(
-          "Who do you want to include on your Food Assistance application?",
+          "Who do you currently live with?",
         )
 
         expect(page).to have_content("#{member[:first_name]} #{member[:last_name]}")
 
         member == members.last ? click_on("Continue") : click_on("Add a member")
       end
+    end
+
+    on_page "Your Household" do
+      expect(page).to have_content(
+        "Who do you want to include on your Food Assistance application?",
+      )
+
+      # Jessie Tester checked by default
+      check "Jonny Tester"
+      check "Jackie Tester"
+      check "Joe Schmoe"
+      check "Pupper McDog"
+
+      proceed_with "Continue"
     end
 
     on_page "Application Submitted" do
@@ -146,7 +161,7 @@ RSpec.feature "Integrated application" do
     pdf_values = filled_in_values(temp_file.path)
 
     expect(pdf_values["legal_name"]).to include("Jessie Tester")
-    expect(pdf_values["is_homeless"]).to eq("Yes")
+    expect(pdf_values["is_homeless"]).to eq("No")
     expect(pdf_values["dob"]).to eq("01/01/1969")
     expect(pdf_values["received_assistance"]).to eq("Yes")
     expect(pdf_values["applying_for_food"]).to eq("Yes")
@@ -177,7 +192,7 @@ RSpec.feature "Integrated application" do
     expect(pdf_values["fifth_member_legal_name"]).to include("Apples McMackintosh")
     expect(pdf_values["fifth_member_male"]).to eq(CIRCLED)
     expect(pdf_values["fifth_member_dob"]).to eq("")
-    expect(pdf_values["fifth_member_requesting_food"]).to eq(UNDERLINED)
+    expect(pdf_values["fifth_member_requesting_food"]).to eq("")
 
     expect(pdf_values["household_added_notes"]).to eq("Yes")
     expect(pdf_values["notes"]).to include("Additional Household Members:")

--- a/spec/features/integrated_application_with_single_member_spec.rb
+++ b/spec/features/integrated_application_with_single_member_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.feature "Integrated application" do
   include PdfHelper
 
-  scenario "with multiple members", :js do
+  scenario "with one member", :js do
     visit before_you_start_sections_path
 
     on_page "Introduction" do
@@ -43,7 +43,7 @@ RSpec.feature "Integrated application" do
 
       select_radio(
         question: "What's your current living situation?",
-        answer: "Stable address",
+        answer: "Temporary address",
       )
 
       proceed_with "Continue"
@@ -57,9 +57,8 @@ RSpec.feature "Integrated application" do
 
     on_page "Your Household" do
       expect(page).to have_content(
-        "Who do you currently live with?",
+        "Who do you want to include on your Food Assistance application?",
       )
-      expect(page).to have_content("Jessie Tester (that’s you!)")
 
       proceed_with "Continue"
     end

--- a/spec/models/common_application_spec.rb
+++ b/spec/models/common_application_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe CommonApplication do
+  describe "#unstable_housing?" do
+    context "with stable housing" do
+      it "returns false" do
+        application = build(:common_application, living_situation: "stable_address")
+        expect(application.unstable_housing?).to eq(false)
+      end
+    end
+
+    context "when homeless" do
+      it "returns true" do
+        application = build(:common_application, living_situation: "homeless")
+        expect(application.unstable_housing?).to eq(true)
+      end
+    end
+
+    context "with temporary housing" do
+      it "returns true" do
+        application = build(:common_application, living_situation: "temporary_address")
+        expect(application.unstable_housing?).to eq(true)
+      end
+    end
+
+    context "when not answered" do
+      it "returns false" do
+        application = build(:common_application)
+        expect(application.unstable_housing?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/pdf_components/assistance_application_form_spec.rb
+++ b/spec/pdf_components/assistance_application_form_spec.rb
@@ -28,7 +28,8 @@ RSpec.describe AssistanceApplicationForm do
           relationship_label: "You",
           birthday: DateTime.new(1991, 10, 18),
           sex_male?: true,
-          sex_female?: false)
+          sex_female?: false,
+          requesting_food_yes?: true)
       end
 
       let(:common_application) do
@@ -74,7 +75,8 @@ RSpec.describe AssistanceApplicationForm do
                         relationship_label: "You",
                         birthday: DateTime.new(1991, 10, 18),
                         sex_male?: true,
-                        sex_female?: false)
+                        sex_female?: false,
+                        requesting_food_yes?: true)
       end
 
       let(:common_application) do
@@ -92,45 +94,39 @@ RSpec.describe AssistanceApplicationForm do
                                     relationship_label: "Spouse",
                                     birthday: DateTime.new(1991, 10, 18),
                                     sex_male?: true,
-                                    sex_female?: false),
+                                    sex_female?: false,
+                                    requesting_food_yes?: true),
                                   instance_double("household_member",
                                     display_name: "Coral Eel",
                                     relationship_label: "Parent",
                                     birthday: DateTime.new(1991, 10, 18),
                                     sex_male?: true,
-                                    sex_female?: false),
+                                    sex_female?: false,
+                                    requesting_food_yes?: true),
                                   instance_double("household_member",
                                     display_name: "Snail Squid",
                                     relationship_label: "Parent",
                                     birthday: DateTime.new(1991, 10, 18),
                                     sex_male?: true,
-                                    sex_female?: false),
+                                    sex_female?: false,
+                                    requesting_food_yes?: true),
                                   instance_double("household_member",
                                     display_name: "Flounder Halibut",
                                     relationship_label: "Sibling",
                                     birthday: DateTime.new(1991, 10, 18),
                                     sex_male?: true,
-                                    sex_female?: false),
+                                    sex_female?: false,
+                                    requesting_food_yes?: false),
                                   instance_double("household_member",
                                     display_name: "Willy Whale",
                                     relationship_label: "Child",
                                     birthday: DateTime.new(1995, 10, 18),
-                                    sex: "male")])
+                                    sex: "male",
+                                    requesting_food_yes?: true)])
       end
 
       let(:attributes) do
         AssistanceApplicationForm.new(common_application).attributes
-      end
-
-      it "defaults to requesting food" do
-        expect(attributes).to include(
-          applying_for_food: "Yes",
-          first_member_requesting_food: Integrated::PdfAttributes::UNDERLINED,
-          second_member_requesting_food: Integrated::PdfAttributes::UNDERLINED,
-          third_member_requesting_food: Integrated::PdfAttributes::UNDERLINED,
-          fourth_member_requesting_food: Integrated::PdfAttributes::UNDERLINED,
-          fifth_member_requesting_food: Integrated::PdfAttributes::UNDERLINED,
-        )
       end
 
       it "returns a hash with basic information" do


### PR DESCRIPTION
![your household 2018-03-09 18-48-49](https://user-images.githubusercontent.com/417/37235253-3f9c46b4-23cb-11e8-90d7-b635501ec9b9.png)


When unstable housing, the checkbox screen is skipped, and
all members of the "household" are set to request food.

[#155522792]

Signed-off-by: Christa Harstock <christa@codeforamerica.org>
Co-authored-by: Christa Harstock <christa@codeforamerica.org>