### PR TITLE
Ask applicants which office they're in for SNAP + Medicaid flows

### DIFF
--- a/app/controllers/introduce_yourself_controller.rb
+++ b/app/controllers/introduce_yourself_controller.rb
@@ -6,7 +6,7 @@ class IntroduceYourselfController < SnapStepsController
 
     if @step.valid?
       app = current_or_new_snap_application
-      app.update!(office_location: step_params[:office_location])
+      app.update!(office_page: step_params[:office_page])
       set_current_application(app)
       member.update!(member_update_params)
       redirect_to(next_path)
@@ -19,11 +19,11 @@ class IntroduceYourselfController < SnapStepsController
 
   def existing_attributes
     HashWithIndifferentAccess.new(member.attributes).
-      merge(office_location_params)
+      merge(office_page_params)
   end
 
   def member_update_params
-    step_params.except(:office_location)
+    step_params.except(:office_page)
   end
 
   def member
@@ -35,7 +35,7 @@ class IntroduceYourselfController < SnapStepsController
     current_application || SnapApplication.new
   end
 
-  def office_location_params
-    { office_location: params[:office_location] }
+  def office_page_params
+    { office_page: params[:office_page] }
   end
 end

--- a/app/controllers/medicaid/office_location_controller.rb
+++ b/app/controllers/medicaid/office_location_controller.rb
@@ -1,0 +1,9 @@
+module Medicaid
+  class OfficeLocationController < MedicaidStepsController
+    private
+
+    def skip?
+      current_application.office_page.present?
+    end
+  end
+end

--- a/app/controllers/medicaid/welcome_controller.rb
+++ b/app/controllers/medicaid/welcome_controller.rb
@@ -3,16 +3,16 @@ module Medicaid
     skip_before_action :ensure_application_present
 
     def edit
-      @step = step_class.new(office_location: office_location)
+      @step = step_class.new(office_page: office_page)
     end
 
     private
 
-    def office_location
-      if params[:office_location].present?
-        params[:office_location]
+    def office_page
+      if params[:office_page].present?
+        params[:office_page]
       elsif current_application
-        current_application.office_location
+        current_application.office_page
       end
     end
 

--- a/app/controllers/office_location_controller.rb
+++ b/app/controllers/office_location_controller.rb
@@ -1,0 +1,7 @@
+class OfficeLocationController < SnapStepsController
+  private
+
+  def skip?
+    current_application.office_page.present?
+  end
+end

--- a/app/dashboards/medicaid_application_dashboard.rb
+++ b/app/dashboards/medicaid_application_dashboard.rb
@@ -54,7 +54,8 @@ class MedicaidApplicationDashboard < Administrate::BaseDashboard
     signed_at: Field::DateTime,
     upload_paperwork: Field::Boolean,
     paperwork: Field::String.with_options(searchable: false),
-    office_location: Field::String,
+    office_page: Field::String,
+    selected_office_location: Field::String,
     mailing_address_same_as_residential_address: Field::Boolean,
     stable_housing: Field::Boolean,
     anyone_married: Field::Boolean,
@@ -70,7 +71,8 @@ class MedicaidApplicationDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = %i[
     id
     phone_number
-    office_location
+    office_page
+    selected_office_location
     email
     signed_at
     last_emailed_office_at
@@ -126,7 +128,8 @@ class MedicaidApplicationDashboard < Administrate::BaseDashboard
     signed_at
     upload_paperwork
     paperwork
-    office_location
+    office_page
+    selected_office_location
     mailing_address_same_as_residential_address
     stable_housing
     anyone_married

--- a/app/dashboards/snap_application_dashboard.rb
+++ b/app/dashboards/snap_application_dashboard.rb
@@ -37,7 +37,8 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     monthly_care_expenses: Field::String.with_options(searchable: false),
     monthly_court_ordered_expenses: Field::String.with_options(searchable: false),
     monthly_medical_expenses: Field::String.with_options(searchable: false),
-    office_location: Field::String,
+    office_page: Field::String,
+    selected_office_location: Field::String,
     phone_number: Field::String,
     property_tax_expense: Field::Number.with_options(searchable: false),
     real_estate_income: Field::Boolean,
@@ -67,7 +68,8 @@ class SnapApplicationDashboard < Administrate::BaseDashboard
     id
     sms_consented
     phone_number
-    office_location
+    office_page
+    selected_office_location
     email
     signed_at
     last_emailed_office_at

--- a/app/models/medicaid_application.rb
+++ b/app/models/medicaid_application.rb
@@ -66,6 +66,14 @@ class MedicaidApplication < ApplicationRecord
     ).completed_file
   end
 
+  def office_location
+    if selected_office_location == "clio" || selected_office_location == "union"
+      selected_office_location
+    else
+      office_page
+    end
+  end
+
   private
 
   def no_self_employment?

--- a/app/models/snap_application.rb
+++ b/app/models/snap_application.rb
@@ -134,6 +134,14 @@ class SnapApplication < ApplicationRecord
     signed_at.present?
   end
 
+  def office_location
+    if selected_office_location == "clio" || selected_office_location == "union"
+      selected_office_location
+    else
+      office_page
+    end
+  end
+
   private
 
   def care_expenses_values

