### PR TITLE
Bugfix for SNAP household builder

### DIFF
--- a/app/controllers/integrated/share_food_costs_with_household_controller.rb
+++ b/app/controllers/integrated/share_food_costs_with_household_controller.rb
@@ -7,6 +7,11 @@ module Integrated
 
     def update_models
       current_application.navigator.update(navigator_params)
+      if navigator_params[:all_share_food_costs]
+        current_application.snap_applying_members.each do |member|
+          member.update_attributes(buy_and_prepare_food_together: "yes")
+        end
+      end
     end
 
     private

--- a/app/views/integrated/review_food_assistance_members/edit.html.erb
+++ b/app/views/integrated/review_food_assistance_members/edit.html.erb
@@ -28,16 +28,18 @@
       Add a person
       <% end %>
     </div>
-    <div class="card card--narrow card--bottom text--help" id="not-applying-with-you">
-      <p>Not applying with you:</p>
-      <% @non_household_members.each do |member| %>
-      <div>
-        <p>
-          <i class="button__icon--left icon-close icon-close--color"></i>
-          <span id="member-name-<%= member.id %>"><%= member.display_name %></span>
-        </p>
+    <% if @non_household_members.present? %>
+      <div class="card card--narrow card--bottom text--help" id="not-applying-with-you">
+        <p>Not applying with you:</p>
+        <% @non_household_members.each do |member| %>
+        <div>
+          <p>
+            <i class="button__icon--left icon-close icon-close--color"></i>
+            <span id="member-name-<%= member.id %>"><%= member.display_name %></span>
+          </p>
+        </div>
+        <% end %>
       </div>
-      <% end %>
-    </div>
+    <% end %>
   </div>
 <% end %>

--- a/spec/controllers/integrated/share_food_costs_with_household_controller_spec.rb
+++ b/spec/controllers/integrated/share_food_costs_with_household_controller_spec.rb
@@ -51,14 +51,14 @@ RSpec.describe Integrated::ShareFoodCostsWithHouseholdController do
   end
 
   describe "#update" do
-    context "with valid params" do
+    context "when false passed" do
       let(:valid_params) do
         { form: { all_share_food_costs: "false" } }
       end
 
       it "updates the models" do
         current_app = create(:common_application,
-          navigator: build(:application_navigator))
+                             navigator: build(:application_navigator))
         session[:current_application_id] = current_app.id
 
         put :update, params: valid_params
@@ -66,6 +66,28 @@ RSpec.describe Integrated::ShareFoodCostsWithHouseholdController do
         current_app.navigator.reload
 
         expect(current_app.navigator.all_share_food_costs).to be_falsey
+      end
+    end
+
+    context "when true passed" do
+      let(:valid_params) do
+        { form: { all_share_food_costs: "true" } }
+      end
+
+      it "updates the models" do
+        current_app = create(:common_application,
+                             navigator: build(:application_navigator),
+                             members: build_list(:household_member, 3, requesting_food: "yes"))
+        session[:current_application_id] = current_app.id
+
+        put :update, params: valid_params
+
+        current_app.navigator.reload
+
+        expect(current_app.navigator.all_share_food_costs).to be_truthy
+        current_app.snap_applying_members.each do |member|
+          expect(member.buy_and_prepare_food_together).to eq("yes")
+        end
       end
     end
   end


### PR DESCRIPTION
When all household members are applying and share meals and costs:

![review 2018-03-20 16-09-31](https://user-images.githubusercontent.com/417/37680089-41237386-2c59-11e8-8de9-83b26566f082.png)

Selecting “Yes” to “Do all of you share meals and food costs?” will correctly set `buy_and_prepare_food_together` on each member in the SNAP household.

https://www.pivotaltracker.com/story/show/156136462

