### PR TITLE
Integrated/married

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -111,12 +111,13 @@ class FormsController < ApplicationController
     end
   end
 
-  def combine_birthday_fields(data)
-    year = data.delete(:birthday_year)
-    month = data.delete(:birthday_month)
-    day = data.delete(:birthday_day)
+  def combined_birthday_fields(day: nil, month: nil, year: nil)
     if [year, month, day].all? &:present?
-      data[:birthday] = DateTime.new(year.to_i, month.to_i, day.to_i)
+      {
+        birthday: DateTime.new(year.to_i, month.to_i, day.to_i),
+      }
+    else
+      {}
     end
   end
 end

--- a/app/controllers/integrated/add_food_member_controller.rb
+++ b/app/controllers/integrated/add_food_member_controller.rb
@@ -1,11 +1,10 @@
 module Integrated
   class AddFoodMemberController < AddMemberController
-    def update_models
-      member_data = member_params
-      combine_birthday_fields(member_data)
-      member_data[:requesting_food] = "yes"
-      member_data[:buy_and_prepare_food_together] = "yes"
-      current_application.members.create(member_data)
+    def additional_model_attributes
+      {
+        requesting_food: "yes",
+        buy_and_prepare_food_together: "yes",
+      }
     end
 
     def overview_path

--- a/app/controllers/integrated/add_healthcare_member_controller.rb
+++ b/app/controllers/integrated/add_healthcare_member_controller.rb
@@ -1,10 +1,9 @@
 module Integrated
   class AddHealthcareMemberController < AddMemberController
-    def update_models
-      member_data = member_params
-      combine_birthday_fields(member_data)
-      member_data[:requesting_healthcare] = "yes"
-      current_application.members.create(member_data)
+    def additional_model_attributes
+      {
+        requesting_healthcare: "yes",
+      }
     end
 
     def overview_path

--- a/app/controllers/integrated/add_household_member_controller.rb
+++ b/app/controllers/integrated/add_household_member_controller.rb
@@ -1,11 +1,5 @@
 module Integrated
   class AddHouseholdMemberController < AddMemberController
-    def update_models
-      member_data = member_params
-      combine_birthday_fields(member_data)
-      current_application.members.create(member_data)
-    end
-
     def overview_path
       household_members_overview_sections_path
     end

--- a/app/controllers/integrated/add_member_controller.rb
+++ b/app/controllers/integrated/add_member_controller.rb
@@ -14,12 +14,39 @@ module Integrated
       AddMemberForm
     end
 
+    def update_models
+      member_data = combined_attributes(member_params)
+      if member_data[:relationship] == "spouse"
+        member_data[:married] = "yes"
+        current_application.navigator.update!(anyone_married: true)
+        current_application.primary_member.update!(married: "yes")
+      end
+      current_application.members.create!(member_data)
+    end
+
     def valid_relationship_options
       if current_application.members.any?(&:is_spouse?)
         HouseholdMember::RELATIONSHIP_LABELS_AND_KEYS.reject { |arr| arr.second == "spouse" }
       else
         HouseholdMember::RELATIONSHIP_LABELS_AND_KEYS
       end
+    end
+
+    private
+
+    def combined_attributes(existing_params)
+      modified_member_data = existing_params.merge(
+        combined_birthday_fields(
+          day: existing_params.delete("birthday_day"),
+          month: existing_params.delete("birthday_month"),
+          year: existing_params.delete("birthday_year"),
+        ),
+      )
+      modified_member_data.merge(additional_model_attributes)
+    end
+
+    def additional_model_attributes
+      {}
     end
   end
 end

--- a/app/controllers/integrated/add_tax_member_controller.rb
+++ b/app/controllers/integrated/add_tax_member_controller.rb
@@ -1,10 +1,9 @@
 module Integrated
   class AddTaxMemberController < AddMemberController
-    def update_models
-      member_data = member_params
-      combine_birthday_fields(member_data)
-      member_data[:requesting_healthcare] = "yes"
-      current_application.members.create(member_data)
+    def additional_model_attributes
+      {
+        requesting_healthcare: "yes",
+      }
     end
 
     def overview_path

--- a/app/controllers/integrated/anyone_married_controller.rb
+++ b/app/controllers/integrated/anyone_married_controller.rb
@@ -1,0 +1,12 @@
+module Integrated
+  class AnyoneMarriedController < FormsController
+    def self.skip?(application)
+      return true if application.single_member_household?
+      application.navigator.anyone_married?
+    end
+
+    def update_models
+      current_application.navigator.update!(navigator_params)
+    end
+  end
+end

--- a/app/controllers/integrated/are_you_married_controller.rb
+++ b/app/controllers/integrated/are_you_married_controller.rb
@@ -6,6 +6,9 @@ module Integrated
 
     def update_models
       current_application.primary_member.update(member_params)
+      if member_params[:married] == "yes"
+        current_application.navigator.update(anyone_married: true)
+      end
     end
   end
 end

--- a/app/controllers/integrated/are_you_married_controller.rb
+++ b/app/controllers/integrated/are_you_married_controller.rb
@@ -1,0 +1,11 @@
+module Integrated
+  class AreYouMarriedController < FormsController
+    def self.skip?(application)
+      !application.single_member_household?
+    end
+
+    def update_models
+      current_application.primary_member.update(member_params)
+    end
+  end
+end

--- a/app/controllers/integrated/introduce_yourself_controller.rb
+++ b/app/controllers/integrated/introduce_yourself_controller.rb
@@ -9,7 +9,11 @@ module Integrated
         requesting_healthcare: "yes",
         buy_and_prepare_food_together: "yes",
       )
-      combine_birthday_fields(member_data)
+      member_data.merge!(combined_birthday_fields(
+                           day: member_data.delete(:birthday_day),
+                           month: member_data.delete(:birthday_month),
+                           year: member_data.delete(:birthday_year),
+      ))
       if current_application
         current_application.primary_member.update(member_data)
         current_application.update(application_params)

