### PR TITLE
Allow cent amounts with HTML5 number input on hourly wage

### DIFF
--- a/app/views/integrated/job_details/edit.html.erb
+++ b/app/views/integrated/job_details/edit.html.erb
@@ -43,13 +43,16 @@
               layout: "inline" %>
           </div>
           <div class="question-with-follow-up__follow-up" id="hourly-follow-up-<%=index%>">
-            <%= ff.mb_money_field :pay_quantity_hourly, t(".hourly_rate_label", **member_appropriate_translation_data),
-                                 help_text: "This includes money withheld from paychecks." %>
+            <%= ff.mb_money_field :pay_quantity_hourly,
+              t(".hourly_rate_label", **member_appropriate_translation_data),
+              help_text: "This includes money withheld from paychecks.",
+              options: { step: "0.01" } %>
             <%= ff.mb_input_field :hours_per_week, t(".hours_per_week_label", **member_appropriate_translation_data) %>
           </div>
           <div class="question-with-follow-up__follow-up question-with-follow-up__follow-up-two" id="salaried-follow-up-<%=index%>">
-            <%= ff.mb_money_field :pay_quantity_salary,  t(".salary_rate_label", **member_appropriate_translation_data),
-                                 help_text: "This includes money withheld from paychecks." %>
+            <%= ff.mb_money_field :pay_quantity_salary,
+              t(".salary_rate_label", **member_appropriate_translation_data),
+              help_text: "This includes money withheld from paychecks." %>
           </div>
         </div>
         <%= ff.mb_radio_set :payment_frequency,


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number#Allowing_decimal_values

This is a browser validation that is currently not caught by our integration tests (driver doesn't do the same validation we're seeing in Chrome that caused the bug), so no tests are added.

Only allowed decimal value on hourly wage, because it didn't' seem to make sense to allow it for salary. The backend validation allows cents for both, though, because it's the same field under the hood and uses a regex that does allow decimal values (the field is a string).

[Fixes #158432889]