### PR TITLE
Enter birthday as text instead of select dropdown

### DIFF
--- a/app/assets/stylesheets/atoms/_form-elements.scss
+++ b/app/assets/stylesheets/atoms/_form-elements.scss
@@ -22,6 +22,10 @@ label {
   }
 }
 
+.form-subquestion {
+  display: block;
+}
+
 .text-input {
   display: block;
   width: 100%;

--- a/app/assets/stylesheets/atoms/_form-widths.scss
+++ b/app/assets/stylesheets/atoms/_form-widths.scss
@@ -33,3 +33,15 @@
 .form-width--searchbar {
   max-width: $width-form-searchbar;
 }
+
+.form-width--year {
+  max-width: $width-form-year;
+}
+
+.form-width--month {
+  max-width: $width-form-month;
+}
+
+.form-width--day {
+  max-width: $width-form-day;
+}

--- a/app/assets/stylesheets/atoms/_typography.scss
+++ b/app/assets/stylesheets/atoms/_typography.scss
@@ -101,6 +101,7 @@ ol, ul {
 }
 
 .text--error {
+  display: block;
   font-size: $font-size-small;
   line-height: $line-height-normal;
   color: $color-red;

--- a/app/assets/stylesheets/atoms/_variables.scss
+++ b/app/assets/stylesheets/atoms/_variables.scss
@@ -79,6 +79,9 @@ $width-form-name:       12em;
 $width-form-zip:        5em;
 $width-form-ssn:        7em;
 $width-form-searchbar:  30em;
+$width-form-year:       6em;
+$width-form-month:      3em;
+$width-form-day:        3em;
 
 
 // Form Colors

--- a/app/assets/stylesheets/molecules/_form-molecules.scss
+++ b/app/assets/stylesheets/molecules/_form-molecules.scss
@@ -17,6 +17,11 @@
     display: inline-block;
     margin-right: .5em;
   }
+  .form-group {
+    display: inline-block;
+    margin: 0 0.5em 0 0;
+    width: auto;
+  }
   margin-bottom: .5em;
 }
 

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -106,4 +106,13 @@ class FormsController < ApplicationController
       end
     end
   end
+
+  def combine_birthday_fields(data)
+    year = data.delete(:birthday_year)
+    month = data.delete(:birthday_month)
+    day = data.delete(:birthday_day)
+    if [year, month, day].all? &:present?
+      data[:birthday] = DateTime.new(year.to_i, month.to_i, day.to_i)
+    end
+  end
 end

--- a/app/controllers/integrated/add_household_member_controller.rb
+++ b/app/controllers/integrated/add_household_member_controller.rb
@@ -13,16 +13,5 @@ module Integrated
     def next_path
       household_members_overview_sections_path
     end
-
-    private
-
-    def combine_birthday_fields(data)
-      year = data.delete(:birthday_year)
-      month = data.delete(:birthday_month)
-      day = data.delete(:birthday_day)
-      if [year, month, day].all? &:present?
-        data[:birthday] = DateTime.new(year.to_i, month.to_i, day.to_i)
-      end
-    end
   end
 end

--- a/app/controllers/integrated/add_household_member_controller.rb
+++ b/app/controllers/integrated/add_household_member_controller.rb
@@ -1,7 +1,9 @@
 module Integrated
   class AddHouseholdMemberController < FormsController
     def update_models
-      current_application.members.create(member_params)
+      member_data = member_params
+      combine_birthday_fields(member_data)
+      current_application.members.create(member_data)
     end
 
     def previous_path(*_args)
@@ -10,6 +12,17 @@ module Integrated
 
     def next_path
       household_members_overview_sections_path
+    end
+
+    private
+
+    def combine_birthday_fields(data)
+      year = data.delete(:birthday_year)
+      month = data.delete(:birthday_month)
+      day = data.delete(:birthday_day)
+      if [year, month, day].all? &:present?
+        data[:birthday] = DateTime.new(year.to_i, month.to_i, day.to_i)
+      end
     end
   end
 end