--- a/app/controllers/integrated/remove_household_member_controller.rb
+++ b/app/controllers/integrated/remove_household_member_controller.rb
@@ -3,6 +3,10 @@ module Integrated
     def update_models
       if member.is_spouse?
         current_application.primary_member.update!(married: "no")
+
+        if (current_application.members - [member]).none?(&:married_yes?)
+          current_application.navigator.update!(anyone_married: false)
+        end
       end
 
       flash[:notice] = if member && current_application.members.delete(member)

--- a/app/controllers/integrated/remove_household_member_controller.rb
+++ b/app/controllers/integrated/remove_household_member_controller.rb
@@ -1,6 +1,10 @@
 module Integrated
   class RemoveHouseholdMemberController < RemoveMemberController
     def update_models
+      if member.is_spouse?
+        current_application.primary_member.update!(married: "no")
+      end
+
       flash[:notice] = if member && current_application.members.delete(member)
                          "Removed the household member."
                        else

--- a/app/controllers/integrated/who_is_married_controller.rb
+++ b/app/controllers/integrated/who_is_married_controller.rb
@@ -1,0 +1,29 @@
+module Integrated
+  class WhoIsMarriedController < FormsController
+    def self.skip?(application)
+      return true if application.single_member_household?
+      return true unless application.navigator.anyone_married?
+    end
+
+    def edit
+      @form = form_class.new(members: current_application.members)
+    end
+
+    def update
+      @form = form_class.new(members: current_application.members)
+      @form.members.each do |member|
+        attrs = params.dig(:form, :members, member.to_param)
+        if attrs.present?
+          member.assign_attributes(attrs.permit(form_class.member_attributes))
+        end
+      end
+
+      if @form.valid?
+        ActiveRecord::Base.transaction { @form.members.each(&:save!) }
+        redirect_to next_path
+      else
+        render :edit
+      end
+    end
+  end
+end

--- a/app/forms/anyone_married_form.rb
+++ b/app/forms/anyone_married_form.rb
@@ -1,0 +1,3 @@
+class AnyoneMarriedForm < Form
+  set_navigator_attributes(:anyone_married)
+end

--- a/app/forms/are_you_married_form.rb
+++ b/app/forms/are_you_married_form.rb
@@ -1,0 +1,3 @@
+class AreYouMarriedForm < Form
+  set_member_attributes(:married)
+end

--- a/app/forms/form_navigation.rb
+++ b/app/forms/form_navigation.rb
@@ -29,6 +29,8 @@ class FormNavigation
     ],
     "Household" => [
       Integrated::AreYouMarriedController,
+      Integrated::AnyoneMarriedController,
+      Integrated::WhoIsMarriedController,
     ],
     "Finish" => [
       Integrated::ApplicationSubmittedController,

--- a/app/forms/form_navigation.rb
+++ b/app/forms/form_navigation.rb
@@ -27,6 +27,9 @@ class FormNavigation
       Integrated::DescribeTaxRelationshipsController,
       Integrated::ReviewTaxRelationshipsController,
     ],
+    "Household" => [
+      Integrated::AreYouMarriedController,
+    ],
     "Finish" => [
       Integrated::ApplicationSubmittedController,
     ],

--- a/app/forms/who_is_married_form.rb
+++ b/app/forms/who_is_married_form.rb
@@ -1,0 +1,11 @@
+class WhoIsMarriedForm < Form
+  set_member_attributes(:married)
+  set_application_attributes(:members)
+
+  validate :at_least_one_person_married
+
+  def at_least_one_person_married
+    return true if members.any?(&:married_yes?)
+    errors.add(:members, "Make sure you select at least one person")
+  end
+end

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -373,8 +373,13 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
                                                  help_text: nil,
                                                  prefix: legend_id)
 
+    classes = ["checkbox"]
+    if options[:disabled] && object.public_send(method) == checked_value
+      classes.push("is-selected")
+    end
+
     <<~HTML.html_safe
-      <label class="checkbox" id="#{sanitized_id(method)}__label">
+      <label class="#{classes.join(' ')}" id="#{sanitized_id(method)}__label">
         #{check_box(method, options, checked_value, unchecked_value)} #{label_text}
       </label>
       #{errors_for(object, method)}

--- a/app/models/household_member.rb
+++ b/app/models/household_member.rb
@@ -18,6 +18,7 @@ class HouseholdMember < ApplicationRecord
   }
 
   enum sex: { unfilled: 0, male: 1, female: 2 }, _prefix: :sex
