### PR TITLE
Reveal tax relationships based on relationship to member when adding a new member

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,7 +24,7 @@ var textWell = (function () {
       })
     }
   }
-})()
+})();
 
 var radioSelector = (function () {
   var rs = {
@@ -40,11 +40,11 @@ var radioSelector = (function () {
         })
       })
     }
-  }
+  };
   return {
     init: rs.init
   }
-})()
+})();
 
 var checkboxSelector = (function () {
   var cs = {
@@ -63,11 +63,11 @@ var checkboxSelector = (function () {
         })
       })
     }
-  }
+  };
   return {
     init: cs.init
   }
-})()
+})();
 
 var yesNoButtons = (function () {
   var yn = {
@@ -80,11 +80,11 @@ var yesNoButtons = (function () {
         $('input.boolean-answer').val('1')
       })
     }
-  }
+  };
   return {
     init: yn.init
   }
-})()
+})();
 
 var yesNoEnumButtons = (function () {
   var yne = {
@@ -97,11 +97,11 @@ var yesNoEnumButtons = (function () {
         $('input.boolean-answer').val('yes')
       })
     }
-  }
+  };
   return {
     init: yne.init
   }
-})()
+})();
 
 var autoAdvanceTelInputs = (function() {
   var autoAdvance = {
@@ -113,17 +113,40 @@ var autoAdvanceTelInputs = (function() {
         }
       })
     }
-  }
+  };
   return {
     init: autoAdvance.init
   }
-})()
+})();
+
+var followUpQuestion = (function() {
+  var followUp = {
+    init: function() {
+      // any pre-selected?
+      $('.question-with-follow-up__question select').each(function(index, select) {
+        $($($(this).find('option:selected')).attr('data-follow-up')).show();
+      });
+      // handle selection events
+      $('.question-with-follow-up__question select').change(function(e) {
+        $('.question-with-follow-up__follow-up').hide();
+        $('.question-with-follow-up__follow-up input').each(function(index, radio) {
+          $(this).prop('checked', false);
+        });
+        $($($(this).find('option:selected')).attr('data-follow-up')).show();
+      });
+    }
+  };
+  return {
+    init: followUp.init
+  }
+})();
 
 $(document).ready(function () {
-  radioSelector.init()
-  checkboxSelector.init()
-  textWell.init()
-  yesNoButtons.init()
-  yesNoEnumButtons.init()
-  autoAdvanceTelInputs.init()
+  radioSelector.init();
+  checkboxSelector.init();
+  textWell.init();
+  yesNoButtons.init();
+  yesNoEnumButtons.init();
+  autoAdvanceTelInputs.init();
+  followUpQuestion.init();
 })

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -71,6 +71,7 @@
 @import "michigan-benefits/atoms/typography";
 @import "michigan-benefits/atoms/buttons";
 @import "michigan-benefits/atoms/form-elements";
+@import "michigan-benefits/molecules/form-molecules";
 @import "michigan-benefits/organisms/step-header";
 @import "michigan-benefits/organisms/form-card";
 @import "michigan-benefits/organisms/main-footer";

--- a/app/assets/stylesheets/michigan-benefits/molecules/_form-molecules.scss
+++ b/app/assets/stylesheets/michigan-benefits/molecules/_form-molecules.scss
@@ -1,0 +1,9 @@
+.question-with-follow-up__follow-up {
+  padding: {
+    bottom: 1em;
+  }
+  border-color: $color-light-grey;
+  &:before {
+    @include triangle(top, $color: $color-light-grey, $size: 12px);
+  }
+}

--- a/app/controllers/integrated/add_member_controller.rb
+++ b/app/controllers/integrated/add_member_controller.rb
@@ -1,6 +1,6 @@
 module Integrated
   class AddMemberController < FormsController
-    helper_method :valid_relationship_options
+    helper_method :valid_relationship_options, :valid_relationship_options_for_taxes
 
     def previous_path(*_args)
       overview_path
@@ -29,6 +29,21 @@ module Integrated
         HouseholdMember::RELATIONSHIP_LABELS_AND_KEYS.reject { |arr| arr.second == "spouse" }
       else
         HouseholdMember::RELATIONSHIP_LABELS_AND_KEYS
+      end
+    end
+
+    def valid_relationship_options_for_taxes
+      options_for_taxes = valid_relationship_options
+      options_for_taxes.each do |option|
+        case option[0]
+        when "Choose one"
+          option # do nothing
+        when "Spouse"
+          option << { "data-follow-up": "#spouse-follow-up" }
+        else
+          option << { "data-follow-up": "#nonspouse-follow-up" }
+        end
+        options_for_taxes
       end
     end
 

--- a/app/controllers/integrated/add_tax_member_controller.rb
+++ b/app/controllers/integrated/add_tax_member_controller.rb
@@ -6,6 +6,18 @@ module Integrated
       }
     end
 
+    def update_models
+      member_data = combined_attributes(member_params)
+      if member_data[:relationship] == "spouse"
+        member_data[:married] = "yes"
+        current_application.navigator.update!(anyone_married: true)
+        current_application.primary_member.update!(married: "yes")
+        member_data[:tax_relationship] = member_data[:tax_relationship_spouse]
+      end
+      member_data.delete(:tax_relationship_spouse)
+      current_application.members.create!(member_data)
+    end
+
     def overview_path
       review_tax_relationships_sections_path
     end

--- a/app/forms/add_tax_member_form.rb
+++ b/app/forms/add_tax_member_form.rb
@@ -8,6 +8,18 @@ class AddTaxMemberForm < AddMemberForm
     :sex,
     :relationship,
     :tax_relationship,
+    :tax_relationship_spouse,
   )
