### PR TITLE
Simple generator for section

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,13 @@ module MichiganBenefits
 
     config.filter_parameters += [:ssn]
     config.middleware.insert_after Warden::Manager, DelayedJobWebLogger
+
+    config.generators do |g|
+      g.orm             :active_record
+      g.template_engine :erb
+      g.test_framework  :rspec, fixture: true
+      g.stylesheets     false
+      g.javascripts     false
+    end
   end
 end

--- a/lib/generators/section/USAGE
+++ b/lib/generators/section/USAGE
@@ -1,0 +1,15 @@
+Description:
+    Create files for adding a new section to the integrated benefit application.
+
+Example:
+    rails generate section FoodAssistance
+
+    This will create:
+        app/forms/food_assistance_form.rb
+        app/controllers/integrated/food_assistance_controller.rb
+        app/views/integrated/food_assistance/edit.html.erb
+        spec/forms/food_assistance_form_spec.rb
+        spec/controllers/integrated/food_assistance_controller_spec.rb
+
+    This will add:
+        * TBD

--- a/lib/generators/section/section_generator.rb
+++ b/lib/generators/section/section_generator.rb
@@ -1,0 +1,43 @@
+class SectionGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('../templates', __FILE__)
+  class_option :doc, type: :boolean, default: true, desc: "Include documentation."
+
+  def generate_model
+    generate_form_model
+    generate_form_controller
+    generate_form_view
+    generate_form_model_spec
+    generate_form_controller_spec
+
+    puts "\nDone generating the #{model} section!"
+    puts "Be sure to add #{model}Controller in the desired application order in `form_navigation.rb`"
+  end
+
+  private
+
+  alias_method :model, :name
+
+  def generate_form_model
+    template 'form_model.template.rb', "app/forms/#{model.underscore}_form.rb"
+  end
+
+  def generate_form_model_spec
+    template 'form_model_spec.template.rb',
+      "spec/forms/#{model.underscore}_form_spec.rb"
+  end
+
+  def generate_form_controller
+    template 'form_controller.template.rb',
+      "app/controllers/integrated/#{model.underscore}_controller.rb"
+  end
+
+  def generate_form_controller_spec
+    template 'form_controller_spec.template.rb',
+      "spec/controllers/integrated/#{model.underscore}_controller_spec.rb"
+  end
+
+  def generate_form_view
+    template 'form_view.template.erb',
+      "app/views/integrated/#{model.underscore}/edit.html.erb"
+  end
+end

--- a/lib/generators/section/templates/form_controller.template.rb
+++ b/lib/generators/section/templates/form_controller.template.rb
@@ -1,0 +1,20 @@
+module Integrated
+  class <%= model.camelcase %>Controller < FormsController
+    <%- if options.doc? -%>
+    # If updating models, uncomment the following and modify required logic:
+    #
+    #   def update_models
+    #     current_application.primary_member.update(member_params)
+    #     current_application.update(application_params)
+    #   end
+    #
+    # If no database update is needed, uncomment the following `form_class` method
+    # to override the form class (otherwise form class will
+    # default to <%= model.underscore %>Form):
+    #
+    #   def form_class
+    #     NullStep
+    #   end
+    <%- end -%>
+  end
+end

--- a/lib/generators/section/templates/form_controller_spec.template.rb
+++ b/lib/generators/section/templates/form_controller_spec.template.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Integrated::<%= model.camelcase %>Controller do
+  describe "edit" do
+    context "with a current application" do
+      xit "assigns existing attributes" do
+        current_app = create(:common_application)
+        session[:current_application_id] = current_app.id
+
+        get :edit
+
+        form = assigns(:form)
+
+        # expectation
+      end
+    end
+
+    context "without a current application" do
+      it "renders edit" do
+        get :edit
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:valid_params) do
+        { }
+      end
+
+      xit "updates the models" do
+        current_app = create(:common_application)
+        session[:current_application_id] = current_app.id
+
+        put :update, params: valid_params
+
+        current_app.reload
+
+        # expectation
+      end
+    end
+
+    context "with invalid params" do
+      let(:invalid_params) do
+        { }
+      end
+
+      xit "renders edit without updating" do
+        current_app = create(:common_application)
+        session[:current_application_id] = current_app.id
+
+        put :update, params: invalid_params
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/lib/generators/section/templates/form_model.template.rb
+++ b/lib/generators/section/templates/form_model.template.rb
@@ -1,0 +1,27 @@
+class <%= model.camelcase %>Form < Form
+
+  <%- if options.doc? -%>
+  # Whitelist top-level parameter names for CommonApplication, e.g.
+  #
+  #   given params: { form: {
+  #      living_situation: "stable_housing",
+  #      members: { "1" => { first_name: "Christa" } }
+  #   }}
+  #
+  #   set_application_attributes(:living_situation, :members)
+  #
+  # Delete the method if you aren't updating the CommonApplication.
+  <%- end -%>
+  set_application_attributes()
+
+  <%- if options.doc? -%>
+  # Whitelist top-level parameter names for a single HouseholdMember, e.g.
+  #
+  #   given params: { form: { first_name: "value", last_name: "value" } }
+  #
+  #   set_member_attributes(:first_name, :last_name)
+  #
+  # Delete the method if you aren't updating a single HouseholdMember.
+  <%- end -%>
+  set_member_attributes()
+end

--- a/lib/generators/section/templates/form_model_spec.template.rb
+++ b/lib/generators/section/templates/form_model_spec.template.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe <%= model.camelcase %>Form do
+  describe "validations" do
+    <%- if options.doc? -%>
+    # Add any required validations here
+    <%- end -%>
+    xit "requires some attribute" do
+      form = <%= "#{model.camelcase}Form".classify %>.new
+
+      expect(form).not_to be_valid
+      expect(form.errors[:some_attribute]).to be_present
+    end
+  end
+end

--- a/lib/generators/section/templates/form_view.template.erb
+++ b/lib/generators/section/templates/form_view.template.erb
@@ -1,0 +1,15 @@
+<%% content_for :header_title, "Template" %>
+
+<%% content_for :form_card_header do %>
+    <h1 class="form-card__title">
+      I'm a template!
+    </h1>
+    <p class="text--centered text--help">
+      Help me!
+    </p>
+<%% end %>
+
+<%% content_for :form_card_body do %>
+    <%%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
+    <%% end %>
+<%% end %>


### PR DESCRIPTION
By running `rails g section SectionName`, we can now generate a minimal scaffolding for what we need (form class and spec, form controller and spec, view). 

Usage instructions here:

```
Usage:
  rails generate section NAME [options]

Options:
  [--skip-namespace], [--no-skip-namespace]  # Skip namespace (affects only isolated applications)
  [--doc], [--no-doc]                        # Include documentation.
                                             # Default: true

Runtime options:
  -f, [--force]                    # Overwrite files that already exist
  -p, [--pretend], [--no-pretend]  # Run but do not make any changes
  -q, [--quiet], [--no-quiet]      # Suppress status output
  -s, [--skip], [--no-skip]        # Skip files that already exist

Description:
    Create files for adding a new section to the integrated benefit application.

Example:
    rails generate section FoodAssistance

    This will create:
        app/forms/food_assistance_form.rb
        app/controllers/integrated/food_assistance_controller.rb
        app/views/integrated/food_assistance/edit.html.erb
        spec/forms/food_assistance_form_spec.rb
        spec/controllers/integrated/food_assistance_controller_spec.rb

    This will add:
        * TBD

```

[Finishes #155712084]