+  enum married: { unfilled: 0, yes: 1, no: 2 }, _prefix: :married
 
   enum relationship: {
     unknown_relation: 0,

--- a/app/pdf_components/assistance_application_form.rb
+++ b/app/pdf_components/assistance_application_form.rb
@@ -54,6 +54,8 @@ class AssistanceApplicationForm
       hash[:"#{prefix}dob"] = mmddyyyy_date(member.birthday)
       hash[:"#{prefix}male"] = circle_if_true(member.sex_male?)
       hash[:"#{prefix}female"] = circle_if_true(member.sex_female?)
+      hash[:"#{prefix}married_yes"] = circle_if_true(member.married_yes?)
+      hash[:"#{prefix}married_no"] = circle_if_true(member.married_no?)
       hash[:"#{prefix}requesting_food"] = underline_if_true(member.requesting_food_yes?)
       hash[:"#{prefix}requesting_healthcare"] = underline_if_true(member.requesting_healthcare_yes?)
     end
@@ -65,6 +67,7 @@ class AssistanceApplicationForm
         hash[:notes] += "Legal name: #{extra_member.display_name}, "
         hash[:notes] += "Sex: #{extra_member.sex.titleize}, "
         hash[:notes] += "DOB: #{mmddyyyy_date(extra_member.birthday)}, "
+        hash[:notes] += "Married: #{extra_member.married.titleize}, "
         if extra_member.requesting_food_yes? || extra_member.requesting_healthcare_yes?
           programs = %w{Food Healthcare}.select do |program|
             extra_member.public_send(:"requesting_#{program.downcase}_yes?")

--- a/app/views/integrated/anyone_married/edit.html.erb
+++ b/app/views/integrated/anyone_married/edit.html.erb
@@ -1,12 +1,12 @@
 <% content_for :header_title, "Household" %>
 
-<% content_for :form_card_title, "Are you married?" %>
+<% content_for :form_card_title, "Is anyone in your household currently married?" %>
 
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
-        <%= f.mb_yes_no_buttons :married,
-          yes_value: "yes",
-          no_value: "no"
+        <%= f.mb_yes_no_buttons :anyone_married,
+          yes_value: true,
+          no_value: false
         %>
     <% end %>
 <% end %>

--- a/app/views/integrated/are_you_married/edit.html.erb
+++ b/app/views/integrated/are_you_married/edit.html.erb
@@ -1,0 +1,12 @@
+<% content_for :header_title, "Household" %>
+
+<% content_for :form_card_title, "Are you married?" %>
+
+<% content_for :form_card_body do %>
+    <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
+        <%= f.mb_yes_no_buttons :married,
+          yes_value: "yes",
+          no_value: "no"
+        %>
+    <% end %>
+<% end %>

--- a/app/views/integrated/who_is_married/edit.html.erb
+++ b/app/views/integrated/who_is_married/edit.html.erb
@@ -1,0 +1,25 @@
+<% content_for :header_title, "Household" %>
+
+<% content_for :form_card_title, "Who in the household is currently married?" %>
+
+<% content_for :form_card_body do %>
+    <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
+      <fieldset class="input-group">
+        <legend class="sr-only" id="married__legend">
+          Choose who is married.
+        </legend>
+        <% @form.members.each do |member| %>
+          <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
+              <%= ff.mb_checkbox :married,
+                member.display_name,
+                legend_id: "married__legend",
+                options: {
+                  checked_value: "yes",
+                  unchecked_value: "no",
+                  disabled: member.married_yes?,
+                } %>
+          <% end %>
+        <% end %>
+      </fieldset>
+    <% end %>
+<% end %>

--- a/db/migrate/20180326172141_add_married_to_household_member.rb
+++ b/db/migrate/20180326172141_add_married_to_household_member.rb
@@ -1,0 +1,6 @@
+class AddMarriedToHouseholdMember < ActiveRecord::Migration[5.1]
+  def change
+    add_column :household_members, :married, :integer
+    change_column_default :household_members, :married, from: nil, to: 0
+  end
+end

--- a/db/migrate/20180326174327_add_anyone_married_to_application_navigator.rb
+++ b/db/migrate/20180326174327_add_anyone_married_to_application_navigator.rb
@@ -1,0 +1,6 @@
+class AddAnyoneMarriedToApplicationNavigator < ActiveRecord::Migration[5.1]
+  def change
+    add_column :application_navigators, :anyone_married, :boolean
+    change_column_default :application_navigators, :anyone_married, from: nil, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180321002715) do
+ActiveRecord::Schema.define(version: 20180326172141) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,6 +152,7 @@ ActiveRecord::Schema.define(version: 20180321002715) do
     t.integer "filing_taxes_next_year", default: 0
     t.string "first_name"
     t.string "last_name"
+    t.integer "married", default: 0
     t.integer "relationship", default: 0
     t.integer "requesting_food", default: 0
     t.integer "requesting_healthcare", default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180326172141) do
+ActiveRecord::Schema.define(version: 20180326174327) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -61,6 +61,7 @@ ActiveRecord::Schema.define(version: 20180326172141) do
   create_table "application_navigators", force: :cascade do |t|
     t.boolean "all_share_food_costs", default: true
     t.boolean "anyone_else_on_tax_return", default: true
+    t.boolean "anyone_married", default: false
     t.bigint "common_application_id"
     t.datetime "created_at", null: false
     t.boolean "resides_in_state", default: true

--- a/lib/generators/section/templates/form_controller.template.rb
+++ b/lib/generators/section/templates/form_controller.template.rb
@@ -2,25 +2,27 @@ module Integrated
   class <%= model.camelcase %>Controller < FormsController
     <%- if options.doc? -%>
     # If controller should be skipped for any reason, uncomment the following and modify logic:
-    #
-    #   def self.skip?(application)
-    #     application.stable_housing?
-    #   end
-    #
+    <%- end -%>
+    def self.skip?(application)
+      # application.stable_housing?
+    end
+
+    <%- if options.doc? -%>
     # If updating models, uncomment the following and modify required logic:
-    #
-    #   def update_models
-    #     current_application.primary_member.update(member_params)
-    #     current_application.update(application_params)
-    #   end
-    #
+    <%- end -%>
+
+    def update_models
+      # current_application.primary_member.update(member_params)
+      # current_application.update(application_params)
+    end
+
+    <%- if options.doc? -%>
     # If no database update is needed, uncomment the following `form_class` method
     # to override the form class (otherwise form class will
     # default to <%= model.underscore %>Form):
-    #
+    <%- end -%>
     #   def form_class
     #     NullStep
     #   end
-    <%- end -%>
   end
 end

--- a/lib/generators/section/templates/form_controller_spec.template.rb
+++ b/lib/generators/section/templates/form_controller_spec.template.rb
@@ -45,7 +45,7 @@ RSpec.describe Integrated::<%= model.camelcase %>Controller do
         current_app = create(:common_application)
         session[:current_application_id] = current_app.id
 
-        put :update, params: valid_params
+        put :update, params: { form: valid_params }
 
         current_app.reload
 
@@ -62,7 +62,7 @@ RSpec.describe Integrated::<%= model.camelcase %>Controller do
         current_app = create(:common_application)
         session[:current_application_id] = current_app.id
 
-        put :update, params: invalid_params
+        put :update, params: { form: invalid_params }
 
         expect(response).to render_template(:edit)
       end

