### PR TITLE
Ask applicant if they own property

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -91,24 +91,15 @@ class FormsController < ApplicationController
   end
 
   def member_params
-    filter_params(form_class.member_attributes)
+    filtered_params(form_class.member_attributes)
   end
 
   def application_params
-    filter_params(form_class.application_attributes)
+    filtered_params(form_class.application_attributes)
   end
 
   def navigator_params
-    filter_params(form_class.navigator_attributes)
-  end
-
-  def filter_params(attributes)
-    return unless attributes.present?
-    form_params.select do |key, _|
-      attributes.any? do |attr|
-        key.match(/^#{attr}(\(.+\))?\z/) # Match single and multi-attribute keys
-      end
-    end
+    filtered_params(form_class.navigator_attributes)
   end
 
   def combined_birthday_fields(day: nil, month: nil, year: nil)
@@ -119,5 +110,9 @@ class FormsController < ApplicationController
     else
       {}
     end
+  end
+
+  def filtered_params(attrs)
+    form_params.slice(*Step::Attributes.new(attrs).to_s)
   end
 end

--- a/app/controllers/integrated/property_controller.rb
+++ b/app/controllers/integrated/property_controller.rb
@@ -1,0 +1,14 @@
+module Integrated
+  class PropertyController < FormsController
+    def update_models
+      selected_types = application_params.fetch(:properties, {}).
+        reject{ |value| value.empty? }
+
+      current_application.update!(properties: selected_types)
+    end
+
+    def existing_attributes
+      HashWithIndifferentAccess.new(current_application.attributes)
+    end
+  end
+end

--- a/app/controllers/integrated/property_controller.rb
+++ b/app/controllers/integrated/property_controller.rb
@@ -2,7 +2,7 @@ module Integrated
   class PropertyController < FormsController
     def update_models
       selected_types = application_params.fetch(:properties, {}).
-        reject{ |value| value.empty? }
+        reject(&:empty?)
 
       current_application.update!(properties: selected_types)
     end

--- a/app/forms/form.rb
+++ b/app/forms/form.rb
@@ -43,7 +43,9 @@ class Form
       attributes = (application_attributes + member_attributes + navigator_attributes)
       self.attribute_names = attributes
 
-      attribute_strings = attribute_names.map(&:to_s)
+      attribute_strings = Step::Attributes.
+        new(attribute_names).
+        to_s
 
       attr_accessor(*attribute_strings)
     end

--- a/app/forms/form_navigation.rb
+++ b/app/forms/form_navigation.rb
@@ -107,6 +107,7 @@ class FormNavigation
       Integrated::MoneyInAccountsController,
       Integrated::AmountInAccountsController,
       Integrated::VehiclesController,
+      Integrated::PropertyController,
     ],
     "Specifics" => [],
     "Finishing Up" => [

--- a/app/forms/property_form.rb
+++ b/app/forms/property_form.rb
@@ -1,0 +1,3 @@
+class PropertyForm < Form
+  set_application_attributes(properties: [])
+end

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -361,6 +361,43 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     HTML
   end
 
+  def mb_checkbox_set_with_none(
+    method,
+    collection,
+    label_text:,
+    options: {}
+  )
+    legend_id = aria_label(method)
+
+    checkbox_html = collection.map do |item|
+      checkbox_label_id = "#{sanitized_id(item[:value])}__label"
+      local_options = options.merge(
+        'aria-labelledby': [legend_id, checkbox_label_id].join(" "),
+      )
+
+      <<~HTML.html_safe
+        <label id="#{checkbox_label_id}" class="checkbox">
+          #{check_box(method, local_options, item[:value].to_s, "")} #{item[:label]}
+        </label>
+      HTML
+    end.join.html_safe
+
+    <<~HTML.html_safe
+      <fieldset class="input-group">
+        <legend class="sr-only" id="#{legend_id}">
+          #{label_text}
+        </legend>
+        #{errors_for(object, method)}
+        #{checkbox_html}
+        <hr>
+        <label class="checkbox" id="none__label">
+          <input aria-labelledby="#{legend_id} none__label" type="checkbox" name="" class="" id="none__checkbox">
+          None of the above
+        </label>
+      </fieldset>
+    HTML
+  end
+
   def mb_select(
     method,
     label_text,

--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -365,19 +365,31 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     method,
     collection,
     label_text:,
+    value_is_array: false,
     options: {}
   )
+
+    if value_is_array
+      options[:multiple] = true
+    end
     legend_id = aria_label(method)
 
-    checkbox_html = collection.map do |item|
-      checkbox_label_id = "#{sanitized_id(item[:value])}__label"
+    checkbox_collection_html = collection.map do |item|
+      checkbox_label_id = aria_label(item[:method])
+
       local_options = options.merge(
         'aria-labelledby': [legend_id, checkbox_label_id].join(" "),
       )
 
+      checkbox_html = if value_is_array
+                        check_box(method, local_options, item[:method].to_s, "")
+                      else
+                        check_box(item[:method], local_options)
+                      end
+
       <<~HTML.html_safe
         <label id="#{checkbox_label_id}" class="checkbox">
-          #{check_box(method, local_options, item[:value].to_s, "")} #{item[:label]}
+          #{checkbox_html} #{item[:label]}
         </label>
       HTML
     end.join.html_safe
@@ -387,8 +399,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
         <legend class="sr-only" id="#{legend_id}">
           #{label_text}
         </legend>
-        #{errors_for(object, method)}
-        #{checkbox_html}
+        #{checkbox_collection_html}
         <hr>
         <label class="checkbox" id="none__label">
           <input aria-labelledby="#{legend_id} none__label" type="checkbox" name="" class="" id="none__checkbox">

--- a/app/models/common_application.rb
+++ b/app/models/common_application.rb
@@ -1,6 +1,15 @@
 class CommonApplication < ApplicationRecord
   include Submittable
 
+  PROPERTY_TYPES = {
+    house: "House(s)",
+    building: "Buildings",
+    rental: "Rental property",
+    land: "Land/lot",
+    burial: "Burial plot",
+    other_property: "Other",
+  }.freeze
+
   has_one :navigator,
     class_name: "ApplicationNavigator",
     foreign_key: "common_application_id",

--- a/app/pdf_components/assistance_application_form.rb
+++ b/app/pdf_components/assistance_application_form.rb
@@ -21,6 +21,7 @@ class AssistanceApplicationForm
       merge(additional_expenses_attributes).
       merge(employed_attributes).
       merge(self_employed_attributes).
+      merge(assets_attributes).
       merge(additional_income_attributes).
       merge(additional_notes_attributes)
   end
@@ -174,6 +175,19 @@ class AssistanceApplicationForm
       hash[:"#{ordinals[i]}_member_self_employed_name"] = member.display_name
     end
     hash
+  end
+
+  def assets_attributes
+    {}.tap do |hash|
+      hash[:anyone_assets_property] = yes_no_or_unfilled(
+        yes: benefit_application.properties.any?,
+        no: benefit_application.properties.none?,
+      )
+
+      benefit_application.properties.each do |property_type|
+        hash["assets_property_#{property_type}".to_sym] = "Yes"
+      end
+    end
   end
 
   def additional_income_attributes

--- a/app/views/integrated/housing_expenses/edit.html.erb
+++ b/app/views/integrated/housing_expenses/edit.html.erb
@@ -4,20 +4,12 @@
 
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
-        <fieldset class="input-group">
-          <legend class="sr-only" id="housing-expenses__legend">
-            What kind of housing expenses do you have?
-          </legend>
 
-          <% Expense::HOUSING_EXPENSES.each do |name, label| %>
-              <%= f.mb_checkbox(name, label, legend_id: "housing-expenses__legend") %>
-          <% end %>
-          <hr>
-          <label class="checkbox" id="none__label">
-            <input aria-labelledby="housing-expenses__legend none__label" type="checkbox" name="" class="" id="none__checkbox">
-            None of the above
-          </label>
+        <%= f.mb_checkbox_set_with_none(:housing_expenses,
+          Expense::HOUSING_EXPENSES.map { |key, label|
+            { method: key, label: label }
+          },
+          label_text: "What kind of housing expenses do you have?") %>
 
-        </fieldset>
     <% end %>
 <% end %>

--- a/app/views/integrated/income_sources/edit.html.erb
+++ b/app/views/integrated/income_sources/edit.html.erb
@@ -6,20 +6,11 @@
   <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
     <%= f.hidden_field :id %>
 
-    <fieldset class="input-group">
-      <legend class="sr-only" id="income_sources__legend">
-        <%= t(".title", **member_appropriate_translation_data) %>
-      </legend>
+    <%= f.mb_checkbox_set_with_none(:income_sources,
+      Income::INCOME_SOURCES.map { |key, label|
+        { method: key, label: label }
+      },
+      label_text: t(".title", **member_appropriate_translation_data)) %>
 
-      <% Income::INCOME_SOURCES.each do |name, label| %>
-        <%= f.mb_checkbox(name, label, legend_id: "income_sources__legend") %>
-      <% end %>
-      <hr>
-      <label class="checkbox" id="none__label">
-        <input aria-labelledby="income_sources__legend none__label" type="checkbox" name="" class="" id="none__checkbox">
-        None of the above
-      </label>
-
-    </fieldset>
   <% end %>
 <% end %>

--- a/app/views/integrated/property/edit.html.erb
+++ b/app/views/integrated/property/edit.html.erb
@@ -5,12 +5,12 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
 
-        <%= f.mb_checkbox_set_with_none("properties",
+        <%= f.mb_checkbox_set_with_none(:properties,
           CommonApplication::PROPERTY_TYPES.map { |key, label|
-            { value: key, label: label }
+            { method: key, label: label }
           },
           label_text: t(".title", count: current_application.members.count),
-          options: { multiple: true } ) %>
+          value_is_array: true) %>
 
     <% end %>
 <% end %>

--- a/app/views/integrated/property/edit.html.erb
+++ b/app/views/integrated/property/edit.html.erb
@@ -1,0 +1,16 @@
+<% content_for :header_title, "Assets" %>
+<% content_for :form_card_title, t(".title", count: current_application.members.count)  %>
+<% content_for :form_card_help, "You should include your primary home, if you own it. But don't worry — it won't be counted against you." %>
+
+<% content_for :form_card_body do %>
+    <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
+
+        <%= f.mb_checkbox_set_with_none("properties",
+          CommonApplication::PROPERTY_TYPES.map { |key, label|
+            { value: key, label: label }
+          },
+          label_text: t(".title", count: current_application.members.count),
+          options: { multiple: true } ) %>
+
+    <% end %>
+<% end %>

--- a/app/views/integrated/utility_expenses/edit.html.erb
+++ b/app/views/integrated/utility_expenses/edit.html.erb
@@ -4,20 +4,12 @@
 
 <% content_for :form_card_body do %>
   <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
-    <fieldset class="input-group">
-      <legend class="sr-only" id="utility-expenses__legend">
-        Do you have any separate utility expenses?
-      </legend>
 
-      <% Expense::UTILITY_EXPENSES.each do |name, label| %>
-          <%= f.mb_checkbox(name, label, legend_id: "utility-expenses__legend") %>
-      <% end %>
-      <hr>
-      <label class="checkbox" id="none__label">
-        <input aria-labelledby="utility-expenses__legend none__label" type="checkbox" name="" class="" id="none__checkbox">
-        None of the above
-      </label>
+    <%= f.mb_checkbox_set_with_none(:utility_expenses,
+      Expense::UTILITY_EXPENSES.map { |key, label|
+        { method: key, label: label }
+      },
+      label_text: "Do you have any separate utility expenses?") %>
 
-    </fieldset>
-  <% end %>
+    <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -225,6 +225,11 @@ en:
         help:
           one: Only list vehicles that are registered in your name.
           other: Only list vehicles that are registered in their name.
+    property:
+      edit:
+        title:
+          one: Do you own any real estate or property?
+          other: Does anyone own real estate or property?
   ssn:
     description: "Providing Social Security numbers ensures you receive the correct benefits. Even if you've applied before, this helps connect this application to the right file. MDHHS maintains strict security guidelines to protect the identities of our residents."
   helpers:

--- a/db/migrate/20180423230634_add_properties_to_common_application.rb
+++ b/db/migrate/20180423230634_add_properties_to_common_application.rb
@@ -1,6 +1,6 @@
 class AddPropertiesToCommonApplication < ActiveRecord::Migration[5.1]
   def change
     add_column :common_applications, :properties, :string, array: true
-      change_column_default :common_applications, :properties, from: nil, to: []
+    change_column_default :common_applications, :properties, from: nil, to: []
   end
 end

--- a/db/migrate/20180423230634_add_properties_to_common_application.rb
+++ b/db/migrate/20180423230634_add_properties_to_common_application.rb
@@ -1,0 +1,6 @@
+class AddPropertiesToCommonApplication < ActiveRecord::Migration[5.1]
+  def change
+    add_column :common_applications, :properties, :string, array: true
+      change_column_default :common_applications, :properties, from: nil, to: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180423223206) do
+ActiveRecord::Schema.define(version: 20180423230634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 20180423223206) do
     t.integer "less_than_threshold_in_accounts", default: 0
     t.integer "living_situation", default: 0
     t.integer "previously_received_assistance", default: 0, null: false
