### PR TITLE
Keep Privacy Policy banner at top on demo + staging

### DIFF
--- a/app/assets/stylesheets/michigan-benefits/organisms/_step-header.scss
+++ b/app/assets/stylesheets/michigan-benefits/organisms/_step-header.scss
@@ -60,4 +60,8 @@
     justify-content: center;
     text-align: center;
   }
+
+  &__top {
+    margin-top: 0;
+  }
 }

--- a/app/views/static_pages/privacy.html.erb
+++ b/app/views/static_pages/privacy.html.erb
@@ -1,4 +1,4 @@
-<h4 class="step-header step-header__title--centered">MichiganBenefits.org Privacy Policy</h4>
+<h4 class="step-header step-header__top step-header__title--centered">MichiganBenefits.org Privacy Policy</h4>
 
 <div class="form-card">
   <p>


### PR DESCRIPTION
The 'This is an example website' banner was causing some funky CSS on the Privacy Policy page. This fixes it.

Simple change, so will merge after tests pass.

*Before*:
![pasted image at 2018_05_08_11_29 am](https://user-images.githubusercontent.com/3675092/41560294-8c0e2420-72fb-11e8-8d7b-4ff2d645d931.png)

*After*:
![screen shot 2018-06-18 at 1 26 33 pm](https://user-images.githubusercontent.com/3675092/41560254-66b4878c-72fb-11e8-9b1a-bd85d3378f1d.png)