--- a/spec/controllers/integrated/add_food_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_food_member_controller_spec.rb
@@ -10,18 +10,13 @@ RSpec.describe Integrated::AddFoodMemberController do
           form: {
             first_name: "Gary",
             last_name: "McTester",
-            birthday_day: "31",
-            birthday_month: "1",
-            birthday_year: "1950",
-            sex: "male",
-            relationship: "roommate",
           },
         }
       end
 
-      it "creates a new member with given information" do
+      it "marks new member as buying and preparing food together" do
         current_app = create(:common_application,
-                             members: [create(:household_member, first_name: "Juan")])
+          members: [create(:household_member, first_name: "Juan")])
         session[:current_application_id] = current_app.id
 
         put :update, params: valid_params
@@ -29,41 +24,6 @@ RSpec.describe Integrated::AddFoodMemberController do
         current_app.reload
 
         new_member = current_app.members.last
-        expect(new_member.first_name).to eq("Gary")
-        expect(new_member.last_name).to eq("McTester")
-        expect(new_member.birthday).to eq(DateTime.new(1950, 1, 31))
-        expect(new_member.sex).to eq("male")
-        expect(new_member.relationship).to eq("roommate")
-        expect(new_member.requesting_food).to eq("yes")
-        expect(new_member.buy_and_prepare_food_together).to eq("yes")
-      end
-    end
-
-    context "with minimal valid params" do
-      let(:valid_params) do
-        {
-          form: {
-            first_name: "Gary",
-            last_name: "McTester",
-          },
-        }
-      end
-
-      it "creates a new member with given information" do
-        current_app = create(:common_application,
-                             members: [create(:household_member, first_name: "Juan")])
-        session[:current_application_id] = current_app.id
-
-        put :update, params: valid_params
-
-        current_app.reload
-
-        new_member = current_app.members.last
-        expect(new_member.first_name).to eq("Gary")
-        expect(new_member.last_name).to eq("McTester")
-        expect(new_member.birthday).to be_nil
-        expect(new_member.sex).to eq("unfilled")
-        expect(new_member.relationship).to eq("unknown_relation")
         expect(new_member.requesting_food).to eq("yes")
         expect(new_member.buy_and_prepare_food_together).to eq("yes")
       end

--- a/spec/controllers/integrated/add_household_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_household_member_controller_spec.rb
@@ -3,69 +3,6 @@ require "rails_helper"
 RSpec.describe Integrated::AddHouseholdMemberController do
   it_behaves_like "add member controller"
 
-  describe "#update" do
-    context "with valid params" do
-      let(:valid_params) do
-        {
-          form: {
-            first_name: "Gary",
-            last_name: "McTester",
-            birthday_day: "31",
-            birthday_month: "1",
-            birthday_year: "1950",
-            sex: "male",
-            relationship: "roommate",
-          },
-        }
-      end
-
-      it "creates a new member with given information" do
-        current_app = create(:common_application,
-          members: [create(:household_member, first_name: "Juan")])
-        session[:current_application_id] = current_app.id
-
-        put :update, params: valid_params
-
-        current_app.reload
-
-        new_member = current_app.members.last
-        expect(new_member.first_name).to eq("Gary")
-        expect(new_member.last_name).to eq("McTester")
-        expect(new_member.birthday).to eq(DateTime.new(1950, 1, 31))
-        expect(new_member.sex).to eq("male")
-        expect(new_member.relationship).to eq("roommate")
-      end
-    end
-
-    context "with minimal valid params" do
-      let(:valid_params) do
-        {
-          form: {
-            first_name: "Gary",
-            last_name: "McTester",
-          },
-        }
-      end
-
-      it "creates a new member with given information" do
-        current_app = create(:common_application,
-          members: [create(:household_member, first_name: "Juan")])
-        session[:current_application_id] = current_app.id
-
-        put :update, params: valid_params
-
-        current_app.reload
-
-        new_member = current_app.members.last
-        expect(new_member.first_name).to eq("Gary")
-        expect(new_member.last_name).to eq("McTester")
-        expect(new_member.birthday).to be_nil
-        expect(new_member.sex).to eq("unfilled")
-        expect(new_member.relationship).to eq("unknown_relation")
-      end
-    end
-  end
-
   describe ".previous_path" do
     it "should be household overview path" do
       expect(controller.previous_path).to eq(household_members_overview_sections_path)

--- a/spec/controllers/integrated/add_tax_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_tax_member_controller_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Integrated::AddTaxMemberController do
-  it_behaves_like "add member controller"
+  it_behaves_like "add member controller", tax_relationship: "dependent"
 
   describe "#update" do
     context "with valid params" do
@@ -13,7 +13,7 @@ RSpec.describe Integrated::AddTaxMemberController do
         }
       end
 
-      it "updates the models" do
+      it "updates the tax relationship" do
         current_app = create(:common_application)
         session[:current_application_id] = current_app.id
 
@@ -22,28 +22,7 @@ RSpec.describe Integrated::AddTaxMemberController do
         end.to change { current_app.members.count }.by 1
 
         member = current_app.members.last
-        expect(member.first_name).to eq("Princess")
-        expect(member.last_name).to eq("Caroline")
         expect(member.tax_relationship_dependent?).to be_truthy
-      end
-    end
-
-    context "with invalid params" do
-      let(:invalid_params) do
-        {
-          first_name: "Princess",
-          last_name: "Caroline",
-          tax_relationship: nil,
-        }
-      end
-
-      it "renders edit without updating" do
-        current_app = create(:common_application)
-        session[:current_application_id] = current_app.id
-
-        put :update, params: { form: invalid_params }
-
-        expect(response).to render_template(:edit)
       end
     end
   end