--- a/app/controllers/integrated/introduce_yourself_controller.rb
+++ b/app/controllers/integrated/introduce_yourself_controller.rb
@@ -8,7 +8,7 @@ module Integrated
         requesting_food: "yes",
         buy_and_prepare_food_together: "yes",
       )
-
+      combine_birthday_fields(member_data)
       if current_application
         current_application.primary_member.update(member_data)
         current_application.update(application_params)
@@ -21,10 +21,21 @@ module Integrated
 
     private
 
+    def combine_birthday_fields(data)
+      data[:birthday] = DateTime.new(
+        data.delete(:birthday_year).to_i,
+        data.delete(:birthday_month).to_i,
+        data.delete(:birthday_day).to_i,
+      )
+    end
+
     def existing_attributes
       if current_application
         attributes = current_application.attributes.
           merge(current_application.primary_member.attributes)
+        %i[year month day].each do |sym|
+          attributes["birthday_#{sym}"] = current_application.primary_member.birthday.try(sym)
+        end
         HashWithIndifferentAccess.new(attributes)
       else
         {}

--- a/app/controllers/integrated/introduce_yourself_controller.rb
+++ b/app/controllers/integrated/introduce_yourself_controller.rb
@@ -21,14 +21,6 @@ module Integrated
 
     private
 
-    def combine_birthday_fields(data)
-      data[:birthday] = DateTime.new(
-        data.delete(:birthday_year).to_i,
-        data.delete(:birthday_month).to_i,
-        data.delete(:birthday_day).to_i,
-      )
-    end
-
     def existing_attributes
       if current_application
         attributes = current_application.attributes.

--- a/app/forms/add_household_member_form.rb
+++ b/app/forms/add_household_member_form.rb
@@ -1,4 +1,6 @@
 class AddHouseholdMemberForm < Form
+  include BirthdayValidations
+
   set_member_attributes(
     :first_name,
     :last_name,
@@ -16,15 +18,4 @@ class AddHouseholdMemberForm < Form
     presence: { message: "Make sure to provide a last name" }
 
   validate :birthday_must_be_valid_date
-
-  def birthday_must_be_valid_date
-    all_present = %i[birthday_year birthday_month birthday_day].all? { |att| send(att).present? }
-    if all_present
-      begin
-        DateTime.new(birthday_year.to_i, birthday_month.to_i, birthday_day.to_i)
-      rescue ArgumentError
-        errors.add(:birthday, "Make sure to provide a real birth date")
-      end
-    end
-  end
 end

--- a/app/forms/add_household_member_form.rb
+++ b/app/forms/add_household_member_form.rb
@@ -1,10 +1,10 @@
 class AddHouseholdMemberForm < Form
-  include MultiparameterAttributeAssignment
-
   set_member_attributes(
     :first_name,
     :last_name,
-    :birthday,
+    :birthday_year,
+    :birthday_month,
+    :birthday_day,
     :sex,
     :relationship,
   )
@@ -15,8 +15,16 @@ class AddHouseholdMemberForm < Form
   validates :last_name,
     presence: { message: "Make sure to provide a last name" }
 
-  # https://github.com/rails/rails/pull/8189#issuecomment-10329403
-  def class_for_attribute(attr)
-    return Date if attr == "birthday"
+  validate :birthday_must_be_valid_date
+
+  def birthday_must_be_valid_date
+    all_present = %i[birthday_year birthday_month birthday_day].all? { |att| send(att).present? }
+    if all_present
+      begin
+        DateTime.new(birthday_year.to_i, birthday_month.to_i, birthday_day.to_i)
+      rescue ArgumentError
+        errors.add(:birthday, "Make sure to provide a real birth date")
+      end
+    end
   end
 end

--- a/app/forms/introduce_yourself_form.rb
+++ b/app/forms/introduce_yourself_form.rb
@@ -1,4 +1,6 @@
 class IntroduceYourselfForm < Form
+  include BirthdayValidations
+
   set_application_attributes(:previously_received_assistance)
 
   set_member_attributes(
@@ -21,18 +23,6 @@ class IntroduceYourselfForm < Form
     message: "Make sure to answer this question",
   }
 
-  validate :birthday_must_be_present_and_valid_date
-
-  def birthday_must_be_present_and_valid_date
-    all_present = %i[birthday_year birthday_month birthday_day].all? { |att| send(att).present? }
-    if all_present
-      begin
-        DateTime.new(birthday_year.to_i, birthday_month.to_i, birthday_day.to_i)
-      rescue ArgumentError
-        errors.add(:birthday, "Make sure to provide a real birthday")
-      end
-    else
-      errors.add(:birthday, "Make sure to provide a full birthday")
-    end
-  end
+  validate :birthday_must_be_present
+  validate :birthday_must_be_valid_date
 end

--- a/app/forms/introduce_yourself_form.rb
+++ b/app/forms/introduce_yourself_form.rb
@@ -1,12 +1,12 @@
 class IntroduceYourselfForm < Form
-  include MultiparameterAttributeAssignment
-
   set_application_attributes(:previously_received_assistance)
 
   set_member_attributes(
     :first_name,
     :last_name,
-    :birthday,
+    :birthday_year,
+    :birthday_month,
+    :birthday_day,
     :sex,
   )
 
@@ -21,11 +21,18 @@ class IntroduceYourselfForm < Form
     message: "Make sure to answer this question",
   }
 
