### PR TITLE
Ask if primary member is filing taxes next year

### DIFF
--- a/app/controllers/integrated/buy_and_prepare_food_separately_controller.rb
+++ b/app/controllers/integrated/buy_and_prepare_food_separately_controller.rb
@@ -19,7 +19,7 @@ module Integrated
     private
 
     def members
-      @_members ||= current_application.snap_applying_members - [current_application.primary_member]
+      @_members ||= current_application.food_applying_members - [current_application.primary_member]
     end
 
     def form_params

--- a/app/controllers/integrated/buy_and_prepare_food_with_other_person_controller.rb
+++ b/app/controllers/integrated/buy_and_prepare_food_with_other_person_controller.rb
@@ -1,7 +1,7 @@
 module Integrated
   class BuyAndPrepareFoodWithOtherPersonController < FormsController
     def self.skip?(application)
-      if application.unstable_housing? || application.snap_applying_members.count != 2
+      if application.unstable_housing? || application.food_applying_members.count != 2
         true
       else
         false
@@ -9,7 +9,7 @@ module Integrated
     end
 
     def update
-      current_application.snap_applying_members.second.update(member_params)
+      current_application.food_applying_members.second.update(member_params)
       redirect_to(next_path)
     end
   end

--- a/app/controllers/integrated/file_taxes_next_year_controller.rb
+++ b/app/controllers/integrated/file_taxes_next_year_controller.rb
@@ -1,0 +1,12 @@
+module Integrated
+  class FileTaxesNextYearController < FormsController
+    def self.skip?(application)
+      return true if application.healthcare_applying_members.count < 1
+      return true unless application.primary_member.requesting_healthcare_yes?
+    end
+
+    def update_models
+      current_application.primary_member.update!(member_params)
+    end
+  end
+end

--- a/app/controllers/integrated/review_food_assistance_members_controller.rb
+++ b/app/controllers/integrated/review_food_assistance_members_controller.rb
@@ -2,8 +2,8 @@ module Integrated
   class ReviewFoodAssistanceMembersController < FormsController
     def edit
       @primary_member = current_application.primary_member
-      @snap_household_members = current_application.snap_household_members - [current_application.primary_member]
-      @non_household_members = current_application.members - current_application.snap_household_members
+      @food_household_members = current_application.food_household_members - [current_application.primary_member]
+      @non_household_members = current_application.members - current_application.food_household_members
     end
 
     def form_class

--- a/app/controllers/integrated/share_food_costs_with_household_controller.rb
+++ b/app/controllers/integrated/share_food_costs_with_household_controller.rb
@@ -2,7 +2,7 @@ module Integrated
   class ShareFoodCostsWithHouseholdController < FormsController
     def self.skip?(application)
       return true if application.unstable_housing?
-      return true if application.snap_applying_members.count <= 2
+      return true if application.food_applying_members.count <= 2
     end
 
     def update_models

--- a/app/forms/file_taxes_next_year_form.rb
+++ b/app/forms/file_taxes_next_year_form.rb
@@ -1,0 +1,3 @@
+class FileTaxesNextYearForm < Form
+  set_member_attributes(:filing_taxes_next_year)
+end