--- a/spec/controllers/integrated/anyone_married_controller_spec.rb
+++ b/spec/controllers/integrated/anyone_married_controller_spec.rb
@@ -1,0 +1,62 @@
+require "rails_helper"
+
+RSpec.describe Integrated::AnyoneMarriedController do
+  describe "#skip?" do
+    context "when single member household" do
+      it "returns true" do
+        application = create(:common_application, :single_member)
+
+        skip_step = Integrated::AnyoneMarriedController.skip?(application)
+        expect(skip_step).to be_truthy
+      end
+    end
+
+    context "when multi member household" do
+      context "anyone is married" do
+        it "returns true" do
+          application = create(:common_application,
+            navigator: build(:application_navigator, anyone_married: true),
+            members: build_list(:household_member, 2))
+
+          skip_step = Integrated::AnyoneMarriedController.skip?(application)
+          expect(skip_step).to be_truthy
+        end
+      end
+
+      context "no one is married" do
+        it "returns false" do
+          application = create(:common_application,
+            navigator: build(:application_navigator, anyone_married: false),
+            members: build_list(:household_member, 2))
+
+          skip_step = Integrated::AnyoneMarriedController.skip?(application)
+          expect(skip_step).to be_falsey
+        end
+      end
+    end
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:valid_params) do
+        {
+          anyone_married: "true",
+        }
+      end
+
+      it "updates the models" do
+        current_app = create(:common_application,
+          navigator: build(:application_navigator),
+          members: build_list(:household_member, 2))
+        session[:current_application_id] = current_app.id
+
+        expect do
+          put :update, params: { form: valid_params }
+        end.to change {
+          current_app.reload
+          current_app.navigator.anyone_married?
+        }.to eq(true)
+      end
+    end
+  end
+end

--- a/spec/controllers/integrated/are_you_married_controller_spec.rb
+++ b/spec/controllers/integrated/are_you_married_controller_spec.rb
@@ -30,12 +30,17 @@ RSpec.describe Integrated::AreYouMarriedController do
       end
 
       it "updates the models" do
-        current_app = create(:common_application, members: build_list(:household_member, 1))
+        current_app = create(:common_application,
+          navigator: build(:application_navigator),
+          members: build_list(:household_member, 1))
         session[:current_application_id] = current_app.id
 
-        expect do
-          put :update, params: { form: valid_params }
-        end.to change { current_app.primary_member.married_yes? }.to eq(true)
+        put :update, params: { form: valid_params }
+
+        current_app.reload
+
+        expect(current_app.primary_member.married_yes?).to eq(true)
+        expect(current_app.navigator.anyone_married?).to eq(true)
       end
     end
   end

--- a/spec/controllers/integrated/are_you_married_controller_spec.rb
+++ b/spec/controllers/integrated/are_you_married_controller_spec.rb
@@ -33,9 +33,9 @@ RSpec.describe Integrated::AreYouMarriedController do
         current_app = create(:common_application, members: build_list(:household_member, 1))
         session[:current_application_id] = current_app.id
 
-        expect {
+        expect do
           put :update, params: { form: valid_params }
-        }.to change{ current_app.primary_member.married_yes? }.to eq(true)
+        end.to change { current_app.primary_member.married_yes? }.to eq(true)
       end
     end
   end

--- a/spec/controllers/integrated/are_you_married_controller_spec.rb
+++ b/spec/controllers/integrated/are_you_married_controller_spec.rb
@@ -1,0 +1,42 @@
+require "rails_helper"
+
+RSpec.describe Integrated::AreYouMarriedController do
+  describe "#skip?" do
+    context "when household has one member" do
+      it "returns false" do
+        application = create(:common_application, members: build_list(:household_member, 1))
+
+        skip_step = Integrated::AreYouMarriedController.skip?(application)
+        expect(skip_step).to be_falsey
+      end
+    end
+
+    context "when household has more than one member" do
+      it "returns true" do
+        application = create(:common_application, members: build_list(:household_member, 2))
+
+        skip_step = Integrated::AreYouMarriedController.skip?(application)
+        expect(skip_step).to be_truthy
+      end
+    end
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:valid_params) do
+        {
+          married: "yes",
+        }
+      end
+
+      it "updates the models" do
+        current_app = create(:common_application, members: build_list(:household_member, 1))
+        session[:current_application_id] = current_app.id
+
+        expect {
+          put :update, params: { form: valid_params }
+        }.to change{ current_app.primary_member.married_yes? }.to eq(true)
+      end
+    end
+  end
+end

--- a/spec/controllers/integrated/remove_food_member_controller_spec.rb
+++ b/spec/controllers/integrated/remove_food_member_controller_spec.rb
@@ -1,5 +1,7 @@
 require "rails_helper"
 
+RSpec::Matchers.define_negated_matcher :not_change, :change
+
 RSpec.describe Integrated::RemoveFoodMemberController do
   describe "#update" do
     it "removes member from SNAP applying members" do
@@ -12,10 +14,13 @@ RSpec.describe Integrated::RemoveFoodMemberController do
       expect(current_app.food_applying_members.count).to eq(2)
       expect(current_app.food_household_members.count).to eq(2)
 
-      put :update, params: { form: { member_id: member_two.id } }
-      current_app.reload
-      expect(current_app.food_applying_members.count).to eq(2)
-      expect(current_app.food_household_members.count).to eq(1)
+      expect do
+        put :update, params: { form: { member_id: member_two.id } }
+      end.to not_change {
+        current_app.food_applying_members.count
+      }.and change {
+        current_app.food_household_members.count
+      }.by(-1)
     end
   end
 end

--- a/spec/controllers/integrated/remove_household_member_controller_spec.rb
+++ b/spec/controllers/integrated/remove_household_member_controller_spec.rb
@@ -6,14 +6,29 @@ RSpec.describe Integrated::RemoveHouseholdMemberController do
       member_one = build(:household_member)
       member_two = build(:household_member)
       current_app = create(:common_application,
-                           members: [member_one, member_two])
+        members: [member_one, member_two])
 
       session[:current_application_id] = current_app.id
-      expect(current_app.members.count).to eq(2)
 