-  validates :birthday,
-    presence: { message: "Make sure to provide a birthday" }
+  validate :birthday_must_be_present_and_valid_date
 
-  # https://github.com/rails/rails/pull/8189#issuecomment-10329403
-  def class_for_attribute(attr)
-    return Date if attr == "birthday"
+  def birthday_must_be_present_and_valid_date
+    all_present = %i[birthday_year birthday_month birthday_day].all? { |att| send(att).present? }
+    if all_present
+      begin
+        DateTime.new(birthday_year.to_i, birthday_month.to_i, birthday_day.to_i)
+      rescue ArgumentError
+        errors.add(:birthday, "Make sure to provide a real birthday")
+      end
+    else
+      errors.add(:birthday, "Make sure to provide a full birthday")
+    end
   end
 end

--- a/app/models/concerns/birthday_validations.rb
+++ b/app/models/concerns/birthday_validations.rb
@@ -1,0 +1,21 @@
+module BirthdayValidations
+  def birthday_present?
+    %i[birthday_year birthday_month birthday_day].all? { |att| send(att).present? }
+  end
+
+  def birthday_must_be_present
+    unless birthday_present?
+      errors.add(:birthday, I18n.t(:full_birthday))
+    end
+  end
+
+  def birthday_must_be_valid_date
+    if birthday_present? && !errors.added?(:birthday, I18n.t(:full_birthday))
+      begin
+        DateTime.new(birthday_year.to_i, birthday_month.to_i, birthday_day.to_i)
+      rescue ArgumentError
+        errors.add(:birthday, I18n.t(:real_birthday))
+      end
+    end
+  end
+end

--- a/app/views/integrated/add_household_member/edit.html.erb
+++ b/app/views/integrated/add_household_member/edit.html.erb
@@ -16,12 +16,12 @@
                          "What's their first name?",
                          autofocus: true %>
     <%= f.mb_input_field :last_name, "What's their last name?" %>
-    <%= f.mb_date_select :birthday,
+    <%= f.mb_date_input :birthday,
                          "When is their birthday?",
+                         help_text: "For example: 4 28 1970",
                          options: {
                              start_year: 1900,
                              end_year: Time.now.year,
-                             order: [:month, :day, :year]
                          } %>
     <%= f.mb_radio_set :sex,
                        label_text: "What's their sex?",

--- a/app/views/integrated/introduce_yourself/edit.html.erb
+++ b/app/views/integrated/introduce_yourself/edit.html.erb
@@ -8,13 +8,12 @@
       "What's your first name?",
       autofocus: true %>
     <%= f.mb_input_field :last_name, "What's your last name?" %>
-    <%= f.mb_date_select :birthday,
+    <%= f.mb_date_input :birthday,
       "When is your birthday?",
