### PR TITLE
Remove delayed_job_web from Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem "bourbon", "~> 4.2.0" # to keep in sync with getcalfresh
 gem "browser"
 gem "capybara"
 gem "delayed_job_active_record"
-gem "delayed_job_web"
+# gem "delayed_job_web"
 gem "devise"
 gem "devise-otp",
   git: "https://github.com/pynixwang/devise-otp",

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -658,10 +658,6 @@ GEM
     delayed_job_active_record (4.1.2)
       activerecord (>= 3.0, < 5.2)
       delayed_job (>= 3.0, < 5)
-    delayed_job_web (1.4)
-      activerecord (> 3.0.0)
-      delayed_job (> 2.0.3)
-      sinatra (>= 1.4.4)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
     devise (4.4.0)
@@ -977,7 +973,6 @@ DEPENDENCIES
   codeclimate-test-reporter
   database_cleaner
   delayed_job_active_record
-  delayed_job_web
   devise
   devise-otp!
   dotenv-rails


### PR DESCRIPTION
There's a known security vulnerability in delayed_job_web, that we addressed by disabling the web interface until it is resolved. Github is still warning us that the gem is in our gemfile.lock, though, so this commit removes the gem to resolve the warning.

[#155759158]