-      put :update, params: { form: { member_id: member_two.id } }
-      current_app.reload
-      expect(current_app.members.count).to eq(1)
+      expect do
+        put :update, params: { form: { member_id: member_two.id } }
+      end.to change { current_app.members.count }.by(-1)
+    end
+
+    context "when removed member is spouse" do
+      it "updates primary member to unmarried" do
+        member_one = build(:household_member, married: "yes")
+        member_two = build(:household_member, married: "yes", relationship: "spouse")
+        current_app = create(:common_application, members: [
+                               member_one, member_two
+                             ])
+
+        session[:current_application_id] = current_app.id
+
+        expect do
+          put :update, params: { form: { member_id: member_two.id } }
+        end.to change { current_app.primary_member.married_no? }.from(false).to(true)
+      end
     end
   end
 end

--- a/spec/controllers/integrated/who_is_married_controller_spec.rb
+++ b/spec/controllers/integrated/who_is_married_controller_spec.rb
@@ -1,0 +1,127 @@
+require "rails_helper"
+
+RSpec.describe Integrated::WhoIsMarriedController do
+  describe "#skip?" do
+    context "when single member household" do
+      it "returns true" do
+        application = create(:common_application, :single_member)
+
+        skip_step = Integrated::WhoIsMarriedController.skip?(application)
+        expect(skip_step).to be_truthy
+      end
+    end
+
+    context "when multi member household" do
+      context "and someone is household is married" do
+        it "returns false" do
+          application = create(:common_application,
+            navigator: build(:application_navigator, anyone_married: true),
+            members: build_list(:household_member, 2))
+
+          skip_step = Integrated::WhoIsMarriedController.skip?(application)
+          expect(skip_step).to be_falsey
+        end
+      end
+
+      context "and no one in household is married" do
+        it "returns true" do
+          application = create(:common_application,
+            navigator: build(:application_navigator, anyone_married: false),
+            members: build_list(:household_member, 2))
+
+          skip_step = Integrated::WhoIsMarriedController.skip?(application)
+          expect(skip_step).to be_truthy
+        end
+      end
+    end
+  end
+
+  describe "edit" do
+    context "with a current application" do
+      it "assigns existing attributes" do
+        current_app = create(:common_application,
+          members: build_list(:household_member, 2, married: "yes"))
+        session[:current_application_id] = current_app.id
+
+        get :edit
+
+        form = assigns(:form)
+
+        expect(form.members.first.married_yes?).to eq(true)
+        expect(form.members.second.married_yes?).to eq(true)
+      end
+    end
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:member_1) do
+        create(:household_member)
+      end
+
+      let(:member_2) do
+        create(:household_member)
+      end
+
+      let(:valid_params) do
+        {
+          members: {
+            member_1.id => {
+              married: "no",
+            },
+            member_2.id => {
+              married: "yes",
+            },
+          },
+        }
+      end
+
+      it "updates each member with marriage info" do
+        current_app = create(:common_application, members: [member_1, member_2])
+        session[:current_application_id] = current_app.id
+
+        put :update, params: { form: valid_params }
+
+        member_1.reload
+        member_2.reload
+
+        expect(member_1.married_no?).to be_truthy
+        expect(member_2.married_yes?).to be_truthy
+      end
+    end
+
+    context "with invalid params" do
+      let(:member_1) do
+        create(:household_member)
+      end
+
+      let(:member_2) do
+        create(:household_member)
+      end
+
+      let(:invalid_params) do
+        {
+          members: {
+            member_1.id => {
+              married: "no",
+            },
+            member_2.id => {
+              married: "no",
+            },
+          },
+        }
+      end
+
+      it "renders edit without updating" do
+        current_app = create(:common_application,
+          members: [member_1, member_2],
+          navigator: build(:application_navigator, anyone_married: true))
+        session[:current_application_id] = current_app.id
+
+        put :update, params: { form: invalid_params }
+
+        expect(response).to render_template(:edit)
+      end
+    end
+  end
+end

--- a/spec/features/integrated_application_food_only_two_members_spec.rb
+++ b/spec/features/integrated_application_food_only_two_members_spec.rb
@@ -69,6 +69,8 @@ RSpec.feature "Integrated application" do
       fill_in "What's their first name?", with: "Jonny"
       fill_in "What's their last name?", with: "Tester"
 
+      select "Spouse", from: "form_relationship"
+
       proceed_with "Continue"
     end
 

--- a/spec/features/integrated_application_with_multiple_members_spec.rb
+++ b/spec/features/integrated_application_with_multiple_members_spec.rb
@@ -286,6 +286,18 @@ RSpec.feature "Integrated application" do
       proceed_with "Continue"
     end
 