+    t.string "properties", default: [], array: true
     t.datetime "updated_at", null: false
   end
 

--- a/spec/controllers/integrated/how_many_babies_controller_spec.rb
+++ b/spec/controllers/integrated/how_many_babies_controller_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Integrated::HowManyBabiesController do
 
         session[:current_application_id] = current_app.id
 
-        get :edit, params: {}
+        get :edit
 
         expect(assigns[:form].id).to eq(pregnant_member.id)
       end

--- a/spec/controllers/integrated/property_controller_spec.rb
+++ b/spec/controllers/integrated/property_controller_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Integrated::PropertyController do
+  describe "edit" do
+    it "assigns existing property types" do
+      current_app = create(:common_application, properties: ["house"])
+
+      session[:current_application_id] = current_app.id
+
+      get :edit
+
+      expect(assigns[:form].properties).to match_array(["house"])
+    end
+  end
+
+  describe "#update" do
+    context "with valid params" do
+      let(:valid_params) do
+        {
+          properties: ["house", ""],
+        }
+      end
+
+      it "creates properties from params" do
+        current_app = create(:common_application, properties: ["rental"])
+        session[:current_application_id] = current_app.id
+
+        put :update, params: { form: valid_params }
+
+        current_app.reload
+
+        expect(current_app.properties).to match_array(["house"])
+      end
+    end
+  end
+end