-  validates :tax_relationship, presence: { message: "Make sure to specify tax filing status." }
+
+  validates :tax_relationship,
+            presence: { message: "Make sure to specify a tax filing status." },
+            unless: :spouse?
+
+  validates :tax_relationship_spouse,
+            presence: { message: "Make sure to specify a tax filing status." },
+            if: :spouse?
+
+  def spouse?
+    relationship == "spouse"
+  end
 end

--- a/app/views/integrated/add_tax_member/edit.html.erb
+++ b/app/views/integrated/add_tax_member/edit.html.erb
@@ -17,21 +17,31 @@
                          autofocus: true %>
     <%= f.mb_input_field :last_name, "What's their last name?" %>
     <%= f.mb_date_input :birthday,
-                        "When is your birthday?",
+                        "When is their birthday?",
                         help_text: "For example: 4 28 1970" %>
     <%= f.mb_radio_set :sex,
                        label_text: "What's their sex?",
                        collection: [{ value: :male, label: "Male" }, { value: :female, label: "Female" }],
                        help_text: "As it appears on their ID",
                        layout: "inline" %>
-
-    <%= f.mb_select :relationship,
-                    "What is their relationship to you?",
-                    valid_relationship_options,
-                    help_text: "Choose one" %>
-
-    <%= f.mb_select :tax_relationship,
-                    "How are they included on your tax return?", HouseholdMember::TAX_RELATIONSHIP_LABELS_AND_KEYS,
-                    help_text: "Choose one" %>
+    <div class="question-with-follow-up">
+      <div class="question-with-follow-up__question">
+        <%= f.mb_select :relationship,
+                        "What is their relationship to you?",
+                        valid_relationship_options_for_taxes,
+                        help_text: "Choose one" %>
+      </div>
+      <div class="question-with-follow-up__follow-up" id="nonspouse-follow-up">
+        <%= f.mb_radio_set :tax_relationship,
+                           label_text: "How are they included on your tax return?",
+                           collection: [{ value: :dependent, label: "Dependent" },
+                                        { value: :not_included, label: "Not included" }] %>
+      </div>
+      <div class="question-with-follow-up__follow-up" id="spouse-follow-up">
+        <%= f.mb_radio_set :tax_relationship_spouse,
+                           label_text: "How are they included on your tax return?",
+                           collection: [{ value: :married_filing_jointly, label: "Married filing jointly" },
+                                        { value: :married_filing_separately, label: "Married filing separately" }] %>
+      </div>
   <% end %>
 <% end %>

--- a/spec/controllers/integrated/add_tax_member_controller_spec.rb
+++ b/spec/controllers/integrated/add_tax_member_controller_spec.rb
@@ -1,30 +1,61 @@
 require "rails_helper"
 
 RSpec.describe Integrated::AddTaxMemberController do
-  it_behaves_like "add member controller", tax_relationship: "dependent"
+  it_behaves_like "add member controller",
+                  tax_relationship: "dependent",
+                  tax_relationship_spouse: "married_filing_jointly"
 
   describe "#update" do
     context "with valid params" do
-      let(:valid_params) do
-        {
-          first_name: "Princess",
-          last_name: "Caroline",
-          relationship: "child",
-          tax_relationship: "dependent",
-        }
+      context "dependent" do
+        let(:valid_params) do
+          {
+            first_name: "Princess",
+            last_name: "Caroline",
+            relationship: "child",
+            tax_relationship: "dependent",
+          }
+        end
+
+        it "updates the tax relationship" do
+          current_app = create(:common_application)
+          session[:current_application_id] = current_app.id
+
+          expect do
+            put :update, params: { form: valid_params }
+          end.to change { current_app.members.count }.by 1
+
+          member = current_app.members.last
+
+          expect(member.tax_relationship_dependent?).to be_truthy
+        end
       end
 
-      it "updates the tax relationship" do
-        current_app = create(:common_application)
-        session[:current_application_id] = current_app.id
+      context "spouse" do
+        let(:valid_params) do
+          {
+            first_name: "Princess",
+            last_name: "Caroline",
+            relationship: "spouse",
+            tax_relationship_spouse: "married_filing_separately",
+          }
+        end
 
-        expect do
-          put :update, params: { form: valid_params }
-        end.to change { current_app.members.count }.by 1
+        it "updates the tax relationship" do
+          current_app = create(:common_application,
+                               navigator: build(:application_navigator),
+                               members: [build(:household_member)])
+          session[:current_application_id] = current_app.id
 
-        member = current_app.members.last
+          expect do
+            put :update, params: { form: valid_params }
+          end.to change { current_app.members.count }.by 1
 
-        expect(member.tax_relationship_dependent?).to be_truthy
+          current_app.reload
+          member = current_app.members.last
+
+          expect(member.tax_relationship_married_filing_separately?).to be_truthy
+        end
       end
     end
   end

--- a/spec/features/integrated_application_with_multiple_members_spec.rb
+++ b/spec/features/integrated_application_with_multiple_members_spec.rb
@@ -273,7 +273,7 @@ RSpec.feature "Integrated application" do
       fill_in "What's their first name?", with: "Ginny"
       fill_in "What's their last name?", with: "Pig"
       select "Child", from: "What is their relationship to you?"
-      select "Dependent", from: "How are they included on your tax return?"
+      select_radio question: "How are they included on your tax return?", answer: "Dependent"
 
       proceed_with "Continue"
     end


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/417/38062759-bd7b87e6-32c3-11e8-98b7-8b51bcda17d2.png)

- Uses GCF’s Follow Up molecule.
- To be accessible, creates a distinct `tax_relationship_spouse` radio set which then gets set to `tax_relationship` in the controller.

https://www.pivotaltracker.com/story/show/156242462