+    on_page "Household" do
+      expect(page).to have_content(
+        "Who in the household is currently married?",
+      )
+
+      # Jessie Tester checked by default
+      # Jonny Tester checked by default
+      check "Joe Schmoe"
+
+      proceed_with "Continue"
+    end
+
     on_page "Application Submitted" do
       expect(page).to have_content(
         "Congratulations",

--- a/spec/features/integrated_application_with_single_member_spec.rb
+++ b/spec/features/integrated_application_with_single_member_spec.rb
@@ -99,6 +99,12 @@ RSpec.feature "Integrated application" do
       proceed_with "Continue"
     end
 
+    on_page "Household" do
+      expect(page).to have_content("Are you married?")
+
+      proceed_with "Yes"
+    end
+
     on_page "Application Submitted" do
       expect(page).to have_content(
         "Congratulations",

--- a/spec/features/integrated_application_with_two_members_spec.rb
+++ b/spec/features/integrated_application_with_two_members_spec.rb
@@ -142,6 +142,14 @@ RSpec.feature "Integrated application" do
       proceed_with "No"
     end
 
+    on_page "Household" do
+      expect(page).to have_content(
+        "Is anyone in your household currently married?",
+      )
+
+      proceed_with "No"
+    end
+
     on_page "Application Submitted" do
       expect(page).to have_content(
         "Congratulations",

--- a/spec/forms/who_is_married_form_spec.rb
+++ b/spec/forms/who_is_married_form_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe WhoIsMarriedForm do
+  describe "validations" do
+    context "when no members are married" do
+      it "is invalid" do
+        members = build_list(:household_member, 2, married: "no")
+        form = WhoIsMarriedForm.new(members: members)
+
+        expect(form).to_not be_valid
+      end
+    end
+
+    context "when at least one member is married" do
+      it "is valid" do
+        members = build_list(:household_member, 2, married: "yes")
+        form = WhoIsMarriedForm.new(members: members)
+
+        expect(form).to be_valid
+      end
+    end
+  end
+end

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -576,6 +576,34 @@ RSpec.describe MbFormBuilder do
         </label>
       HTML
     end
+
+    context "when checkbox is disabled and value is equal to checked value" do
+      it "renders disabled checkbox as selected" do
+        class SampleStep < Step
+          step_attributes(:read_tos)
+        end
+
+        sample = SampleStep.new(read_tos: "yes")
+        form = MbFormBuilder.new("sample", sample, template, {})
+        output = form.mb_checkbox(:read_tos,
+          "Confirm that you agree to Terms of Service",
+          options: {
+            checked_value: "yes",
+            unchecked_value: "no",
+            disabled: true,
+          })
+
+        expect(output).to be_html_safe
+
+        expect(output).to match_html <<-HTML
+        <label class="checkbox is-selected" id="sample_read_tos__label">
+          <input name="sample[read_tos]" disabled="disabled" type="hidden" value="no" />
+          <input checked_value="yes" unchecked_value="no" disabled="disabled" aria-labelledby="sample_read_tos__label" type="checkbox" value="yes" checked="checked" name="sample[read_tos]" id="sample_read_tos" />
+          Confirm that you agree to Terms of Service
+        </label>
+        HTML
+      end
+    end
   end
 
   describe "#mb_yes_no_buttons" do

--- a/spec/pdf_components/assistance_application_form_spec.rb
+++ b/spec/pdf_components/assistance_application_form_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe AssistanceApplicationForm do
           sex_male?: true,
           sex_female?: false,
           requesting_food_yes?: true,
-          requesting_healthcare_yes?: true)
+          requesting_healthcare_yes?: true,
+          married_yes?: true,
+          married_no?: false)
       end
 
       let(:common_application) do
@@ -62,20 +64,15 @@ RSpec.describe AssistanceApplicationForm do
           first_member_dob: "10/18/1991",
           first_member_male: Integrated::PdfAttributes::CIRCLED,
           first_member_female: nil,
+          first_member_married_yes: Integrated::PdfAttributes::CIRCLED,
+          first_member_married_no: nil,
         )
       end
     end
 
     context "an application with six members" do
       let(:primary_member) do
-        instance_double("household_member",
-                        display_name: "Octopus Cuttlefish",
-                        relationship_label: "You",
-                        birthday: DateTime.new(1991, 10, 18),
-                        sex_male?: true,
-                        sex_female?: false,
-                        requesting_food_yes?: true,
-                        requesting_healthcare_yes?: true)
+        instance_double("primary household_member").as_null_object
       end
 
       let(:common_application) do
@@ -88,45 +85,18 @@ RSpec.describe AssistanceApplicationForm do
                         stable_address?: false,
                         primary_member: primary_member,
                         members: [primary_member,
-                                  instance_double("household_member",
-                                    display_name: "Tuna Anemone",
-                                    relationship_label: "Spouse",
-                                    birthday: DateTime.new(1991, 10, 18),
-                                    sex_male?: true,
-                                    sex_female?: false,
-                                    requesting_food_yes?: true,
-                                    requesting_healthcare_yes?: false),
-                                  instance_double("household_member",
-                                    display_name: "Coral Eel",
-                                    relationship_label: "Parent",
-                                    birthday: DateTime.new(1991, 10, 18),
-                                    sex_male?: true,
-                                    sex_female?: false,
-                                    requesting_food_yes?: true,
-                                    requesting_healthcare_yes?: false),
-                                  instance_double("household_member",
-                                    display_name: "Snail Squid",
-                                    relationship_label: "Parent",
-                                    birthday: DateTime.new(1991, 10, 18),
-                                    sex_male?: true,
-                                    sex_female?: false,
-                                    requesting_food_yes?: true,
-                                    requesting_healthcare_yes?: false),
-                                  instance_double("household_member",
-                                    display_name: "Flounder Halibut",
-                                    relationship_label: "Sibling",
-                                    birthday: DateTime.new(1991, 10, 18),
-                                    sex_male?: true,
-                                    sex_female?: false,
-                                    requesting_food_yes?: false,
-                                    requesting_healthcare_yes?: false),
-                                  instance_double("household_member",
+                                  instance_double("household_member 2").as_null_object,
+                                  instance_double("household_member 3").as_null_object,
+                                  instance_double("household_member 4").as_null_object,
+                                  instance_double("household_member 5").as_null_object,
+                                  instance_double("household_member 6",
                                     display_name: "Willy Whale",
                                     relationship_label: "Child",
                                     birthday: DateTime.new(1995, 10, 18),
                                     sex: "male",
                                     requesting_food_yes?: true,
-                                    requesting_healthcare_yes?: true)])
+                                    requesting_healthcare_yes?: true,
+                                    married: "yes")])
       end
 
       let(:attributes) do
@@ -135,36 +105,12 @@ RSpec.describe AssistanceApplicationForm do
 
       it "returns a hash with basic information" do
         expect(attributes).to include(
-          first_member_legal_name: "Octopus Cuttlefish",
-          first_member_dob: "10/18/1991",
-          first_member_male: Integrated::PdfAttributes::CIRCLED,
-          first_member_female: nil,
-          second_member_legal_name: "Tuna Anemone",
-          second_member_relation: "Spouse",
-          second_member_dob: "10/18/1991",
-          second_member_male: Integrated::PdfAttributes::CIRCLED,
-          second_member_female: nil,
-          third_member_legal_name: "Coral Eel",
-          third_member_relation: "Parent",
-          third_member_dob: "10/18/1991",
-          third_member_male: Integrated::PdfAttributes::CIRCLED,
-          third_member_female: nil,
-          fourth_member_legal_name: "Snail Squid",
-          fourth_member_relation: "Parent",
-          fourth_member_dob: "10/18/1991",
-          fourth_member_male: Integrated::PdfAttributes::CIRCLED,
-          fourth_member_female: nil,
-          fifth_member_legal_name: "Flounder Halibut",
-          fifth_member_relation: "Sibling",
-          fifth_member_dob: "10/18/1991",
-          fifth_member_male: Integrated::PdfAttributes::CIRCLED,
-          fifth_member_female: nil,
           household_added_notes: "Yes",
         )
         expect(attributes[:notes]).to eq(
           <<~NOTES
             Additional Household Members:
-            - Relation: Child, Legal name: Willy Whale, Sex: Male, DOB: 10/18/1995, Applying for: Food, Healthcare
+            - Relation: Child, Legal name: Willy Whale, Sex: Male, DOB: 10/18/1995, Married: Yes, Applying for: Food, Healthcare
           NOTES
         )
       end