+      help_text: "For example: 4 28 1970",
       options: {
         start_year: 1900,
         end_year: Time.now.year,
-        default: Date.new(1990,1,15),
-        order: [:month, :day, :year],
       } %>
     <%= f.mb_radio_set :sex,
       label_text: "What's your sex?",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -188,3 +188,5 @@ en:
       member:
         ssn: SSN?
   real_phone_number: "This number looks wrong. Please use a real phone number."
+  full_birthday: "Make sure to provide a full birthday."
+  real_birthday: "Make sure to provide a real birthday."

--- a/spec/controllers/integrated/add_household_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_household_member_controller_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Integrated::AddHouseholdMemberController do
           form: {
             first_name: "Gary",
             last_name: "McTester",
-            "birthday(3i)" => "31",
-            "birthday(2i)" => "1",
-            "birthday(1i)" => "1950",
+            birthday_day: "31",
+            birthday_month: "1",
+            birthday_year: "1950",
             sex: "male",
             relationship: "roommate",
           },

--- a/spec/controllers/integrated/add_household_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_household_member_controller_spec.rb
@@ -34,6 +34,35 @@ RSpec.describe Integrated::AddHouseholdMemberController do
         expect(new_member.relationship).to eq("roommate")
       end
     end
+
+    context "with minimal valid params" do
+      let(:valid_params) do
+        {
+          form: {
+            first_name: "Gary",
+            last_name: "McTester",
+          },
+        }
+      end
+
+      it "creates a new member with given information" do
+        current_app = create(:common_application,
+          members: [create(:household_member, first_name: "Juan")])
+        session[:current_application_id] = current_app.id
+
+        put :update, params: valid_params
+
+        current_app.reload
+
+        new_member = current_app.members.last
+        expect(new_member.first_name).to eq("Gary")
+        expect(new_member.last_name).to eq("McTester")
+        expect(new_member.birthday).to be_nil
+        expect(new_member.sex).to eq("unfilled")
+        expect(new_member.relationship).to eq("unknown_relation")
+      end
+
+    end
   end
 
   describe ".previous_path" do

--- a/spec/controllers/integrated/buy_and_prepare_food_with_other_person_controller_spec.rb
+++ b/spec/controllers/integrated/buy_and_prepare_food_with_other_person_controller_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Integrated::BuyAndPrepareFoodWithOtherPersonController do
 
           expect do
             put :update, params: { form: { buy_and_prepare_food_together: "yes" } }
-          end.to_not change { current_app.primary_member.buy_and_prepare_food_together }
+          end.to_not(change { current_app.primary_member.buy_and_prepare_food_together })
 
           members.map(&:reload)
 
@@ -77,7 +77,7 @@ RSpec.describe Integrated::BuyAndPrepareFoodWithOtherPersonController do
 
           expect do
             put :update, params: { form: { buy_and_prepare_food_together: "no" } }
-          end.to_not change { current_app.primary_member.buy_and_prepare_food_together }
+          end.to_not(change { current_app.primary_member.buy_and_prepare_food_together })
 
           members.map(&:reload)
 

--- a/spec/controllers/integrated/introduce_yourself_controller_spec.rb
+++ b/spec/controllers/integrated/introduce_yourself_controller_spec.rb
@@ -6,7 +6,11 @@ RSpec.describe Integrated::IntroduceYourselfController do
       it "assigns existing attributes" do
         current_app = create(:common_application,
           previously_received_assistance: "yes",
-          members: [build(:household_member, first_name: "Juan")])
+          members: [build(:household_member,
+            first_name: "Juan",
+            last_name: "Two",
+            birthday: DateTime.new(1950, 1, 31),
+            sex: "male")])
         session[:current_application_id] = current_app.id
 
         get :edit
@@ -14,6 +18,9 @@ RSpec.describe Integrated::IntroduceYourselfController do
         form = assigns(:form)
 
         expect(form.first_name).to eq("Juan")
+        expect(form.birthday_year).to eq(1950)
+        expect(form.birthday_month).to eq(1)
+        expect(form.birthday_day).to eq(31)
         expect(form.previously_received_assistance).to eq("yes")
       end
     end
