### PR TITLE
Require zip code be a 5-digit number

### DIFF
--- a/app/forms/mailing_address_form.rb
+++ b/app/forms/mailing_address_form.rb
@@ -7,11 +7,15 @@ class MailingAddressForm < Form
   )
 
   validates :street_address,
-            presence: { message: "Make sure to provide a street address", allow_blank: false }
+            presence: { message: "Make sure to provide a street address" }
 
   validates :city,
-            presence: { message: "Make sure to provide a city", allow_blank: false }
+            presence: { message: "Make sure to provide a city" }
 
   validates :zip,
+            numericality: {
+              only_integer: true,
+              message: "Make sure the ZIP code is a number",
+            },
             length: { is: 5, message: "Make sure the ZIP code is 5 digits long" }
 end

--- a/app/forms/residential_address_form.rb
+++ b/app/forms/residential_address_form.rb
@@ -9,11 +9,15 @@ class ResidentialAddressForm < Form
   )
 
   validates :street_address,
-    presence: { message: "Make sure to provide a street address", allow_blank: false }
+    presence: { message: "Make sure to provide a street address" }
 
   validates :city,
-    presence: { message: "Make sure to provide a city", allow_blank: false }
+    presence: { message: "Make sure to provide a city" }
 
   validates :zip,
+    numericality: {
+      only_integer: true,
+      message: "Make sure the ZIP code is a number",
+    },
     length: { is: 5, message: "Make sure the ZIP code is 5 digits long" }
 end

--- a/app/views/integrated/mailing_address/edit.html.erb
+++ b/app/views/integrated/mailing_address/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :header_title, "Introduction" %>
-<% content_for :form_card_title, "Tell us where to send your postal mail." %>
+<% content_for :form_card_title, "Tell us where to send you postal mail." %>
 
 <% content_for :form_card_body do %>
   <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>

--- a/spec/features/integrated_application_with_multiple_members_spec.rb
+++ b/spec/features/integrated_application_with_multiple_members_spec.rb
@@ -67,7 +67,7 @@ RSpec.feature "Integrated application" do
     end
 
     on_page "Introduction" do
-      expect(page).to have_content("Tell us where to send your postal mail.")
+      expect(page).to have_content("Tell us where to send you postal mail.")
 
       fill_in "Street address", with: "PO Box 123"
       fill_in "City", with: "Flint"

--- a/spec/features/integrated_application_with_single_member_spec.rb
+++ b/spec/features/integrated_application_with_single_member_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature "Integrated application" do
     end
 
     on_page "Introduction" do
-      expect(page).to have_content("Tell us where to send your postal mail.")
+      expect(page).to have_content("Tell us where to send you postal mail.")
 
       fill_in "Street address", with: "123 Main St"
       fill_in "Street address 2", with: "Floor 2"

--- a/spec/forms/mailing_address_form_spec.rb
+++ b/spec/forms/mailing_address_form_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe MailingAddressForm do
+  describe "validations" do
+    it "requires street address" do
+      form = MailingAddressForm.new
+
+      expect(form).not_to be_valid
+      expect(form.errors[:street_address]).to be_present
+    end
+
+    it "requires city" do
+      form = MailingAddressForm.new
+
+      expect(form).not_to be_valid
+      expect(form.errors[:city]).to be_present
+    end
+
+    it "requires zip" do
+      form = MailingAddressForm.new
+
+      expect(form).not_to be_valid
+      expect(form.errors[:zip]).to be_present
+    end
+
+    it "requires zip to be 5-digit number" do
+      alpha_form = MailingAddressForm.new(zip: "whaat")
+      too_short_form = MailingAddressForm.new(zip: "123")
+
+      expect(alpha_form).not_to be_valid
+      expect(alpha_form.errors[:zip]).to be_present
+
+      expect(too_short_form).not_to be_valid
+      expect(too_short_form.errors[:zip]).to be_present
+    end
+
+    it "is valid with required fields" do
+      form = MailingAddressForm.new(
+        street_address: "1234 Fake St",
+        city: "Pleasanton",
+        zip: "12345",
+      )
+
+      expect(form).to be_valid
+    end
+  end
+end

--- a/spec/forms/residential_address_form_spec.rb
+++ b/spec/forms/residential_address_form_spec.rb
@@ -2,13 +2,34 @@ require "rails_helper"
 
 RSpec.describe ResidentialAddressForm do
   describe "validations" do
-    it "requires some attribute" do
+    it "is invalid without required fields" do
       form = ResidentialAddressForm.new
 
       expect(form).not_to be_valid
       expect(form.errors["street_address"]).to be_present
       expect(form.errors["city"]).to be_present
       expect(form.errors["zip"]).to be_present
+    end
+
+    it "requires zip to be 5-digit number" do
+      alpha_form = ResidentialAddressForm.new(zip: "whaat")
+      too_short_form = ResidentialAddressForm.new(zip: "123")
+
+      expect(alpha_form).not_to be_valid
+      expect(alpha_form.errors[:zip]).to be_present
+
+      expect(too_short_form).not_to be_valid
+      expect(too_short_form.errors[:zip]).to be_present
+    end
+
+    it "is valid with required fields" do
+      form = ResidentialAddressForm.new(
+        street_address: "1234 Fake St",
+        city: "Pleasanton",
+        zip: "12345",
+      )
+
+      expect(form).to be_valid
     end
   end
 end


### PR DESCRIPTION
Previously, we only required that zip code be 5 digits. This makes sure that those 5 digits are all numbers!

Also adds a few tests and makes a small copy update.

![screen shot 2018-05-08 at 6 22 59 pm](https://user-images.githubusercontent.com/3675092/39790832-047f519c-52ed-11e8-8034-dd15c0478c5d.png)

![screen shot 2018-05-08 at 6 23 30 pm](https://user-images.githubusercontent.com/3675092/39790833-04977e70-52ed-11e8-8e81-863dd57dd0f5.png)


[Fixes #156390099]
[Fixes #156390093]