--- a/spec/support/shared_examples/add_member_controller.rb
+++ b/spec/support/shared_examples/add_member_controller.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.shared_examples_for "add member controller" do
+RSpec.shared_examples_for "add member controller" do |additional_valid_params|
   describe ".valid_relationship_options" do
     context "with one spouse household member" do
       it "does not include spouse as relationship option" do
@@ -9,9 +9,9 @@ RSpec.shared_examples_for "add member controller" do
 
         session[:current_application_id] = current_app.id
 
-        expect(controller.valid_relationship_options).to_not include([
-                                                                       "Spouse", "spouse"
-                                                                     ])
+        expect(controller.valid_relationship_options).to_not include(
+          ["Spouse", "spouse"],
+        )
       end
     end
 
@@ -21,9 +21,102 @@ RSpec.shared_examples_for "add member controller" do
 
         session[:current_application_id] = current_app.id
 
-        expect(controller.valid_relationship_options).to include([
-                                                                   "Spouse", "spouse"
-                                                                 ])
+        expect(controller.valid_relationship_options).to include(
+          ["Spouse", "spouse"],
+        )
+      end
+    end
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:base_valid_params) do
+        {
+          first_name: "Gary",
+          last_name: "McTester",
+          birthday_day: "31",
+          birthday_month: "1",
+          birthday_year: "1950",
+          sex: "male",
+          relationship: "roommate",
+        }
+      end
+
+      let(:additional_params) do
+        additional_valid_params || {}
+      end
+
+      let(:valid_params) do
+        base_valid_params.merge(additional_params)
+      end
+
+      it "creates a new member with given information" do
+        current_app = create(:common_application,
+          members: [create(:household_member, first_name: "Juan")])
+        session[:current_application_id] = current_app.id
+
+        put :update, params: { form: valid_params }
+
+        current_app.reload
+        new_member = current_app.members.second
+
+        expect(current_app.members.count).to eq(2)
+        expect(new_member.first_name).to eq("Gary")
+        expect(new_member.last_name).to eq("McTester")
+        expect(new_member.birthday).to eq(DateTime.new(1950, 1, 31))
+        expect(new_member.sex).to eq("male")
+        expect(new_member.relationship).to eq("roommate")
+      end
+
+      context "when spouse indicated as relationship for any member" do
+        let(:spouse_params) do
+          valid_params.merge(relationship: "spouse")
+        end
+
+        it "updates primary member and spouse to married" do
+          current_app = create(:common_application,
+            navigator: build(:application_navigator),
+            members: [create(:household_member)])
+          session[:current_application_id] = current_app.id
+
+          put :update, params: { form: spouse_params }
+
+          current_app.reload
+
+          expect(current_app.primary_member.married_yes?).to eq(true)
+          expect(current_app.members.second.married_yes?).to eq(true)
+        end
+
+        it "updates navigator" do
+          current_app = create(:common_application,
+            navigator: build(:application_navigator),
+            members: [create(:household_member)])
+          session[:current_application_id] = current_app.id
+
+          expect do
+            put :update, params: { form: spouse_params }
+          end.to change {
+            current_app.reload
+            current_app.navigator.anyone_married?
+          }.to eq(true)
+        end
+      end
+    end
+
+    context "with invalid params" do
+      let(:invalid_params) do
+        {
+          first_name: nil,
+        }
+      end
+
+      it "renders edit without updating" do
+        current_app = create(:common_application)
+        session[:current_application_id] = current_app.id
+
+        put :update, params: { form: invalid_params }
+
+        expect(response).to render_template(:edit)
       end
     end
   end


### PR DESCRIPTION
Does a couple of feature things:

1) If user has added a member and that member is their spouse, mark them as married (on `household_member`) and as someone in the household being married (on `navigator`).
1) *In single-member household*: asks user if they're married
1) *In multi-member household with no known spouses*: asks user if anyone in household is married.
1) *In multi-member household with known married people*: asks user who is married. On this screen, they can't deselect members that have indicated they're married by relation "spouse", and they must select at least one married person.

Commits have a decent descriptions of other things done along the way.

![screen shot 2018-03-26 at 5 51 36 pm](https://user-images.githubusercontent.com/3675092/37941024-bd3d54a2-3120-11e8-961c-506bdbb23e37.png)
![screen shot 2018-03-26 at 6 13 15 pm](https://user-images.githubusercontent.com/3675092/37941187-c57449c2-3121-11e8-8b79-7dfb56703199.png)
![screen shot 2018-03-26 at 5 51 51 pm](https://user-images.githubusercontent.com/3675092/37941026-bf42e7bc-3120-11e8-9990-55d7067a9ad5.png)

There ended up being a good amount of logical complexity in here. I started to feel the pain of two sources of truth (navigator's `anyone_married` vs member's `married`), but ultimately think they serve different purposes in this PR.

I'd still like to refactor the 'update' logic for multiple members—will tag a note with the relevant lines to get your thoughts. We had talked about refactoring this the next time it came up and I wanted to do so, but I ran out of time and wanted to get this up because my calendar is packed tomorrow. Some clear patterns have emerged, though!