@@ -34,9 +41,9 @@ RSpec.describe Integrated::IntroduceYourselfController do
           form: {
             first_name: "Gary",
             last_name: "McTester",
-            "birthday(3i)" => "31",
-            "birthday(2i)" => "1",
-            "birthday(1i)" => "1950",
+            birthday_day: "31",
+            birthday_month: "1",
+            birthday_year: "1950",
             sex: "male",
             previously_received_assistance: "yes",
           },

--- a/spec/features/integrated_application_non_resident_spec.rb
+++ b/spec/features/integrated_application_non_resident_spec.rb
@@ -18,9 +18,9 @@ RSpec.feature "Integrated application" do
       fill_in "What's your first name?", with: "Jessie"
       fill_in "What's your last name?", with: "Tester"
 
-      select "January", from: "form_birthday_2i"
-      select "1", from: "form_birthday_3i"
-      select "1969", from: "form_birthday_1i"
+      fill_in "Month", with: "1"
+      fill_in "Day", with: "1"
+      fill_in "Year", with: "1969"
 
       select_radio(question: "What's your sex?", answer: "Female")
 

--- a/spec/features/integrated_application_with_multiple_members_spec.rb
+++ b/spec/features/integrated_application_with_multiple_members_spec.rb
@@ -21,9 +21,9 @@ RSpec.feature "Integrated application" do
       fill_in "What's your first name?", with: "Jessie"
       fill_in "What's your last name?", with: "Tester"
 
-      select "January", from: "form_birthday_2i"
-      select "1", from: "form_birthday_3i"
-      select "1969", from: "form_birthday_1i"
+      fill_in "Month", with: "1"
+      fill_in "Day", with: "1"
+      fill_in "Year", with: "1969"
 
       select_radio(question: "What's your sex?", answer: "Female")
 
@@ -71,35 +71,35 @@ RSpec.feature "Integrated application" do
       {
         first_name: "Jonny",
         last_name: "Tester",
-        dob: ["January", "1", "1969"],
+        dob: ["1", "1", "1969"],
         sex: "Female",
         relation: "Roommate",
       },
       {
         first_name: "Jackie",
         last_name: "Tester",
-        dob: ["January", "1", "1970"],
+        dob: ["1", "1", "1970"],
         sex: "Male",
         relation: "Sibling",
       },
       {
         first_name: "Joe",
         last_name: "Schmoe",
-        dob: ["Month", "Day", "Year"],
+        dob: ["", "", ""],
         sex: "Female",
         relation: "Parent",
       },
       {
         first_name: "Apples",
         last_name: "McMackintosh",
-        dob: ["Month", "Day", "Year"],
+        dob: ["", "", ""],
         sex: "Male",
         relation: "Other",
       },
       {
         first_name: "Pupper",
         last_name: "McDog",
-        dob: ["December", "30", "2016"],
+        dob: ["12", "30", "2016"],
         sex: "Male",
         relation: "Child",
       },
@@ -112,9 +112,9 @@ RSpec.feature "Integrated application" do
         fill_in "What's their first name?", with: member[:first_name]
         fill_in "What's their last name?", with: member[:last_name]
 
-        select member[:dob][0], from: "form_birthday_2i"
-        select member[:dob][1], from: "form_birthday_3i"
-        select member[:dob][2], from: "form_birthday_1i"
+        fill_in "Month", with: member[:dob][0]
+        fill_in "Day", with: member[:dob][1]
+        fill_in "Year", with: member[:dob][2]
 
         select_radio(question: "What's their sex?", answer: member[:sex])
 

--- a/spec/features/integrated_application_with_single_member_spec.rb
+++ b/spec/features/integrated_application_with_single_member_spec.rb
@@ -18,9 +18,9 @@ RSpec.feature "Integrated application" do
       fill_in "What's your first name?", with: "Jessie"
       fill_in "What's your last name?", with: "Tester"
 
-      select "January", from: "form_birthday_2i"
-      select "1", from: "form_birthday_3i"
-      select "1969", from: "form_birthday_1i"
+      fill_in "Month", with: "1"
+      fill_in "Day", with: "1"
+      fill_in "Year", with: "1969"
 
       select_radio(question: "What's your sex?", answer: "Female")
 