--- a/app/forms/form_navigation.rb
+++ b/app/forms/form_navigation.rb
@@ -18,6 +18,7 @@ class FormNavigation
     ],
     "Healthcare" => [
       Integrated::HealthcareController,
+      Integrated::FileTaxesNextYearController,
     ],
     "Finish" => [
       Integrated::ApplicationSubmittedController,

--- a/app/models/common_application.rb
+++ b/app/models/common_application.rb
@@ -13,7 +13,7 @@ class CommonApplication < ApplicationRecord
     foreign_key: "common_application_id",
     dependent: :destroy
 
-  has_many :snap_applying_members,
+  has_many :food_applying_members,
     -> {
       requesting_food
     },
@@ -27,7 +27,7 @@ class CommonApplication < ApplicationRecord
     class_name: "HouseholdMember",
     foreign_key: "common_application_id"
 
-  has_many :snap_household_members,
+  has_many :food_household_members,
     -> {
       requesting_food.buy_and_prepare_food_together
     },

--- a/app/models/common_application.rb
+++ b/app/models/common_application.rb
@@ -60,9 +60,10 @@ class CommonApplication < ApplicationRecord
   end
 
   def applying_for_food_assistance?
-    members.each do |member|
-      return true if member.requesting_food_yes?
-    end
-    false
+    members.any?(&:requesting_food_yes?)
+  end
+
+  def applying_for_healthcare?
+    members.any?(&:requesting_healthcare_yes?)
   end
 end

--- a/app/models/household_member.rb
+++ b/app/models/household_member.rb
@@ -29,6 +29,7 @@ class HouseholdMember < ApplicationRecord
 
   enum requesting_food: { unfilled: 0, yes: 1, no: 2 }, _prefix: :requesting_food
   enum requesting_healthcare: { unfilled: 0, yes: 1, no: 2 }, _prefix: :requesting_healthcare
+  enum filing_taxes_next_year: { unfilled: 0, yes: 1, no: 2 }, _prefix: :filing_taxes_next_year
 
   enum buy_and_prepare_food_together: { unfilled: 0, yes: 1, no: 2 },
        _prefix: :buy_and_prepare_food_together

--- a/app/pdf_components/food_assistance_supplement.rb
+++ b/app/pdf_components/food_assistance_supplement.rb
@@ -37,6 +37,6 @@ class FoodAssistanceSupplement
 
   def non_household_members_applying_for_snap
     @_non_household_members_applying_for_snap =
-      benefit_application.snap_applying_members - benefit_application.snap_household_members
+      benefit_application.food_applying_members - benefit_application.food_household_members
   end
 end

--- a/app/pdf_components/healthcare_coverage_supplement.rb
+++ b/app/pdf_components/healthcare_coverage_supplement.rb
@@ -1,0 +1,41 @@
+class HealthcareCoverageSupplement
+  include Integrated::PdfAttributes
+
+  def initialize(benefit_application)
+    @benefit_application = benefit_application
+  end
+
+  def source_pdf_path
+    "app/lib/pdfs/HealthcareCoverageSupplement.pdf"
+  end
+
+  def fill?
+    true
+  end
+
+  def attributes
+    supplement_attributes
+  end
+
+  def output_file
+    @_output_file ||= Tempfile.new(["healthcare_coverage_supplement", ".pdf"], "tmp/")
+  end
+
+  private
+
+  attr_reader :benefit_application
+
+  def supplement_attributes
+    {
+      anyone_filing_taxes: yes_no_or_unfilled(
+        yes: benefit_application.primary_member.filing_taxes_next_year_yes?,
+        no: benefit_application.primary_member.filing_taxes_next_year_no?,
+      ),
+      filing_taxes_primary_filer_name: primary_tax_filer_name,
+    }
+  end
+
+  def primary_tax_filer_name
+    benefit_application.primary_member.display_name if benefit_application.primary_member.filing_taxes_next_year_yes?
+  end
+end

--- a/app/services/application_pdf_assembler.rb
+++ b/app/services/application_pdf_assembler.rb
@@ -19,6 +19,9 @@ class ApplicationPdfAssembler
     if benefit_application.applying_for_food_assistance?
       components << FoodAssistanceSupplement.new(benefit_application)
     end
+    if benefit_application.applying_for_healthcare?
+      components << HealthcareCoverageSupplement.new(benefit_application)
+    end
     components << verification_documents
     components.flatten
   end

--- a/app/views/integrated/file_taxes_next_year/edit.html.erb
+++ b/app/views/integrated/file_taxes_next_year/edit.html.erb
@@ -1,0 +1,14 @@
+<% content_for :header_title, "Healthcare" %>
+
+<% content_for :form_card_title, "Will you file taxes next year?" %>
+
+<% content_for :form_card_body do %>
+    <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
+        <%= f.mb_yes_no_buttons :filing_taxes_next_year,
+          yes_value: "yes",
+          no_value: "no"
+        %>
+    <% end %>
+<% end %>
+
+<% content_for :skip_footer, true %>

--- a/app/views/integrated/review_food_assistance_members/edit.html.erb
+++ b/app/views/integrated/review_food_assistance_members/edit.html.erb
@@ -9,7 +9,7 @@
         <i class="button__icon--left icon-check icon-check--color"></i>
         <%= "#{@primary_member.display_name} (that's you!)" %>
       </p>
-      <% @snap_household_members.each do |member| %>
+      <% @food_household_members.each do |member| %>
       <div>
         <p>
           <i class="button__icon--left icon-check icon-check--color"></i>

--- a/db/migrate/20180320200147_add_filing_taxes_next_year_to_household_member.rb
+++ b/db/migrate/20180320200147_add_filing_taxes_next_year_to_household_member.rb
@@ -1,0 +1,6 @@
+class AddFilingTaxesNextYearToHouseholdMember < ActiveRecord::Migration[5.1]
+  def change
+    add_column :household_members, :filing_taxes_next_year, :integer
+    change_column_default :household_members, :filing_taxes_next_year, from: nil, to: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180320173759) do
+ActiveRecord::Schema.define(version: 20180320200147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -148,6 +148,7 @@ ActiveRecord::Schema.define(version: 20180320173759) do
     t.integer "buy_and_prepare_food_together", default: 0
     t.bigint "common_application_id"
     t.datetime "created_at", null: false
+    t.integer "filing_taxes_next_year", default: 0
     t.string "first_name"
     t.string "last_name"
     t.integer "relationship", default: 0

--- a/spec/controllers/integrated/file_taxes_next_year_controller_spec.rb
+++ b/spec/controllers/integrated/file_taxes_next_year_controller_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe Integrated::FileTaxesNextYearController do
+  describe "#skip?" do
+    context "when no one is requesting healthcare" do
+      it "returns true" do
+        application = create(:common_application, members: [
+                               create(:household_member, requesting_healthcare: "no"),
+                             ])
+
+        skip_step = Integrated::FileTaxesNextYearController.skip?(application)
+        expect(skip_step).to be_truthy
+      end
+    end
+
+    context "when primary member is not requesting healthcare" do
+      it "returns true" do
+        application = create(:common_application, members: [
+                               create(:household_member, requesting_healthcare: "no"),
+                               create(:household_member, requesting_healthcare: "yes"),
+                             ])
+
+        skip_step = Integrated::FileTaxesNextYearController.skip?(application)
+        expect(skip_step).to be_truthy
+      end
+    end
+
+    context "when one or more members are requesting healthcare, including primary member" do
+      it "returns false" do
+        application = create(:common_application, members: [
+                               create(:household_member, requesting_healthcare: "yes"),
+                             ])
+
+        skip_step = Integrated::FileTaxesNextYearController.skip?(application)
+        expect(skip_step).to be_falsey
+      end
+    end
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:valid_params) do
+        { form: {
+          filing_taxes_next_year: "yes",
+        } }
+      end
+
+      it "updates the primary member" do
+        current_app = create(:common_application, :single_member)
+        session[:current_application_id] = current_app.id
+
+        put :update, params: valid_params
+
+        current_app.reload
+
+        expect(current_app.primary_member.filing_taxes_next_year_yes?).to be_truthy
+      end
+    end
+  end
+end

