### PR TITLE
Show office links in the footer on non-flow pages only.

### DIFF
--- a/app/assets/stylesheets/michigan-benefits/atoms/_variables.scss
+++ b/app/assets/stylesheets/michigan-benefits/atoms/_variables.scss
@@ -7,3 +7,6 @@ $color-darkest-sky:   shade($color-sky, 30%);
 // Button Colors
 $button-cta-color: $color-sky;
 $button-cta-border-color: $color-dark-sky;
+
+// Magic Numbers
+$footer-height: 240px;

--- a/app/views/layouts/form.html.erb
+++ b/app/views/layouts/form.html.erb
@@ -65,7 +65,7 @@
     </div>
     <div class="form-card--security-message">Your information is always kept safe and secure</div>
   </div>
-  <%= render 'shared/footer' %>
+  <%= render 'shared/footer', office_links: false %>
 <% end %>
 
 <%= render template: 'layouts/application' %>

--- a/app/views/layouts/step.html.erb
+++ b/app/views/layouts/step.html.erb
@@ -20,7 +20,7 @@
     </div>
     <div class="form-card--security-message">Your information is always kept safe and secure</div>
   </div>
-  <%= render 'shared/footer' %>
+  <%= render 'shared/footer', office_links: false %>
 <% end %>
 
 <%= render template: 'layouts/application' %>

--- a/app/views/messages/new.html.erb
+++ b/app/views/messages/new.html.erb
@@ -56,7 +56,7 @@ end %>
   </div>
 </div>
 
-<%= render 'shared/footer' %>
+<%= render 'shared/footer', office_links: false %>
 
 <% unless Rails.env.test? -%>
 <script>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,12 +1,15 @@
 <div class="main-footer">
   <div class="grid">
-    <div class="footer--office-links">
-      <p class="footer--office-links-header text--small">
-        MDHHS Offices
-      </p>
-      <%= link_to "Union Street Office", union_path, class: "text--small" %>
-      <%= link_to "Clio Road Office", clio_path, class: "text--small" %>
-    </div>
+
+    <% if office_links %>
+      <div class="footer--office-links">
+        <p class="footer--office-links-header text--small">
+          MDHHS Offices
+        </p>
+        <%= link_to "Union Street Office", union_path, class: "text--small" %>
+        <%= link_to "Clio Road Office", clio_path, class: "text--small" %>
+      </div>
+    <% end %>
 
     <div class="footer--partners">
       <div class="illustration illustration--cfa"></div>

--- a/app/views/static_pages/clio.html.erb
+++ b/app/views/static_pages/clio.html.erb
@@ -46,4 +46,4 @@ end %>
 </div>
 
 <%= render "home_page_bottom_section_dual", office_page: "clio" %>
-<%= render 'shared/footer' %>
+<%= render 'shared/footer', office_links: true %>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -40,4 +40,4 @@ end %>
 </div>
 
 <%= render "home_page_bottom_section_dual", office_page: nil %>
-<%= render "shared/footer" %>
+<%= render "shared/footer", office_links: true %>

--- a/app/views/static_pages/union.html.erb
+++ b/app/views/static_pages/union.html.erb
@@ -46,4 +46,4 @@ end %>
 </div>
 
 <%= render "home_page_bottom_section_dual", office_page: "union" %>
-<%= render 'shared/footer' %>
+<%= render 'shared/footer', office_links: true %>


### PR DESCRIPTION
Also adjust the height of the footer.

Office links are removed for in-flow pages so that they're not accidentally tapped on:

![introduction 2018-06-21 19-42-28](https://user-images.githubusercontent.com/417/41750796-d60f84f0-758b-11e8-97ed-d478fdc09e40.png)

[#158482452]