--- a/spec/features/integrated_application_with_two_members_spec.rb
+++ b/spec/features/integrated_application_with_two_members_spec.rb
@@ -18,9 +18,9 @@ RSpec.feature "Integrated application" do
       fill_in "What's your first name?", with: "Jessie"
       fill_in "What's your last name?", with: "Tester"
 
-      select "January", from: "form_birthday_2i"
-      select "1", from: "form_birthday_3i"
-      select "1969", from: "form_birthday_1i"
+      fill_in "Month", with: "1"
+      fill_in "Day", with: "1"
+      fill_in "Year", with: "1969"
 
       select_radio(question: "What's your sex?", answer: "Female")
 

--- a/spec/forms/add_household_member_form_spec.rb
+++ b/spec/forms/add_household_member_form_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe AddHouseholdMemberForm do
+  describe "validations" do
+    it "requires first_name" do
+      form = AddHouseholdMemberForm.new
+
+      expect(form).not_to be_valid
+      expect(form.errors[:first_name]).to be_present
+    end
+
+    it "requires last_name" do
+      form = AddHouseholdMemberForm.new
+
+      expect(form).not_to be_valid
+      expect(form.errors[:last_name]).to be_present
+    end
+
+    it "does not accept invalid dates for birthday" do
+      form = AddHouseholdMemberForm.new(birthday_year: 1992, birthday_month: 2, birthday_day: 30)
+
+      expect(form).not_to be_valid
+      expect(form.errors[:birthday]).to be_present
+    end
+  end
+end

--- a/spec/forms/add_household_member_form_spec.rb
+++ b/spec/forms/add_household_member_form_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe AddHouseholdMemberForm do
       expect(form.errors[:last_name]).to be_present
     end
 
+    it "does accept empty birthday" do
+      form = AddHouseholdMemberForm.new(first_name: "Gary", last_name: "Tester")
+
+      expect(form).to be_valid
+      expect(form.errors[:birthday]).to_not be_present
+    end
+
     it "does not accept invalid dates for birthday" do
       form = AddHouseholdMemberForm.new(birthday_year: 1992, birthday_month: 2, birthday_day: 30)
 

--- a/spec/forms/introduce_yourself_form_spec.rb
+++ b/spec/forms/introduce_yourself_form_spec.rb
@@ -30,8 +30,15 @@ RSpec.describe IntroduceYourselfForm do
       expect(form.errors[:sex]).to be_present
     end
 
-    it "requires birthday" do
+    it "requires birthday subfields" do
       form = IntroduceYourselfForm.new
+
+      expect(form).not_to be_valid
+      expect(form.errors[:birthday]).to be_present
+    end
+
+    it "does not accept invalid dates for birthday" do
+      form = IntroduceYourselfForm.new(birthday_year: 1992, birthday_month: 2, birthday_day: 30)
 
       expect(form).not_to be_valid
       expect(form.errors[:birthday]).to be_present

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe MbFormBuilder do
           <div class="field_with_errors">
             <input type="text" class="text-input" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" id="sample_name" aria-labelledby="sample_name__errors sample_name__label sample_name__help" name="sample[name]" />
           </div>
-          <div class="text--error" id="sample_name__errors"><i class="icon-warning"></i> can't be blank </div>
+          <span class="text--error" id="sample_name__errors"><i class="icon-warning"></i> can't be blank </div>
         </div>
       HTML
     end
@@ -88,7 +88,7 @@ RSpec.describe MbFormBuilder do
          <div class="field_with_errors">
            <textarea class="textarea" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" aria-labelledby="sample_description__errors sample_description__label sample_description__help" name="sample[description]" id="sample_description"></textarea>
          </div>
-         <div class="text--error" id="sample_description__errors"><i class="icon-warning"></i> can't be blank </div>
+         <span class="text--error" id="sample_description__errors"><i class="icon-warning"></i> can't be blank </span>
        </div>
       HTML
     end
@@ -162,7 +162,7 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
           </div>
