### PR TITLE
Disable banner on demo websites

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,9 +21,9 @@
   <body class="<%= template_name_css_class %>">
 
     <div class="page-wrapper">
-      <% if GateKeeper.demo_environment? %>
-        <div class="demo-banner staging-warning">This is an <strong>example website</strong>. Visit <a href="https://www.michiganbenefits.org">www.michiganbenefits.org</a> for the real website.</div>
-      <% end %>
+      <%# if GateKeeper.demo_environment? %>
+        <!--<div class="demo-banner staging-warning">This is an <strong>example website</strong>. Visit <a href="https://www.michiganbenefits.org">www.michiganbenefits.org</a> for the real website.</div>-->
+      <%# end %>
       <%= content_for?(:banner) ? content_for(:banner) : '' %>
       <%= content_for?(:content) ? content_for(:content) : yield %>
     </div>

--- a/spec/features/staging_warning_spec.rb
+++ b/spec/features/staging_warning_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.feature "Warn users on staging only" do
-  scenario "Renders the staging warning message", :js do
+  xscenario "Renders the staging warning message", :js do
     allow(GateKeeper).to receive(:demo_environment?).and_return(true)
 
     visit root_path


### PR DESCRIPTION
For testing with Lighthouse on Monday, disable the example website banner.

Revert this commit after to reenable on staging and demo environments.