--- a/spec/controllers/integrated/remove_snap_member_controller_spec.rb
+++ b/spec/controllers/integrated/remove_snap_member_controller_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Integrated::RemoveSnapMemberController do
                            members: [member_one, member_two])
 
       session[:current_application_id] = current_app.id
-      expect(current_app.snap_applying_members.count).to eq(2)
-      expect(current_app.snap_household_members.count).to eq(2)
+      expect(current_app.food_applying_members.count).to eq(2)
+      expect(current_app.food_household_members.count).to eq(2)
 
       put :update, params: { form: { member_id: member_two.id } }
       current_app.reload
-      expect(current_app.snap_applying_members.count).to eq(2)
-      expect(current_app.snap_household_members.count).to eq(1)
+      expect(current_app.food_applying_members.count).to eq(2)
+      expect(current_app.food_household_members.count).to eq(1)
     end
   end
 end

--- a/spec/features/integrated_application_with_multiple_members_spec.rb
+++ b/spec/features/integrated_application_with_multiple_members_spec.rb
@@ -197,6 +197,12 @@ RSpec.feature "Integrated application" do
       proceed_with "Continue"
     end
 
+    on_page "Healthcare" do
+      expect(page).to have_content("Will you file taxes next year?")
+
+      proceed_with "Yes"
+    end
+
     on_page "Application Submitted" do
       expect(page).to have_content(
         "Congratulations",
@@ -214,5 +220,6 @@ RSpec.feature "Integrated application" do
     expect(pdf_values["legal_name"]).to include("Jessie Tester") # Main application
     expect(pdf_values["notes"]).to include("Additional Household Members:") # Additional info
     expect(pdf_values["anyone_buys_food_separately"]).to eq("Yes") # Food assistance supplement
+    expect(pdf_values["anyone_filing_taxes"]).to eq("Yes") # Healthcare coverage supplement
   end
 end

--- a/spec/features/integrated_application_with_single_member_spec.rb
+++ b/spec/features/integrated_application_with_single_member_spec.rb
@@ -75,6 +75,12 @@ RSpec.feature "Integrated application" do
       proceed_with "Continue"
     end
 
+    on_page "Healthcare" do
+      expect(page).to have_content("Will you file taxes next year?")
+
+      proceed_with "Yes"
+    end
+
     on_page "Application Submitted" do
       expect(page).to have_content(
         "Congratulations",

--- a/spec/features/integrated_application_with_two_members_spec.rb
+++ b/spec/features/integrated_application_with_two_members_spec.rb
@@ -128,6 +128,12 @@ RSpec.feature "Integrated application" do
       proceed_with "Continue"
     end
 
+    on_page "Healthcare" do
+      expect(page).to have_content("Will you file taxes next year?")
+
+      proceed_with "Yes"
+    end
+
     on_page "Application Submitted" do
       expect(page).to have_content(
         "Congratulations",

--- a/spec/models/common_application_spec.rb
+++ b/spec/models/common_application_spec.rb
@@ -123,16 +123,30 @@ RSpec.describe CommonApplication do
   end
 
   describe "#applying_for_food_assistance?" do
-    it "returns true when at least one household member is" do
+    it "returns true when at least one household member is applying for food" do
       application = create(:common_application,
                            members: [create(:household_member, requesting_food: "yes")])
       expect(application.applying_for_food_assistance?).to be_truthy
     end
 
-    it "returns false when no one is" do
+    it "returns false when no one is applying for food" do
       application = create(:common_application,
                            members: [create(:household_member, requesting_food: "no")])
       expect(application.applying_for_food_assistance?).to be_falsey
+    end
+  end
+
+  describe "#applying_for_healthcare?" do
+    it "returns true when at least one household member is applying for healthcare" do
+      application = create(:common_application,
+        members: [create(:household_member, requesting_healthcare: "yes")])
+      expect(application.applying_for_healthcare?).to be_truthy
+    end
+
+    it "returns false when no one is applying for healthcare" do
+      application = create(:common_application,
+        members: [create(:household_member, requesting_healthcare: "no")])
+      expect(application.applying_for_healthcare?).to be_falsey
     end
   end
 end

--- a/spec/models/common_application_spec.rb
+++ b/spec/models/common_application_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe CommonApplication do
   describe "scopes" do
-    describe ".snap_household_members" do
+    describe ".food_household_members" do
       it "returns members applying for food assistance who buy and prepare food together" do
         in_household = build(:household_member, requesting_food: "yes", buy_and_prepare_food_together: "yes")
 
@@ -15,8 +15,8 @@ RSpec.describe CommonApplication do
             build(:household_member, requesting_food: "unfilled", buy_and_prepare_food_together: "yes"),
           ])
 
-        expect(application.snap_household_members.count).to eq(1)
-        expect(application.snap_household_members.first).to eq(in_household)
+        expect(application.food_household_members.count).to eq(1)
+        expect(application.food_household_members.first).to eq(in_household)
       end
 
       it "orders by time created at" do
@@ -28,12 +28,12 @@ RSpec.describe CommonApplication do
                                first_member,
                              ])
 
