### PR TITLE
Disable new and edit actions in administrate

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,13 +5,13 @@ Rails.application.routes.draw do
     # match "/delayed_job" => DelayedJobWeb, anchor: false, via: %i(get post)
 
     namespace :admin do
-      resources :snap_applications do
+      resources :snap_applications, only: %i[index show] do
         get "pdf", on: :member
       end
-      resources :medicaid_applications do
+      resources :medicaid_applications, only: %i[index show] do
         get "pdf", on: :member
       end
-      resources :common_applications do
+      resources :common_applications, only: %i[index show] do
         get "pdf", on: :member
       end
       resources :exports, only: %i[index show]


### PR DESCRIPTION
We don't use these actions, and they're often broken. So, let's remove them.

'Edit' and 'New' links be gone:

<img width="872" alt="screen shot 2018-03-23 at 4 00 45 pm" src="https://user-images.githubusercontent.com/3675092/37856754-6c860550-2eb3-11e8-9689-81928b1b26ff.png">

[Finishes #155668442]