### PR TITLE
Move birthday errors

### DIFF
--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -198,7 +198,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
             )}
           </div>
         </div>
-
+      #{errors_for(object, base_method)}
       </fieldset>
     HTML
   end
@@ -281,6 +281,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
           legend_class: legend_class,
         )}
         #{mb_radio_button(method, collection, layout, help_text)}
+        #{errors_for(object, method)}
       </fieldset>
     HTML
   end
@@ -434,7 +435,6 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
 
     label_html = <<~HTML
       <legend class="form-question #{legend_class}" id="#{sanitized_id(method)}__label">
-        #{errors_for(object, method)}
         #{label_text + optional_text(optional)}
       </legend>
     HTML

--- a/app/steps/medicaid/paperwork_identification.rb
+++ b/app/steps/medicaid/paperwork_identification.rb
@@ -2,6 +2,7 @@ module Medicaid
   class PaperworkIdentification < Step
     step_attributes(:has_picture_id_for_everyone)
 
-    validates_presence_of :has_picture_id_for_everyone
+    validates :has_picture_id_for_everyone,
+      presence: { message: "Make sure to answer this question" }
   end
 end

--- a/app/steps/medicaid/paperwork_income_proof.rb
+++ b/app/steps/medicaid/paperwork_income_proof.rb
@@ -5,6 +5,10 @@ module Medicaid
       :has_proof_of_income,
     )
 
-    validates_presence_of :id, :has_proof_of_income
+    validates :id,
+      presence: { message: "Can't find member ID. Please click back and answer question again." }
+
+    validates :has_proof_of_income,
+      presence: { message: "Make sure to answer this question" }
   end
 end

--- a/app/steps/paperwork_identification.rb
+++ b/app/steps/paperwork_identification.rb
@@ -1,5 +1,6 @@
 class PaperworkIdentification < Step
   step_attributes(:has_picture_id_for_everyone)
 
-  validates_presence_of :has_picture_id_for_everyone
+  validates :has_picture_id_for_everyone,
+    presence: { message: "Make sure to answer this question" }
 end

--- a/app/steps/paperwork_income_proof.rb
+++ b/app/steps/paperwork_income_proof.rb
@@ -4,5 +4,9 @@ class PaperworkIncomeProof < Step
     :has_proof_of_income,
   )
 
-  validates_presence_of :id, :has_proof_of_income
+  validates :id,
+    presence: { message: "Can't find member ID. Please click back and answer question again." }
+
+  validates :has_proof_of_income,
+    presence: { message: "Make sure to answer this question" }
 end

--- a/spec/controllers/integrated/add_household_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_household_member_controller_spec.rb
@@ -61,7 +61,6 @@ RSpec.describe Integrated::AddHouseholdMemberController do
         expect(new_member.sex).to eq("unfilled")
         expect(new_member.relationship).to eq("unknown_relation")
       end
-
     end
   end
 

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -477,7 +477,6 @@ RSpec.describe MbFormBuilder do
       expect(output).to match_html <<-HTML
         <fieldset class="form-group form-group--error">
           <legend class="form-question " id="sample_dependent_care__label">
-            <span class="text--error" id="sample_dependent_care__errors"><i class="icon-warning"></i> can't be blank </span>
             Does your household have dependent care expenses?
           </legend>
           <p class="text--help" id="sample_dependent_care__help">This includes child care.</p>
@@ -485,6 +484,7 @@ RSpec.describe MbFormBuilder do
             <label class="radio-button" id="sample_dependent_care_true__label"><div class="field_with_errors"><input aria-labelledby="sample_dependent_care__errors sample_dependent_care__label sample_dependent_care__help sample_dependent_care_true__label" type="radio" value="true" name="sample[dependent_care]" id="sample_dependent_care_true"/></div> Yep </label>
             <label class="radio-button" id="sample_dependent_care_false__label"><div class="field_with_errors"><input aria-labelledby="sample_dependent_care__errors sample_dependent_care__label sample_dependent_care__help sample_dependent_care_false__label" type="radio" value="false" name="sample[dependent_care]" id="sample_dependent_care_false"/></div> Nope </label>
           </radiogroup>
+          <span class="text--error" id="sample_dependent_care__errors"><i class="icon-warning"></i> can't be blank </span>
         </fieldset>
       HTML
     end


### PR DESCRIPTION
Moves errors for mb_date_input and mb_radio_set to below the input. Previously was above, which was inconsistent with other form fields.

Also, in doing the first commit, I noticed that our error messages were a little hard to parse on one question since the field name wasn't included in the message, e.g. not selecting a radio button just showed the error message "can't be blank". Changed this to be a bit more verbose to bring them in line with other error messages, and to suggest a remedy for a failed presence validation that may not be because of user error.