-        expect(application.snap_household_members.first).to eq(first_member)
-        expect(application.snap_household_members.second).to eq(second_member)
+        expect(application.food_household_members.first).to eq(first_member)
+        expect(application.food_household_members.second).to eq(second_member)
       end
     end
 
-    describe ".snap_applying_members" do
+    describe ".food_applying_members" do
       it "returns all members requesting food assistance" do
         in_household = build(:household_member, requesting_food: "yes")
 
@@ -44,8 +44,8 @@ RSpec.describe CommonApplication do
             build(:household_member),
           ])
 
-        expect(application.snap_applying_members.count).to eq(1)
-        expect(application.snap_applying_members.first).to eq(in_household)
+        expect(application.food_applying_members.count).to eq(1)
+        expect(application.food_applying_members.first).to eq(in_household)
       end
     end
 

--- a/spec/pdf_components/healthcare_coverage_supplement_spec.rb
+++ b/spec/pdf_components/healthcare_coverage_supplement_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe HealthcareCoverageSupplement do
+  describe "pdf component" do
+    let(:subject) do
+      HealthcareCoverageSupplement.new(double("fake application"))
+    end
+
+    it_should_behave_like "pdf component"
+  end
+
+  describe "#fill?" do
+    it "responds to fill? and returns true" do
+      form = HealthcareCoverageSupplement.new(double("fake application"))
+      expect(form.fill?).to be_truthy
+    end
+  end
+
+  describe "#attributes" do
+    let(:attributes) do
+      common_application = create(:common_application, members: [
+                                    build(:household_member,
+                                      requesting_healthcare: "yes",
+                                      filing_taxes_next_year: "yes",
+                                      first_name: "Julie",
+                                      last_name: "Tester"),
+                                    build(:household_member,
+                                      first_name: "Jonny",
+                                      last_name: "Tester",
+                                      requesting_food: "yes"),
+                                  ])
+      HealthcareCoverageSupplement.new(common_application).attributes
+    end
+
+    it "returns a hash with basic information" do
+      expect(attributes).to include(
+        anyone_filing_taxes: "Yes",
+        filing_taxes_primary_filer_name: "Julie Tester",
+      )
+    end
+  end
+end


### PR DESCRIPTION
As part of this, adds the healthcare supplement and indicates whether someone is filing taxes, and who that person is (in this case, always the primary member).

Also renames `snap_applying_x` to `food_applying_x` per comments in https://github.com/codeforamerica/michigan-benefits/pull/709.

![screen shot 2018-03-20 at 1 41 00 pm](https://user-images.githubusercontent.com/3675092/37681697-a9e49c0c-2c44-11e8-823b-3b23db795212.png)

![screen shot 2018-03-20 at 1 43 00 pm](https://user-images.githubusercontent.com/3675092/37681698-a9fea782-2c44-11e8-981c-0743b9062897.png)