--- a/spec/controllers/integrated/vehicles_controller_spec.rb
+++ b/spec/controllers/integrated/vehicles_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Integrated::VehiclesController do
     context "with valid params" do
       let(:valid_params) do
         {
-          own_vehicles: "true"
+          own_vehicles: "true",
         }
       end
 

--- a/spec/features/integrated_application_with_multiple_members_spec.rb
+++ b/spec/features/integrated_application_with_multiple_members_spec.rb
@@ -650,6 +650,16 @@ RSpec.feature "Integrated application" do
       proceed_with "Yes"
     end
 
+    on_page "Assets" do
+      expect(page).to have_content(
+        "Does anyone own real estate or property?",
+      )
+
+      check "House(s)"
+
+      proceed_with "Continue"
+    end
+
     on_page "Finishing Up" do
       expect(page).to have_content(
         "Would you like to designate someone as your authorized representative?",

--- a/spec/features/integrated_application_with_single_member_spec.rb
+++ b/spec/features/integrated_application_with_single_member_spec.rb
@@ -271,6 +271,14 @@ RSpec.feature "Integrated application" do
       proceed_with "No"
     end
 
+    on_page "Assets" do
+      expect(page).to have_content(
+        "Do you own any real estate or property?",
+      )
+
+      proceed_with "Continue"
+    end
+
     on_page "Finishing Up" do
       expect(page).to have_content(
         "Would you like to designate someone as your authorized representative?",

--- a/spec/features/integrated_application_with_two_members_spec.rb
+++ b/spec/features/integrated_application_with_two_members_spec.rb
@@ -325,6 +325,14 @@ RSpec.feature "Integrated application" do
       proceed_with "No"
     end
 
+    on_page "Assets" do
+      expect(page).to have_content(
+        "Does anyone own real estate or property?",
+      )
+
+      proceed_with "Continue"
+    end
+
     on_page "Finishing Up" do
       expect(page).to have_content(
         "Would you like to designate someone as your authorized representative?",

--- a/spec/forms/form_spec.rb
+++ b/spec/forms/form_spec.rb
@@ -8,14 +8,12 @@ RSpec.describe Form do
     end
 
     it "creates a getter that returns passed in attributes as keys" do
-      Form.set_application_attributes(:foo, :bar)
+      Form.set_application_attributes(:foo, bar: [])
 
-      expect(Form.application_attributes).to match_array(
-        %i[
-          foo
-          bar
-        ],
-      )
+      expect(Form.application_attributes).to match_array([
+        :foo,
+        {:bar=>[]},
+      ])
     end
   end
 
@@ -27,14 +25,12 @@ RSpec.describe Form do
     end
 
     it "creates a getter that returns passed in attributes as keys" do
-      Form.set_member_attributes(:foo, :bar)
+      Form.set_member_attributes(:foo, bar: [])
 
-      expect(Form.member_attributes).to match_array(
-        %i[
-          foo
-          bar
-        ],
-      )
+      expect(Form.member_attributes).to match_array([
+        :foo,
+        {:bar=>[]},
+      ])
     end
   end
 
@@ -45,14 +41,12 @@ RSpec.describe Form do
     end
 
     it "creates a getter that returns passed in attributes as keys" do
-      Form.set_navigator_attributes(:foo, :bar)
+      Form.set_navigator_attributes(:foo, bar: [])
 
-      expect(Form.navigator_attributes).to match_array(
-        %i[
-          foo
-          bar
-        ],
-      )
+      expect(Form.navigator_attributes).to match_array([
+        :foo,
+        {:bar=>[]},
+      ])
     end
   end
 

--- a/spec/forms/form_spec.rb
+++ b/spec/forms/form_spec.rb
@@ -11,9 +11,9 @@ RSpec.describe Form do
       Form.set_application_attributes(:foo, bar: [])
 
       expect(Form.application_attributes).to match_array([
-        :foo,
-        {:bar=>[]},
-      ])
+                                                           :foo,
+                                                           { bar: [] },
+                                                         ])
     end
   end
 
@@ -28,9 +28,9 @@ RSpec.describe Form do
       Form.set_member_attributes(:foo, bar: [])
 
       expect(Form.member_attributes).to match_array([
-        :foo,
-        {:bar=>[]},
-      ])
+                                                      :foo,
+                                                      { bar: [] },
+                                                    ])
     end
   end
 