-          <div class="text--error" id="sample_how_many__errors"><i class="icon-warning"></i> can't be blank </div>
+          <span class="text--error" id="sample_how_many__errors"><i class="icon-warning"></i> can't be blank </span>
         </div>
       HTML
     end
@@ -191,7 +191,7 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
         <fieldset class="form-group">
-          <legend class="form-question " id="sample_birthday__label">What is your birthday?</legend>
+          <legend class="form-question " id="sample_birthday__label"> What is your birthday? </legend>
           <p class="text--help" id="sample_birthday__help">(For surprises)</p>
           <div class="input-group--inline">
             <div class="select">
@@ -299,7 +299,7 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
         <fieldset class="form-group">
-          <legend class="form-question " id="sample_members_72_birthday__label">What is your birthday?</legend>
+          <legend class="form-question " id="sample_members_72_birthday__label"> What is your birthday? </legend>
           <p class="text--help" id="sample_members_72_birthday__help">(For surprises)</p>
           <div class="input-group--inline">
             <div class="select">
@@ -372,6 +372,87 @@ RSpec.describe MbFormBuilder do
     end
   end
 
+  describe "#mb_date_input" do
+    it "renders an accessible trio of text fields for month, day, and year" do
+      class SampleStep < Step
+        step_attributes(:birthday_year)
+        step_attributes(:birthday_month)
+        step_attributes(:birthday_day)
+      end
+
+      sample = SampleStep.new
+      form = MbFormBuilder.new(:sample, sample, template, {})
+      output = form.mb_date_input(
+        :birthday,
+        "What is your birthday?",
+        help_text: "(For surprises)",
+        options: {
+          start_year: 1990,
+          end_year: 1992,
+        },
+      )
+      expect(output).to be_html_safe
+
+      expect(output).to match_html <<-HTML
+      <fieldset class="form-group">
+        <legend class="form-question " id="sample_birthday__label"> What is your birthday? </legend>
+        <p class="text--help" id="sample_birthday__help">(For surprises)</p>
+        <div class="input-group--inline">
+          <div class="form-group">
+            <label class="text--help form-subquestion" for="sample_birthday_month" id="sample_birthday_month__label">Month</label>
+            <input class="form-width--month text-input" min="1" max="12" id="sample_birthday_month" name="sample[birthday_month]" type="number" />
+          </div>
+          <div class="form-group">
+            <label class="text--help form-subquestion" for="sample_birthday_day" id="sample_birthday_day__label">Day</label>
+            <input class="form-width--day text-input" min="1" max="31" id="sample_birthday_day" name="sample[birthday_day]" type="number" />
+          </div>
+          <div class="form-group">
+            <label class="text--help form-subquestion" for="sample_birthday_year" id="sample_birthday_year__label">Year</label>
+            <input class="form-width--year text-input" min="1990" max="1992" id="sample_birthday_year" name="sample[birthday_year]" type="number" />
+          </div>
+        </div>
+      </fieldset>
+      HTML
+    end
+
+    it "displays errors on the containing field" do
+      class SampleForm < Form
+        set_member_attributes(
+          :birthday_year,
+          :birthday_month,
+          :birthday_day,
+        )
+
+        validate :birthday_should_be_valid
+
+        def birthday_should_be_valid
+          errors.add(:birthday, "Not a great birthday tbh")
+        end
+      end
+
+      sample = SampleForm.new
+
+      expect(sample).not_to be_valid
+
+      form = MbFormBuilder.new(:sample, sample, template, {})
+      output = form.mb_date_input(
+        :birthday,
+        "What is your birthday?",
+        help_text: "(For surprises)",
+        options: {
+          start_year: 1990,
+          end_year: 1992,
+        },
+      )
+
+      expect(output).to be_html_safe
+
+      expect(output).to include_html <<-HTML
+        <span class="text--error" id="sample_birthday__errors"><i class="icon-warning"></i> Not a great birthday tbh </div>
+      HTML
+    end
+  end
+
   describe "#mb_radio_set" do
     it "renders an accessible set of radio inputs" do
       class SampleStep < Step
