### PR TITLE
Add members to SNAP household when housing unstable

### DIFF
--- a/app/controllers/integrated/food_assistance_controller.rb
+++ b/app/controllers/integrated/food_assistance_controller.rb
@@ -3,7 +3,9 @@ module Integrated
     def self.skip?(current_application)
       if current_application.members.count == 1 || current_application.unstable_housing?
         ActiveRecord::Base.transaction do
-          current_application.members.each { |member| member.update!(requesting_food: "yes") }
+          current_application.members.each do |member|
+            member.update!(requesting_food: "yes", buy_and_prepare_food_together: "yes")
+          end
         end
         true
       else


### PR DESCRIPTION
In the last feature PR, we started adding people to a SNAP household if they had stable housing, were requesting food, and indicated they bought food together. This meant that we wouldn't fill out the SNAP supplement for anyone in unstable housing, because they weren't prompted to indicate who they bought and prepared food with.

This PR adds members to the SNAP household automatically after someone with unstable housing adds them as household members, and also fills out the required fields on the SNAP supplement.