### PR TITLE
Remove spouse as relationship option when spouse already in household

### DIFF
--- a/app/controllers/integrated/add_member_controller.rb
+++ b/app/controllers/integrated/add_member_controller.rb
@@ -1,5 +1,7 @@
 module Integrated
   class AddMemberController < FormsController
+    helper_method :valid_relationship_options
+
     def previous_path(*_args)
       overview_path
     end
@@ -10,6 +12,14 @@ module Integrated
 
     def form_class
       AddMemberForm
+    end
+
+    def valid_relationship_options
+      if current_application.members.any?(&:is_spouse?)
+        HouseholdMember::RELATIONSHIP_LABELS_AND_KEYS.reject { |arr| arr.second == "spouse" }
+      else
+        HouseholdMember::RELATIONSHIP_LABELS_AND_KEYS
+      end
     end
   end
 end

--- a/app/views/integrated/add_food_member/edit.html.erb
+++ b/app/views/integrated/add_food_member/edit.html.erb
@@ -26,7 +26,8 @@
                        layout: "inline" %>
 
     <%= f.mb_select :relationship,
-                    "What is their relationship to you?", HouseholdMember::RELATIONSHIP_LABELS_AND_KEYS,
+                    "What is their relationship to you?",
+                    valid_relationship_options,
                     help_text: "They are my..." %>
   <% end %>
 <% end %>

--- a/app/views/integrated/add_healthcare_member/edit.html.erb
+++ b/app/views/integrated/add_healthcare_member/edit.html.erb
@@ -26,7 +26,8 @@
           layout: "inline" %>
 
         <%= f.mb_select :relationship,
-          "What is their relationship to you?", HouseholdMember::RELATIONSHIP_LABELS_AND_KEYS,
+          "What is their relationship to you?",
+          valid_relationship_options,
           help_text: "They are my..." %>
     <% end %>
 <% end %>

--- a/app/views/integrated/add_household_member/edit.html.erb
+++ b/app/views/integrated/add_household_member/edit.html.erb
@@ -26,7 +26,8 @@
                        layout: "inline" %>
 
     <%= f.mb_select :relationship,
-                    "What is their relationship to you?", HouseholdMember::RELATIONSHIP_LABELS_AND_KEYS,
+                    "What is their relationship to you?",
+                    valid_relationship_options,
                     help_text: "They are my..." %>
   <% end %>
 <% end %>

--- a/app/views/integrated/add_tax_member/edit.html.erb
+++ b/app/views/integrated/add_tax_member/edit.html.erb
@@ -26,7 +26,8 @@
                        layout: "inline" %>
 
     <%= f.mb_select :relationship,
-                    "What is their relationship to you?", HouseholdMember::RELATIONSHIP_LABELS_AND_KEYS,
+                    "What is their relationship to you?",
+                    valid_relationship_options,
                     help_text: "Choose one" %>
 
     <%= f.mb_select :tax_relationship,

--- a/spec/controllers/integrated/add_food_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_food_member_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Integrated::AddFoodMemberController do
+  it_behaves_like "add member controller"
+
   describe "#update" do
     context "with valid params" do
       let(:valid_params) do

--- a/spec/controllers/integrated/add_healthcare_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_healthcare_member_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Integrated::AddHealthcareMemberController do
+  it_behaves_like "add member controller"
+
   describe "#update" do
     context "with valid params" do
       let(:valid_params) do

--- a/spec/controllers/integrated/add_household_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_household_member_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Integrated::AddHouseholdMemberController do
+  it_behaves_like "add member controller"
+
   describe "#update" do
     context "with valid params" do
       let(:valid_params) do

--- a/spec/controllers/integrated/add_tax_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_tax_member_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Integrated::AddTaxMemberController do
+  it_behaves_like "add member controller"
+
   describe "#update" do
     context "with valid params" do
       let(:valid_params) do

--- a/spec/support/shared_examples/add_member_controller.rb
+++ b/spec/support/shared_examples/add_member_controller.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.shared_examples_for "add member controller" do
+  describe ".valid_relationship_options" do
+    context "with one spouse household member" do
+      it "does not include spouse as relationship option" do
+        current_app = create(:common_application,
+          members: [create(:household_member, relationship: "spouse")])
+
+        session[:current_application_id] = current_app.id
+
+        expect(controller.valid_relationship_options).to_not include([
+                                                                       "Spouse", "spouse"
+                                                                     ])
+      end
+    end
+
+    context "with no spouse household members" do
+      it "includes spouse as relationship option" do
+        current_app = create(:common_application)
+
+        session[:current_application_id] = current_app.id
+
+        expect(controller.valid_relationship_options).to include([
+                                                                   "Spouse", "spouse"
+                                                                 ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
If someone has already been added as a spouse, remove spouse as an option for future added members. Add option back in if spouse was removed.

![screen shot 2018-03-26 at 9 53 21 am](https://user-images.githubusercontent.com/3675092/37920380-9008885c-30db-11e8-858c-6002dc254ec1.png)