@@ -395,13 +476,15 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
         <fieldset class="form-group form-group--error">
-          <legend class="form-question " id="sample_dependent_care__label">Does your household have dependent care expenses?</legend>
+          <legend class="form-question " id="sample_dependent_care__label">
+            <span class="text--error" id="sample_dependent_care__errors"><i class="icon-warning"></i> can't be blank </span>
+            Does your household have dependent care expenses?
+          </legend>
           <p class="text--help" id="sample_dependent_care__help">This includes child care.</p>
           <radiogroup class="input-group--block">
             <label class="radio-button" id="sample_dependent_care_true__label"><div class="field_with_errors"><input aria-labelledby="sample_dependent_care__errors sample_dependent_care__label sample_dependent_care__help sample_dependent_care_true__label" type="radio" value="true" name="sample[dependent_care]" id="sample_dependent_care_true"/></div> Yep </label>
             <label class="radio-button" id="sample_dependent_care_false__label"><div class="field_with_errors"><input aria-labelledby="sample_dependent_care__errors sample_dependent_care__label sample_dependent_care__help sample_dependent_care_false__label" type="radio" value="false" name="sample[dependent_care]" id="sample_dependent_care_false"/></div> Nope </label>
           </radiogroup>
-          <div class="text--error" id="sample_dependent_care__errors"><i class="icon-warning"></i> can't be blank </div>
         </fieldset>
       HTML
     end
@@ -436,7 +519,7 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
         <fieldset class="input-group">
-          <legend class="form-question " id="sample_captains__label">Which captains do you think are cool?</legend>
+          <legend class="form-question " id="sample_captains__label"> Which captains do you think are cool? </legend>
           <p class="text--help" id="sample_captains__help">like, really cool</p>
           <label id="sample_captains_tng__label" class="checkbox"><input name="sample[tng]" type="hidden" value="0" /><input aria-labelledby="sample_captains__label sample_captains__help sample_captains_tng__label" type="checkbox" value="1" name="sample[tng]" id="sample_tng"/> Picard </label>
           <label id="sample_captains_ds9__label" class="checkbox"><input name="sample[ds9]" type="hidden" value="0" /><input aria-labelledby="sample_captains__label sample_captains__help sample_captains_ds9__label" type="checkbox" value="1" name="sample[ds9]" id="sample_ds9"/> Sisko </label>
@@ -472,9 +555,9 @@ RSpec.describe MbFormBuilder do
           </div>
           Confirm that you agree to Terms of Service
         </label>
-        <div class="text--error" id="sample_read_tos__errors">
+        <span class="text--error" id="sample_read_tos__errors">
           <i class="icon-warning"></i> can't be blank
-        </div>
+        </span>
       HTML
     end
 

--- a/spec/support/include_html.rb
+++ b/spec/support/include_html.rb
@@ -1,0 +1,18 @@
+RSpec::Matchers.define :include_html do |expected|
+  def clean_html(s)
+    s = s.squish.gsub(/>(\s)+</, "><")
+    Nokogiri::HTML.fragment(s).to_xhtml(
+      indent: 2, save_options: Nokogiri::XML::Node::SaveOptions::AS_HTML,
+    )
+  end
+
+  match do |actual|
+    @actual = clean_html(actual)
+    @expected = clean_html(expected)
+    @actual.include? @expected
+  end
+
+  failure_message do |_actual|
+    "EXPECTED:\n#{@actual}\n\nTO INCLUDE:\n#{@expected}"
+  end
+end


### PR DESCRIPTION
- adds new spec helper `include_html`
- only changes inputs for *integrated* flow
- uses new `mb_date_input` method to `MbFormBuilder`
- renders form errors as spans instead of divs

### _Date input:_
![screen shot 2018-03-12 at 4 11 15 pm](https://user-images.githubusercontent.com/451510/37314220-33a39a64-2610-11e8-87e2-326a99b0053a.png)

### _Date input with errors:_
![screen shot 2018-03-12 at 4 12 14 pm](https://user-images.githubusercontent.com/451510/37314219-338572a0-2610-11e8-9aac-ccbfcd72cd41.png)