--- a/app/steps/introduce_yourself.rb
+++ b/app/steps/introduce_yourself.rb
@@ -5,7 +5,7 @@ class IntroduceYourself < Step
     :birthday,
     :first_name,
     :last_name,
-    :office_location,
+    :office_page,
   )
 
   validates :first_name,
@@ -18,7 +18,7 @@ class IntroduceYourself < Step
     presence: { message: "Make sure to provide a birthday" }
 
   validates(
-    :office_location,
+    :office_page,
     allow_blank: true,
     inclusion: {
       in: %w(clio union),

--- a/app/steps/medicaid/office_location.rb
+++ b/app/steps/medicaid/office_location.rb
@@ -1,0 +1,5 @@
+module Medicaid
+  class OfficeLocation < Step
+    step_attributes(:selected_office_location)
+  end
+end

--- a/app/steps/medicaid/step_navigation.rb
+++ b/app/steps/medicaid/step_navigation.rb
@@ -5,6 +5,7 @@ module Medicaid
         Medicaid::WelcomeController,
         Medicaid::IntroLocationController,
         Medicaid::IntroLocationHelpController,
+        Medicaid::OfficeLocationController,
         Medicaid::IntroNameController,
         Medicaid::IntroAppliedBeforeController,
         Medicaid::IntroHouseholdController,

--- a/app/steps/medicaid/welcome.rb
+++ b/app/steps/medicaid/welcome.rb
@@ -1,5 +1,5 @@
 module Medicaid
   class Welcome < Step
-    step_attributes(:office_location)
+    step_attributes(:office_page)
   end
 end

--- a/app/steps/office_location.rb
+++ b/app/steps/office_location.rb
@@ -1,3 +1,3 @@
-class IntroductionChangeOfficeLocation < Step
+class OfficeLocation < Step
   step_attributes(:selected_office_location)
 end

--- a/app/steps/step_navigation.rb
+++ b/app/steps/step_navigation.rb
@@ -2,6 +2,7 @@ class StepNavigation
   ALL = {
     "Introduction" => [
       IntroduceYourselfController,
+      OfficeLocationController,
       ContactInformationController,
       MailingAddressController,
       ResidentialAddressController,

--- a/app/views/introduce_yourself/edit.html.erb
+++ b/app/views/introduce_yourself/edit.html.erb
@@ -14,7 +14,7 @@
         autofocus: true %>
       <%= f.mb_input_field :last_name, "What is your last name?" %>
       <%= f.mb_date_select :birthday, "What is your birthday?", { options: { start_year: 1900, end_year: Time.now.year, default: Date.new(1990,1,15), order: [:month, :day, :year] } } %>
-      <%= f.hidden_field :office_location, value: @step.office_location %>
+      <%= f.hidden_field :office_page, value: @step.office_page %>
       <%= render partial: 'shared/next_step' %>
     <% end %>
   </div>

--- a/app/views/introduction_change_office_location/edit.html.erb
+++ b/app/views/introduction_change_office_location/edit.html.erb
@@ -9,7 +9,7 @@
 
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.mb_radio_set :office_location,
+      <%= f.mb_radio_set :selected_office_location,
         label_text: t("snap.introduction_change_office_location.edit.title"),
         collection: [
           { value: "clio", label: "Clio Road" },

--- a/app/views/medicaid/office_location/edit.html.erb
+++ b/app/views/medicaid/office_location/edit.html.erb
@@ -1,0 +1,30 @@
+<% content_for :header_title, "Office" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Which office are you in?
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step,
+      as: :step,
+      builder: MbFormBuilder,
+      url: current_path,
+      method: :put do |f| %>
+
+      <%= f.mb_radio_set :selected_office_location,
+        label_text: "Which office are you in?",
+        legend_class: "sr-only",
+        collection: [
+          { value: :clio, label: "Clio Road" },
+          { value: :union, label: "Union Street" },
+          { value: :other, label: "Other" },
+          { value: :not_in_office, label: "I'm not in an office" },
+        ] %>
+
+      <%= render "medicaid/next_step" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/medicaid/welcome/edit.html.erb
+++ b/app/views/medicaid/welcome/edit.html.erb
@@ -17,7 +17,7 @@
 
   <div class="form-card__footer">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
-      <%= f.hidden_field :office_location, value: @step.office_location %>
+      <%= f.hidden_field :office_page, value: @step.office_page %>
       <%= render "medicaid/next_step" %>
     <% end %>
   </div>

--- a/app/views/office_location/edit.html.erb
+++ b/app/views/office_location/edit.html.erb
@@ -1,0 +1,30 @@
+<% content_for :header_title, "Office" %>
+
+<div class="form-card">
+  <header class="form-card__header">
+    <div class="form-card__title">
+      Which office are you in?
+    </div>
+  </header>
+
+  <div class="form-card__content">
+    <%= form_for @step,
+      as: :step,
+      builder: MbFormBuilder,
+      url: current_path,
+      method: :put do |f| %>
+
+      <%= f.mb_radio_set :selected_office_location,
+        label_text: "Which office are you in?",
+        legend_class: "sr-only",
+        collection: [
+          { value: :clio, label: "Clio Road" },
+          { value: :union, label: "Union Street" },
+          { value: :other, label: "Other" },
+          { value: :not_in_office, label: "I'm not in an office" },
+        ] %>
+
+      <%= render "shared/next_step" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/static_pages/_home_page_bottom_section_dual.html.erb
+++ b/app/views/static_pages/_home_page_bottom_section_dual.html.erb
@@ -29,7 +29,7 @@
         Buy groceries, shop farmers’ markets, and grow your own food – EBT and
         SNAP benefits let you choose what works best for you.
       </p>
-      <%= link_to step_path(StepNavigation.first, office_location: office_location), class: "button button--cta button--fully-width" do %>
+      <%= link_to step_path(StepNavigation.first, office_page: office_page), class: "button button--cta button--fully-width" do %>
         Apply for FAP
       <% end %>
     </div>
@@ -43,7 +43,7 @@
         Health care is essential. If you need help paying for medical expenses
         over the last three months, you may be eligible for retroactive coverage.
       </p>
-      <%= link_to step_path(Medicaid::StepNavigation.first, office_location: office_location), class: "button button--cta button--fully-width" do %>
+      <%= link_to step_path(Medicaid::StepNavigation.first, office_page: office_page), class: "button button--cta button--fully-width" do %>
         Apply for Medicaid
       <% end %>
     </div>

--- a/app/views/static_pages/clio.html.erb
+++ b/app/views/static_pages/clio.html.erb
@@ -19,12 +19,12 @@ end %>
     </div>
 
       <div class="hero--cta-options grid__item">
-    <%= link_to step_path(StepNavigation.first, office_location: "clio") do %>
+    <%= link_to step_path(StepNavigation.first, office_page: "clio") do %>
       <p class="button button--cta button--fully-width">Apply for FAP</p>
       <p class="text--help">Food Stamps</p>
     <% end %>
 
-    <%= link_to step_path(Medicaid::StepNavigation.first, office_location: "clio") do %>
+    <%= link_to step_path(Medicaid::StepNavigation.first, office_page: "clio") do %>
       <p class="button button--cta button--fully-width">Apply for Medicaid</p>
       <p class="text--help">Health insurance</p>
     <% end %>
@@ -37,5 +37,5 @@ end %>
   </div>
 </div>
 
-<%= render "home_page_bottom_section_dual", office_location: "clio" %>
+<%= render "home_page_bottom_section_dual", office_page: "clio" %>
 <%= render 'shared/footer' %>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -29,5 +29,5 @@ end %>
   </div>
 </div>
 
-<%= render "home_page_bottom_section_dual", office_location: nil %>
+<%= render "home_page_bottom_section_dual", office_page: nil %>
 <%= render "shared/footer" %>

--- a/app/views/static_pages/union.html.erb
+++ b/app/views/static_pages/union.html.erb
@@ -19,12 +19,12 @@ end %>
     </div>
 
     <div class="hero--cta-options grid__item">
-      <%= link_to step_path(StepNavigation.first, office_location: "union") do %>
+      <%= link_to step_path(StepNavigation.first, office_page: "union") do %>
         <p class="button button--cta button--fully-width">Apply for FAP</p>
         <p class="text--help">Food Stamps</p>
       <% end %>
 
-      <%= link_to step_path(Medicaid::StepNavigation.first, office_location: "union") do %>
+      <%= link_to step_path(Medicaid::StepNavigation.first, office_page: "union") do %>
         <p class="button button--cta button--fully-width">Apply for Medicaid</p>
         <p class="text--help">Health insurance</p>
       <% end %>
@@ -37,5 +37,5 @@ end %>
   </div>
 </div>
 
-<%= render "home_page_bottom_section_dual", office_location: "union" %>
+<%= render "home_page_bottom_section_dual", office_page: "union" %>
 <%= render 'shared/footer' %>

--- a/db/migrate/20180508220008_modify_office_location.rb
+++ b/db/migrate/20180508220008_modify_office_location.rb
@@ -1,0 +1,33 @@
+class ModifyOfficeLocation < ActiveRecord::Migration[5.1]
+  def up
+    add_column :snap_applications, :selected_office_location, :string
+    add_column :snap_applications, :office_page, :string
+    add_column :medicaid_applications, :selected_office_location, :string
+    add_column :medicaid_applications, :office_page, :string
+    safety_assured do
+      execute "UPDATE snap_applications SET office_page = office_location;"
+      execute "UPDATE medicaid_applications SET office_page = office_location;"
+
+      commit_db_transaction
+
+      remove_column :snap_applications, :office_location
+      remove_column :medicaid_applications, :office_location
+    end
+  end
+
+  def down
+    add_column :snap_applications, :office_location, :string
+    add_column :medicaid_applications, :office_location, :string
+    safety_assured do
+      execute "UPDATE snap_applications SET office_location = office_page;"
+      execute "UPDATE medicaid_applications SET office_location = office_page;"
+
+      commit_db_transaction
+
+      remove_column :snap_applications, :selected_office_location
+      remove_column :snap_applications, :office_page
+      remove_column :medicaid_applications, :selected_office_location
+      remove_column :medicaid_applications, :office_page
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180501041944) do
+ActiveRecord::Schema.define(version: 20180508220008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -259,10 +259,11 @@ ActiveRecord::Schema.define(version: 20180501041944) do
     t.integer "members_count", default: 0
     t.boolean "michigan_resident"
     t.boolean "need_medical_expense_help_3_months"
-    t.string "office_location"
+    t.string "office_page"
     t.string "paperwork", array: true
     t.string "phone_number"
     t.boolean "reliable_mail_address"
+    t.string "selected_office_location"
     t.integer "self_employed_monthly_income"
     t.string "signature"
     t.datetime "signed_at"
@@ -373,11 +374,12 @@ ActiveRecord::Schema.define(version: 20180501041944) do
     t.integer "monthly_care_expenses"
     t.integer "monthly_court_ordered_expenses"
     t.integer "monthly_medical_expenses"
-    t.string "office_location"
+    t.string "office_page"
     t.string "phone_number"
     t.integer "property_tax_expense"
     t.boolean "real_estate_income"
     t.integer "rent_expense"
+    t.string "selected_office_location"
     t.string "signature"
     t.datetime "signed_at"
     t.boolean "sms_consented"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -133,7 +133,7 @@ complete_application.update!(
   financial_accounts: ["checking_account", "four_oh_one_k"],
   total_money: 2000,
   additional_information: "N/A",
-  office_location: "union",
+  office_page: "union",
 )
 
 complete_mailing = Address.find_or_initialize_by(

--- a/spec/controllers/introduce_yourself_controller_spec.rb
+++ b/spec/controllers/introduce_yourself_controller_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe IntroduceYourselfController do
   describe "#edit" do
     context "office location in params" do
       it "assigns office location" do
-        get :edit, params: { office_location: "clio" }
+        get :edit, params: { office_page: "clio" }
 
-        expect(step.office_location).to eq "clio"
+        expect(step.office_page).to eq "clio"
       end
     end
 
@@ -77,7 +77,7 @@ RSpec.describe IntroduceYourselfController do
         it "redirects to the next step" do
           put :update, params: valid_params
 
-          expect(response).to redirect_to("/steps/contact-information")
+          expect(response).to redirect_to(controller.next_path)
         end
       end
     end
@@ -90,12 +90,12 @@ RSpec.describe IntroduceYourselfController do
           "birthday(3i)" => "31",
           "birthday(2i)" => "1",
           "birthday(1i)" => "1950",
-          office_location: "union",
+          office_page: "union",
         } }
 
         put :update, params: params
 
-        expect(current_app.reload.office_location).to eq "union"
+        expect(current_app.reload.office_page).to eq "union"
       end
     end
   end

--- a/spec/controllers/medicaid/intro_location_help_controller_spec.rb
+++ b/spec/controllers/medicaid/intro_location_help_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Medicaid::IntroLocationHelpController do
 
         get :edit
 
-        expect(response).to redirect_to("/steps/medicaid/intro-name")
+        expect(response).to redirect_to(controller.next_path)
       end
     end
 

--- a/spec/controllers/medicaid/office_location_controller_spec.rb
+++ b/spec/controllers/medicaid/office_location_controller_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe Medicaid::OfficeLocationController do
+  describe "#edit" do
+    context "office page present on application" do
+      it "skips to the next step" do
+        medicaid_application = create(:medicaid_application, office_page: "clio")
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(controller.next_path)
+      end
+    end
+
+    context "office page not present on application" do
+      it "assigns the location to the step" do
+        medicaid_application = create(:medicaid_application,
+          office_page: nil,
+          selected_office_location: "clio")
+        session[:medicaid_application_id] = medicaid_application.id
+
+        get :edit
+
+        step = assigns(:step)
+
+        expect(step.selected_office_location).to eq("clio")
+      end
+    end
+  end
+
+  describe "#update" do
+    context "when step is valid" do
+      it "redirects to next step and updates the application" do
+        medicaid_application = create(:medicaid_application)
+        session[:medicaid_application_id] = medicaid_application.id
+
+        params = {
+          selected_office_location: "clio",
+        }
+        put :update, params: { step: params }
+
+        medicaid_application.reload
+
+        expect(response).to redirect_to(subject.next_path)
+        expect(medicaid_application.selected_office_location).to eq("clio")
+      end
+    end
+  end
+end

--- a/spec/controllers/medicaid/welcome_controller_spec.rb
+++ b/spec/controllers/medicaid/welcome_controller_spec.rb
@@ -11,24 +11,24 @@ RSpec.describe Medicaid::WelcomeController do
         expect(response).to render_template(:edit)
       end
 
-      context "assigning office location to the step" do
+      context "assigning office page to the step" do
         context "when query param is not present" do
           it "assigns nil to the step" do
             get :edit
 
             step = assigns(:step)
 
-            expect(step.office_location).to be_nil
+            expect(step.office_page).to be_nil
           end
         end
 
         context "when query param is present" do
           it "assigns the query param to the step" do
-            get :edit, params: { office_location: "blah" }
+            get :edit, params: { office_page: "blah" }
 
             step = assigns(:step)
 
-            expect(step.office_location).to eq("blah")
+            expect(step.office_page).to eq("blah")
           end
         end
       end
@@ -36,16 +36,16 @@ RSpec.describe Medicaid::WelcomeController do
 
     context "application has already been created" do
       context "when query param is not present" do
-        it "sets office location to existing value" do
+        it "sets office page to existing value" do
           medicaid_application = create(:medicaid_application,
-            office_location: "my_office")
+            office_page: "my_office")
           session[:medicaid_application_id] = medicaid_application.id
 
           get :edit
 
           step = assigns(:step)
 
-          expect(step.office_location).to eq("my_office")
+          expect(step.office_page).to eq("my_office")
         end
       end
     end
@@ -53,25 +53,25 @@ RSpec.describe Medicaid::WelcomeController do
 
   describe "#update" do
     context "without an existing application" do
-      it "creates application with office location and assigns to session" do
-        put :update, params: { step: { office_location: "my office" } }
+      it "creates application with office page and assigns to session" do
+        put :update, params: { step: { office_page: "my office" } }
 
         current_application_id = session[:medicaid_application_id]
         medicaid_application = MedicaidApplication.find(current_application_id)
 
-        expect(medicaid_application.office_location).to eq("my office")
+        expect(medicaid_application.office_page).to eq("my office")
       end
     end
 
     context "with an existing application" do
-      it "updates with office location" do
+      it "updates with office page" do
         medicaid_application = create(:medicaid_application)
         session[:medicaid_application_id] = medicaid_application.id
 
-        put :update, params: { step: { office_location: "my office" } }
+        put :update, params: { step: { office_page: "my office" } }
 
         medicaid_application.reload
-        expect(medicaid_application.office_location).to eq("my office")
+        expect(medicaid_application.office_page).to eq("my office")
       end
     end
   end

--- a/spec/controllers/office_location_controller_spec.rb
+++ b/spec/controllers/office_location_controller_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe OfficeLocationController do
+  describe "#edit" do
+    context "office page present on application" do
+      it "skips to the next step" do
+        snap_application = create(:snap_application, office_page: "clio")
+        session[:snap_application_id] = snap_application.id
+
+        get :edit
+
+        expect(response).to redirect_to(controller.next_path)
+      end
+    end
+
+    context "office page not present on application" do
+      it "assigns the location to the step" do
+        snap_application = create(:snap_application,
+          office_page: nil,
+          selected_office_location: "clio")
+        session[:snap_application_id] = snap_application.id
+
+        get :edit
+
+        step = assigns(:step)
+
+        expect(step.selected_office_location).to eq("clio")
+      end
+    end
+  end
+
+  describe "#update" do
+    context "when step is valid" do
+      it "redirects to next step and updates the application" do
+        snap_application = create(:snap_application)
+        session[:snap_application_id] = snap_application.id
+
+        params = {
+          selected_office_location: "clio",
+        }
+        put :update, params: { step: params }
+
+        snap_application.reload
+
+        expect(response).to redirect_to(subject.next_path)
+        expect(snap_application.selected_office_location).to eq("clio")
+      end
+    end
+  end
+end

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -142,7 +142,7 @@ RSpec.describe SuccessController do
 
     context "office location present" do
       it "redirects to the office specific landing page" do
-        current_app.update(office_location: "union")
+        current_app.update(office_page: "union")
         params = { step: attributes }
 
         put :update, params: params

--- a/spec/features/medicaid_address_flow_spec.rb
+++ b/spec/features/medicaid_address_flow_spec.rb
@@ -13,7 +13,17 @@ RSpec.feature "medicaid address flows" do
       proceed_with "Next"
 
       proceed_with "Yes"
+    end
 
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Next"
+    end
+
+    on_page "Introduction" do
       fill_in "What is your first name?", with: "Jessie"
       fill_in "What is your last name?", with: "Tester"
       select_radio(question: "What is your gender?", answer: "Female")
@@ -46,7 +56,17 @@ RSpec.feature "medicaid address flows" do
       proceed_with "Next"
 
       proceed_with "Yes"
+    end
 
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Next"
+    end
+
+    on_page "Introduction" do
       fill_in "What is your first name?", with: "Jessie"
       fill_in "What is your last name?", with: "Tester"
       select_radio(question: "What is your gender?", answer: "Female")
@@ -88,12 +108,18 @@ RSpec.feature "medicaid address flows" do
       expect(page).to have_content("Welcome to the Medicaid application")
       proceed_with "Next"
 
-      expect(page).to have_content(
-        "Before we get started, do you currently reside in Michigan?",
-      )
-
       proceed_with "Yes"
+    end
 
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Next"
+    end
+
+    on_page "Introduction" do
       fill_in "What is your first name?", with: "Jessie"
       fill_in "What is your last name?", with: "Tester"
       select_radio(question: "What is your gender?", answer: "Female")

--- a/spec/features/medicaid_application_with_maximum_info_spec.rb
+++ b/spec/features/medicaid_application_with_maximum_info_spec.rb
@@ -13,7 +13,17 @@ RSpec.feature "Medicaid app" do
       proceed_with "Next"
 
       proceed_with "Yes"
+    end
 
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Next"
+    end
+
+    on_page "Introduction" do
       fill_in "What is your first name?", with: "Jessie"
       fill_in "What is your last name?", with: "Tester"
       select_radio(question: "What is your gender?", answer: "Female")

--- a/spec/features/medicaid_application_with_minimal_info_spec.rb
+++ b/spec/features/medicaid_application_with_minimal_info_spec.rb
@@ -11,9 +11,25 @@ RSpec.feature "Medicaid app" do
     on_pages "Introduction" do
       expect(page).to have_content("Welcome to the Medicaid application")
       proceed_with "Next"
+    end
+
+    on_page "Introduction" do
+      expect(page).to have_content(
+        "Before we get started, do you currently reside in Michigan?",
+      )
 
       proceed_with "Yes"
+    end
 
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Next"
+    end
+
+    on_page "Introduction" do
       fill_in "What is your first name?", with: "Jessie"
       fill_in "What is your last name?", with: "Tester"
       select_radio(question: "What is your gender?", answer: "Female")

--- a/spec/features/medicaid_application_with_multiple_members_spec.rb
+++ b/spec/features/medicaid_application_with_multiple_members_spec.rb
@@ -11,9 +11,25 @@ RSpec.feature "Medicaid app" do
     on_pages "Introduction" do
       expect(page).to have_content("Welcome to the Medicaid application")
       proceed_with "Next"
+    end
+
+    on_page "Introduction" do
+      expect(page).to have_content(
+        "Before we get started, do you currently reside in Michigan?",
+      )
 
       proceed_with "Yes"
+    end
 
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Next"
+    end
+
+    on_page "Introduction" do
       fill_in "What is your first name?", with: "Jessie"
       fill_in "What is your last name?", with: "Tester"
       select_radio(question: "What is your gender?", answer: "Female")

--- a/spec/features/missing_required_fields_spec.rb
+++ b/spec/features/missing_required_fields_spec.rb
@@ -5,14 +5,29 @@ RSpec.feature "Missing required fields" do
     visit root_path
     within(".slab--hero") { proceed_with "Apply for FAP" }
 
-    fill_in_name_and_birthday
-    proceed_with "Continue"
+    on_page "Introduction" do
+      expect(page).to have_content("Food Assistance Application")
+      fill_in_name_and_birthday
+      proceed_with "Continue"
+    end
 
-    fill_in "What is the best phone number to reach you?", with: "2024561111"
-    proceed_with "Continue"
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Continue"
+    end
 
-    fill_in "Street address", with: "123 Main St."
-    proceed_with "Continue"
+    on_page "Contact Information" do
+      fill_in "What is the best phone number to reach you?", with: "2024561111"
+      proceed_with "Continue"
+    end
+
+    on_page "Your Location" do
+      fill_in "Street address", with: "123 Main St."
+      proceed_with "Continue"
+    end
 
     on_page("Your Location") do
       expect(

--- a/spec/features/office_specific_landing_pages_spec.rb
+++ b/spec/features/office_specific_landing_pages_spec.rb
@@ -7,7 +7,7 @@ RSpec.feature "Office-specific landing pages", :js do
       proceed_with "Apply for FAP"
 
       expect(current_path).to eq "/steps/introduce-yourself"
-      expect(find("#step_office_location", visible: false).value).to eq("clio")
+      expect(find("#step_office_page", visible: false).value).to eq("clio")
     end
 
     scenario "union street" do
@@ -15,7 +15,7 @@ RSpec.feature "Office-specific landing pages", :js do
       proceed_with "Apply for FAP"
 
       expect(current_path).to eq "/steps/introduce-yourself"
-      expect(find("#step_office_location", visible: false).value).to eq("union")
+      expect(find("#step_office_page", visible: false).value).to eq("union")
     end
 
     scenario "regular home page" do
@@ -23,7 +23,7 @@ RSpec.feature "Office-specific landing pages", :js do
       within(".slab--hero") { proceed_with "Apply for FAP" }
 
       expect(current_path).to eq "/steps/introduce-yourself"
-      expect(find("#step_office_location", visible: false).value).to eq("")
+      expect(find("#step_office_page", visible: false).value).to eq("")
     end
   end
 
@@ -33,7 +33,7 @@ RSpec.feature "Office-specific landing pages", :js do
       proceed_with "Apply for Medicaid"
 
       expect(current_path).to eq "/steps/medicaid/welcome"
-      expect(find("#step_office_location", visible: false).value).to eq("clio")
+      expect(find("#step_office_page", visible: false).value).to eq("clio")
     end
 
     scenario "union street" do
@@ -41,7 +41,7 @@ RSpec.feature "Office-specific landing pages", :js do
       proceed_with "Apply for Medicaid"
 
       expect(current_path).to eq "/steps/medicaid/welcome"
-      expect(find("#step_office_location", visible: false).value).to eq("union")
+      expect(find("#step_office_page", visible: false).value).to eq("union")
     end
 
     scenario "regular home page" do
@@ -49,7 +49,7 @@ RSpec.feature "Office-specific landing pages", :js do
       within(".slab--hero") { proceed_with "Apply for Medicaid" }
 
       expect(current_path).to eq "/steps/medicaid/welcome"
-      expect(find("#step_office_location", visible: false).value).to eq("")
+      expect(find("#step_office_page", visible: false).value).to eq("")
     end
   end
 end

--- a/spec/features/snap_application_change_location_spec.rb
+++ b/spec/features/snap_application_change_location_spec.rb
@@ -6,24 +6,37 @@ RSpec.feature "Submit snap application" do
     within(".slab--hero") { proceed_with "Apply for FAP" }
 
     on_page "Introduction" do
+      expect(page).to have_content("Food Assistance Application")
       fill_in_name_and_birthday
       proceed_with "Continue"
     end
 
-    fill_in "What is the best phone number to reach you?", with: "2024561111"
-    proceed_with "Continue"
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Continue"
+    end
 
-    fill_in "Street address", with: "123 Main St"
-    fill_in "City", with: "Flint"
-    fill_in "ZIP code", with: "48411"
-    select_address_same_as_home_address
-    proceed_with "Continue"
+    on_page "Contact Information" do
+      fill_in "What is the best phone number to reach you?", with: "2024561111"
+      proceed_with "Continue"
+    end
 
-    within(".form-card__content") do
-      expect(page).to have_content("Union Street")
+    on_page "Your Location" do
+      fill_in "Street address", with: "123 Main St"
+      fill_in "City", with: "Flint"
+      fill_in "ZIP code", with: "48411"
+      select_address_same_as_home_address
+      proceed_with "Continue"
     end
 
     on_page "Introduction Complete" do
+      within(".form-card__content") do
+        expect(page).to have_content("Union Street")
+      end
+
       proceed_with "here"
     end
 

--- a/spec/features/snap_application_with_maximum_info_spec.rb
+++ b/spec/features/snap_application_with_maximum_info_spec.rb
@@ -12,6 +12,14 @@ feature "SNAP application with maximum info" do
       proceed_with "Continue"
     end
 
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Continue"
+    end
+
     on_page "Contact Information" do
       fill_in "What is the best phone number to reach you?", with: "2024561111"
       fill_in "What is your email address?", with: "test@example.com"

--- a/spec/features/snap_application_with_minimal_info_spec.rb
+++ b/spec/features/snap_application_with_minimal_info_spec.rb
@@ -11,14 +11,26 @@ RSpec.feature "Submit application with minimal information" do
       proceed_with "Continue"
     end
 
-    fill_in "What is the best phone number to reach you?", with: "2024561111"
-    proceed_with "Continue"
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Continue"
+    end
 
-    fill_in "Street address", with: "123 Main St"
-    fill_in "City", with: "Flint"
-    fill_in "ZIP code", with: "12345"
-    select_address_same_as_home_address
-    proceed_with "Continue"
+    on_page "Contact Information" do
+      fill_in "What is the best phone number to reach you?", with: "2024561111"
+      proceed_with "Continue"
+    end
+
+    on_page "Your Location" do
+      fill_in "Street address", with: "123 Main St"
+      fill_in "City", with: "Flint"
+      fill_in "ZIP code", with: "12345"
+      select_address_same_as_home_address
+      proceed_with "Continue"
+    end
 
     on_page "Introduction Complete" do
       proceed_with "Continue"
@@ -28,9 +40,11 @@ RSpec.feature "Submit application with minimal information" do
       proceed_with "Continue"
     end
 
-    select_radio(question: "What is your sex?", answer: "Female")
-    select "Divorced", from: "What is your marital status?"
-    proceed_with "Continue"
+    on_page "Personal Details" do
+      select_radio(question: "What is your sex?", answer: "Female")
+      select "Divorced", from: "What is your marital status?"
+      proceed_with "Continue"
+    end
 
     on_page "Case Details" do
       expect(page).to have_content(

--- a/spec/features/snap_mailing_and_residential_addresses_spec.rb
+++ b/spec/features/snap_mailing_and_residential_addresses_spec.rb
@@ -1,22 +1,37 @@
 require "rails_helper"
 
 RSpec.feature "Mailing and residential addresses" do
-  scenario "home address not same as mailing address" do
+  scenario "home address not same as mailing address", :js do
     visit root_path
     within(".slab--hero") { click_on "Apply for FAP" }
 
-    fill_in_name_and_birthday
-    click_on "Continue"
+    on_page "Introduction" do
+      expect(page).to have_content("Food Assistance Application")
+      fill_in_name_and_birthday
+      proceed_with "Continue"
+    end
 
-    fill_in "What is the best phone number to reach you?", with: "2024561111"
-    fill_in "What is your email address?", with: "test@example.com"
-    click_on "Continue"
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Continue"
+    end
 
-    fill_in "Street address", with: "123 Main St"
-    fill_in "City", with: "Flint"
-    fill_in "ZIP code", with: "12345"
-    select_address_not_same_as_home_address
-    click_on "Continue"
+    on_page "Contact Information" do
+      fill_in "What is the best phone number to reach you?", with: "2024561111"
+      fill_in "What is your email address?", with: "test@example.com"
+      click_on "Continue"
+    end
+
+    on_page "Your Location" do
+      fill_in "Street address", with: "123 Main St"
+      fill_in "City", with: "Flint"
+      fill_in "ZIP code", with: "12345"
+      select_address_not_same_as_home_address
+      click_on "Continue"
+    end
 
     expect(current_path).to eq "/steps/residential-address"
     fill_in "Street address", with: "456 Hello St"
@@ -28,22 +43,37 @@ RSpec.feature "Mailing and residential addresses" do
     expect(current_path).to eq "/steps/introduction-complete"
   end
 
-  scenario "goes back after skipping residential address step" do
+  scenario "goes back after skipping residential address step", :js do
     visit root_path
     within(".slab--hero") { click_on "Apply for FAP" }
 
-    fill_in_name_and_birthday
-    click_on "Continue"
+    on_page "Introduction" do
+      expect(page).to have_content("Food Assistance Application")
+      fill_in_name_and_birthday
+      proceed_with "Continue"
+    end
 
-    fill_in "What is the best phone number to reach you?", with: "2024561111"
-    fill_in "What is your email address?", with: "test@example.com"
-    click_on "Continue"
+    on_page "Office" do
+      select_radio(
+        question: "Which office are you in?",
+        answer: "I'm not in an office",
+      )
+      proceed_with "Continue"
+    end
 
-    fill_in "Street address", with: "123 Main St"
-    fill_in "City", with: "Flint"
-    fill_in "ZIP code", with: "12345"
-    select_address_same_as_home_address
-    click_on "Continue"
+    on_page "Contact Information" do
+      fill_in "What is the best phone number to reach you?", with: "2024561111"
+      fill_in "What is your email address?", with: "test@example.com"
+      click_on "Continue"
+    end
+
+    on_page "Your Location" do
+      fill_in "Street address", with: "123 Main St"
+      fill_in "City", with: "Flint"
+      fill_in "ZIP code", with: "12345"
+      select_address_same_as_home_address
+      click_on "Continue"
+    end
 
     find(".step-header__back-link").click
 

--- a/spec/models/medicaid_application_spec.rb
+++ b/spec/models/medicaid_application_spec.rb
@@ -139,4 +139,38 @@ RSpec.describe MedicaidApplication do
       expect(app.members_count).to eq 5
     end
   end
+
+  describe "#office_location" do
+    context "when selected office location clio or union" do
+      it "returns selected office location" do
+        app1 = create(:medicaid_application,
+          selected_office_location: "clio",
+          office_page: "foo")
+        app2 = create(:medicaid_application,
+          selected_office_location: "union",
+          office_page: "foo")
+
+        expect(app1.office_location).to eq("clio")
+        expect(app2.office_location).to eq("union")
+      end
+    end
+
+    context "when selected office location is not clio or union" do
+      it "returns nil" do
+        app = create(:medicaid_application, selected_office_location: "other")
+
+        expect(app.office_location).to eq(nil)
+      end
+    end
+
+    context "when selected office location not present" do
+      it "returns office page" do
+        app = create(:medicaid_application,
+          selected_office_location: nil,
+          office_page: "union")
+
+        expect(app.office_location).to eq("union")
+      end
+    end
+  end
 end

--- a/spec/models/snap_application_spec.rb
+++ b/spec/models/snap_application_spec.rb
@@ -217,4 +217,38 @@ RSpec.describe SnapApplication do
       expect(app.latest_drive_attempt).to eq latest
     end
   end
+
+  describe "#office_location" do
+    context "when selected office location clio or union" do
+      it "returns selected office location" do
+        app1 = create(:snap_application,
+          selected_office_location: "clio",
+          office_page: "foo")
+        app2 = create(:snap_application,
+          selected_office_location: "union",
+          office_page: "foo")
+
+        expect(app1.office_location).to eq("clio")
+        expect(app2.office_location).to eq("union")
+      end
+    end
+
+    context "when selected office location is not clio or union" do
+      it "returns nil" do
+        app = create(:snap_application, selected_office_location: "other")
+
+        expect(app.office_location).to eq(nil)
+      end
+    end
+
+    context "when selected office location not present" do
+      it "returns office page" do
+        app = create(:snap_application,
+          selected_office_location: nil,
+          office_page: "union")
+
+        expect(app.office_location).to eq("union")
+      end
+    end
+  end
 end


### PR DESCRIPTION
We were receiving misdirected applications, because offices aren't always using the office-specific landing places. To prevent misdirected applications, we added a question that explicitly asks users where they're applying. If they indicate that they're not in an office or are in an office other than those we serve, we direct the application to us. Otherwise, we route to the correct office.

To do this, we now have a synthetic "office_location" field on the old-style applications, which looks first to a recognized chosen office location, then to whether someone applied via an office page. If neither of these results in an office, then we look up the person's address by county to route it.

[Finishes #156967567]

In SNAP flow, we ask user for office location after the application is created (step 2, after introduce yourself).

In Medicaid flow, we ask user for their office location after they answer whether they live in Michigan.

We skip this question if the user applies via an office-specific landing page.

![screen shot 2018-05-08 at 5 55 05 pm](https://user-images.githubusercontent.com/3675092/39790131-fcf1d2aa-52e8-11e8-9893-c591be41af35.png)

Co-authored-by: Ben Golder <bgolder@codeforamerica.org>