### PR TITLE
Integrated/remove unused hours per week

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,3 +15,5 @@ end
 task default: %w(lint:autocorrect bundler:audit brakeman spec)
 
 Rails.application.load_tasks
+
+task "db:schema:dump": "strong_migrations:alphabetize_columns"

--- a/db/migrate/20180626222332_remove_hours_per_week_int_from_employments.rb
+++ b/db/migrate/20180626222332_remove_hours_per_week_int_from_employments.rb
@@ -1,0 +1,5 @@
+class RemoveHoursPerWeekIntFromEmployments < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :employments, :hours_per_week_int, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180626001406) do
+ActiveRecord::Schema.define(version: 20180626222332) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -191,11 +191,10 @@ ActiveRecord::Schema.define(version: 20180626001406) do
     t.datetime "created_at", null: false
     t.string "employer_name"
     t.integer "hourly_or_salary", default: 0
-    t.integer "hours_per_week_int"
+    t.string "hours_per_week"
     t.string "pay_quantity"
     t.string "payment_frequency"
     t.datetime "updated_at", null: false
-    t.string "hours_per_week"
     t.index ["application_member_id"], name: "index_employments_on_application_member_id"
   end
 

--- a/lib/tasks/alphabetize_columns.rake
+++ b/lib/tasks/alphabetize_columns.rake
@@ -1,0 +1,26 @@
+# From https://github.com/ankane/strong_migrations/blob/c870b1a8b942a0b616f09d4758d109e03a79c806/lib/tasks/strong_migrations.rake
+
+namespace :strong_migrations do
+  task safety_assured: :environment do
+    raise "Set SAFETY_ASSURED=1 to run this task in production" if Rails.env.production? && !ENV["SAFETY_ASSURED"]
+  end
+
+  # https://www.pgrs.net/2008/03/13/alphabetize-schema-rb-columns/
+  task :alphabetize_columns do
+    $stderr.puts "Dumping schema"
+    ActiveRecord::Base.logger.level = Logger::INFO
+
+    class << ActiveRecord::Base.connection
+      alias_method :old_columns, :columns unless instance_methods.include?("old_columns")
+      alias_method :old_extensions, :extensions unless instance_methods.include?("old_extensions")
+
+      def columns(*args)
+        old_columns(*args).sort_by(&:name)
+      end
+
+      def extensions(*args)
+        old_extensions(*args).sort
+      end
+    end
+  end
+end

--- a/lib/tasks/one_offs.rake
+++ b/lib/tasks/one_offs.rake
@@ -2,11 +2,5 @@
 namespace :one_offs do
   desc "runs all one_offs, remove things from here after they are deployed"
   task run_all: :environment do
-    Employment.where(hours_per_week: nil).where.not(hours_per_week_int: nil).find_each do |employment|
-      puts "Updating: Employment ##{employment.id}..."
-      employment.hours_per_week = employment.hours_per_week_int.to_s
-      employment.save!
-      puts "Completed: Employment ##{employment.id}"
-    end
   end
 end


### PR DESCRIPTION
Removes unused `hours_per_week_int` column and data migration rake task, now that prod deploy containing the relevant code has been done.

Also adds task to alphabetize columns on schema dump. Previously, we were using the strong migrations gem to alphabetize our schema to minimize diffs each time we run a migration. When we removed the gem, we lost that power. This reinstates it by harvesting the rake task.