### PR TITLE
Unblock integrated flow on demo environment

### DIFF
--- a/app/lib/gate_keeper.rb
+++ b/app/lib/gate_keeper.rb
@@ -10,4 +10,8 @@ class GateKeeper
   def self.demo_environment?
     application_routing_environment == "staging"
   end
+
+  def self.production_environment?
+    Rails.env.production? && !demo_environment?
+  end
 end

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -84,16 +84,9 @@ class SnapApplication < ApplicationRecord
   end
 
   def pdf
-    @_pdf ||=
-      if GateKeeper.feature_enabled?("NEW_FORM")
-        ApplicationPdfAssembler.new(
-          benefit_application: self,
-        ).run
-      else
-        Dhs1171Pdf.new(
-          snap_application: self,
-        ).completed_file
-      end
+    @_pdf ||= Dhs1171Pdf.new(
+                snap_application: self,
+              ).completed_file
   end
 
   def monthly_gross_income

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
     end
   end
 
-  unless Rails.env.production?
+  unless GateKeeper.production_environment?
     resources :sections, controller: :forms, only: %i[index show] do
       collection do
         FormNavigation.all.each do |controller_class|

--- a/spec/lib/gate_keeper_spec.rb
+++ b/spec/lib/gate_keeper_spec.rb
@@ -25,4 +25,47 @@ describe GateKeeper do
       end
     end
   end
+
+  describe ".production_environment?" do
+    context "when APP_RELEASE_STAGE is 'staging'" do
+      it "returns false" do
+        with_modified_env APP_RELEASE_STAGE: "staging" do
+          expect(GateKeeper.production_environment?).to eq(false)
+        end
+      end
+    end
+
+    context "when APP_RELEASE_STAGE is production" do
+      context "and RAILS_ENV is production" do
+        before do
+          allow(Rails).to receive(:env) { "production".inquiry }
+        end
+
+        it "returns true" do
+          with_modified_env APP_RELEASE_STAGE: "production" do
+            expect(GateKeeper.production_environment?).to eq(true)
+          end
+        end
+      end
+
+      context "and RAILS_ENV is not production" do
+        before do
+          allow(Rails).to receive(:env) { "development".inquiry }
+        end
+
+        it "returns true" do
+          with_modified_env APP_RELEASE_STAGE: "production" do
+            expect(GateKeeper.production_environment?).to eq(false)
+          end
+        end
+      end
+    end
+
+    context "when APP_RELEASE_STAGE is not set" do
+      it "returns false" do
+        expect(GateKeeper.production_environment?).to eq(false)
+        expect(GateKeeper.application_routing_environment).to eq("development")
+      end
+    end
+  end
 end

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -56,30 +56,14 @@ RSpec.describe SnapApplication do
   end
 
   describe "#pdf" do
-    context "when using new civilla form" do
-      it "delegates to the PdfComposer class" do
-        app = build(:snap_application)
+    it "delegates to the Dhs1171Pdf class" do
+      app = build(:snap_application)
 
-        fake_pdf_builder = double(run: "I am fake. It's OK")
-        allow(ApplicationPdfAssembler).to receive(:new).with(benefit_application: app).
-          and_return(fake_pdf_builder)
+      fake_pdf_builder = double(completed_file: "I am fake. It's OK")
+      allow(Dhs1171Pdf).to receive(:new).with(snap_application: app).
+        and_return(fake_pdf_builder)
 
-        with_modified_env NEW_FORM_ENABLED: "true" do
-          expect(app.pdf).to eql(fake_pdf_builder.run)
-        end
-      end
-    end
-
-    context "when using old 1171 form" do
-      it "delegates to the Dhs1171Pdf class" do
-        app = build(:snap_application)
-
-        fake_pdf_builder = double(completed_file: "I am fake. It's OK")
-        allow(Dhs1171Pdf).to receive(:new).with(snap_application: app).
-          and_return(fake_pdf_builder)
-
-        expect(app.pdf).to eql(fake_pdf_builder.completed_file)
-      end
+      expect(app.pdf).to eql(fake_pdf_builder.completed_file)
     end
   end
 


### PR DESCRIPTION
Previously, we blocked access to the combined application (`/sections/*`) on any environment where RAILS_ENV=production, which included our demo site.

In prep for an upcoming presentation, I'm unblocking that route in demo. Applications aren't in danger of sending anyway, since this is already blocked on demo.

While touching GateKeeper, I noticed that we had an unused 'NEW FORM' feature flag in SnapApplication PDF generation—think we added to build infrastructure for the new form before the integrated flow was under way. We aren't using the new Civilla PDF for the old application flows, so this commit removes the logical branch.