@@ -44,9 +44,9 @@ RSpec.describe Form do
       Form.set_navigator_attributes(:foo, bar: [])
 
       expect(Form.navigator_attributes).to match_array([
-        :foo,
-        {:bar=>[]},
-      ])
+                                                         :foo,
+                                                         { bar: [] },
+                                                       ])
     end
   end
 

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -582,6 +582,74 @@ RSpec.describe MbFormBuilder do
     end
   end
 
+  describe "#mb_checkbox_set_with_none" do
+    it "renders an accessible set of checkbox inputs" do
+      class SampleStep < Step
+        step_attributes(
+          :tng,
+          :voyager,
+        )
+      end
+
+      sample = SampleStep.new(tng: true)
+      form = MbFormBuilder.new("sample", sample, template, {})
+      output = form.mb_checkbox_set_with_none(
+        :captains,
+        [
+          { method: :tng, label: "Picard" },
+          { method: :voyager, label: "Janeway" },
+        ],
+        label_text: "Which captains do you think are cool?",
+      )
+
+      expect(output).to be_html_safe
+
+      expect(output).to match_html <<-HTML
+        <fieldset class="input-group">
+          <legend class="sr-only" id="sample_captains__label"> Which captains do you think are cool? </legend>
+          <label id="sample_tng__label" class="checkbox"><input name="sample[tng]" type="hidden" value="0" /><input aria-labelledby="sample_captains__label sample_tng__label" type="checkbox" value="1" checked="checked" name="sample[tng]" id="sample_tng" /> Picard </label>
+          <label id="sample_voyager__label" class="checkbox"><input name="sample[voyager]" type="hidden" value="0" /><input aria-labelledby="sample_captains__label sample_voyager__label" type="checkbox" value="1" name="sample[voyager]" id="sample_voyager" /> Janeway </label>
+          <hr />
+          <label class="checkbox" id="none__label"><input aria-labelledby="sample_captains__label none__label" type="checkbox" name="" class="" id="none__checkbox" /> None of the above </label>
+        </fieldset>
+      HTML
+    end
+
+    context "when value is an array on the model" do
+      it "renders an accessible set of checkbox inputs" do
+        class SampleStep < Step
+          step_attributes(
+            captains: [],
+          )
+        end
+
+        sample = SampleStep.new(captains: ["tng"])
+        form = MbFormBuilder.new("sample", sample, template, {})
+        output = form.mb_checkbox_set_with_none(
+          :captains,
+          [
+            { method: :tng, label: "Picard" },
+            { method: :ds9, label: "Sisko" },
+          ],
+          label_text: "Which captains do you think are cool?",
+          value_is_array: true,
+        )
+
+        expect(output).to be_html_safe
+
+        expect(output).to match_html <<-HTML
+          <fieldset class="input-group">
+            <legend class="sr-only" id="sample_captains__label"> Which captains do you think are cool? </legend>
+            <label id="sample_tng__label" class="checkbox"><input name="sample[captains][]" type="hidden" value="" /><input aria-labelledby="sample_captains__label sample_tng__label" type="checkbox" value="tng" checked="checked" name="sample[captains][]" id="sample_captains_tng" /> Picard </label>
+            <label id="sample_ds9__label" class="checkbox"><input name="sample[captains][]" type="hidden" value="" /><input aria-labelledby="sample_captains__label sample_ds9__label" type="checkbox" value="ds9" name="sample[captains][]" id="sample_captains_ds9" /> Sisko </label>
+            <hr />
+            <label class="checkbox" id="none__label"><input aria-labelledby="sample_captains__label none__label" type="checkbox" name="" class="" id="none__checkbox" /> None of the above </label>
+          </fieldset>
+        HTML
+      end
+    end
+  end
+
   describe "#mb_checkbox" do
     it "renders an accessible checkbox input" do
       class SampleStep < Step

--- a/spec/pdf_components/assistance_application_form_spec.rb
+++ b/spec/pdf_components/assistance_application_form_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe AssistanceApplicationForm do
              build(:expense, expense_type: "child_support"),
              build(:expense, expense_type: "student_loan_interest"),
            ],
+           properties: ["rental"],
            previously_received_assistance: "yes",
            living_situation: "temporary_address",
            income_changed: "yes",
@@ -110,6 +111,8 @@ RSpec.describe AssistanceApplicationForm do
           anyone_court_expenses: "Yes",
           court_expenses_child_support: "Yes",
           anyone_student_loans_deductions: "Yes",
+          anyone_assets_property: "Yes",
+          assets_property_rental: "Yes",
         )
       end
     end

--- a/spec/pdf_components/assistance_application_form_spec.rb
+++ b/spec/pdf_components/assistance_application_form_spec.rb
@@ -101,7 +101,6 @@ RSpec.describe AssistanceApplicationForm do
           additional_income_unemployment: "Yes",
           first_member_additional_income_name: "Octopus Cuttlefish",
           first_member_additional_income_type: "Unemployment",
-          anyone_medical_expenses: "Yes",
           medical_expenses_health_insurance: "Yes",
           wants_authorized_representative: "Yes",
           authorized_representative_full_name: "Trusty McTrusterson",


### PR DESCRIPTION
Also:
* Modifies form_attributes to accept array (e.g. `application_attributes(dogs: [])`)
* Creates new form builder method to use with the checkbox + none pattern.
* Expands support in checkbox_set to accept a simple array, rather than to assign methods/attributes directly to form (e.g. will result in post like `["foo", "bar"]` rather than `{ foo: "1", bar: "0" }`. This is useful for updating simple array attributes on one model, rather than updating a collection of models


![screen shot 2018-04-24 at 11 07 41 am](https://user-images.githubusercontent.com/3675092/39205526-bec8bb5e-47af-11e8-8944-9cee88462b71.png)