### PR TITLE
Correct integrated application flow scopes

### DIFF
--- a/app/models/common_application.rb
+++ b/app/models/common_application.rb
@@ -77,18 +77,17 @@ class CommonApplication < ApplicationRecord
 
   scope :signed, -> { where.not(signed_at: nil) }
 
-  scope :applying_for_healthcare_only, -> {
-    joins(:members).where(household_members: { requesting_healthcare: 1, requesting_food: [0, 2] }).distinct
+  scope :applying_for_food, -> {
+    joins(:members).merge(HouseholdMember.requesting_food).distinct
   }
-  scope :applying_for_food_only, -> {
-    joins(:members).where(household_members: { requesting_food: 1, requesting_healthcare: [0, 2] }).distinct
+
+  scope :applying_for_healthcare, -> {
+    joins(:members).merge(HouseholdMember.requesting_healthcare).distinct
   }
-  scope :applying_for_food_and_healthcare, -> {
-    joins(:members).
-      where(household_members: { requesting_food: 1 }).
-      where(household_members: { requesting_healthcare: 1 }).
-      distinct
-  }
+
+  scope :applying_for_food_only, -> { applying_for_food - applying_for_healthcare }
+  scope :applying_for_healthcare_only, -> { applying_for_healthcare - applying_for_food }
+  scope :applying_for_food_and_healthcare, -> { applying_for_food & applying_for_healthcare }
 
   delegate :display_name, to: :primary_member
 

--- a/spec/factories/household_members.rb
+++ b/spec/factories/household_members.rb
@@ -3,9 +3,17 @@ FactoryBot.define do
     first_name "Lilly"
     last_name "Pad"
 
+    trait :requesting_food do
+      requesting_food "yes"
+    end
+
+    trait :requesting_healthcare do
+      requesting_healthcare "yes"
+    end
+
     trait :in_food_household do
       buy_and_prepare_food_together "yes"
-      requesting_food "yes"
+      requesting_food
     end
   end
 end

--- a/spec/models/common_application_spec.rb
+++ b/spec/models/common_application_spec.rb
@@ -98,38 +98,61 @@ RSpec.describe CommonApplication do
     end
 
     describe ".applying_for_healthcare_only" do
-      it "returns apps where at least one member is applying for healthcare" do
-        applying = create(:common_application, :multi_member_healthcare)
-        create(:common_application, :multi_member_food_and_healthcare)
-        create(:common_application, :single_member)
+      it "returns apps where at least one member is applying for healthcare but no one is applying for food" do
+        applying_one = create(:common_application, :multi_member_healthcare)
+        applying_two = create(:common_application,
+          members: [
+            build(:household_member, requesting_healthcare: "yes", requesting_food: "no"),
+            build(:household_member, requesting_healthcare: "no", requesting_food: "no"),
+          ])
 
-        healthcare_apps = CommonApplication.applying_for_healthcare_only
+        create(:common_application,
+          members: [
+            build(:household_member, requesting_healthcare: "yes", requesting_food: "no"),
+            build(:household_member, requesting_healthcare: "no", requesting_food: "yes"),
+          ])
 
-        expect(healthcare_apps).to match_array([applying])
+        health_apps = CommonApplication.applying_for_healthcare_only
+
+        expect(health_apps).to match_array([applying_one, applying_two])
       end
     end
 
     describe ".applying_for_food_only" do
-      it "returns apps where at least one member is applying for food" do
-        applying = create(:common_application, :multi_member_food)
-        create(:common_application, :multi_member_food_and_healthcare)
-        create(:common_application, :single_member)
+      it "returns apps where at least one member is applying for food but no one is applying for healthcare" do
+        applying_one = create(:common_application, :multi_member_food)
+        applying_two = create(:common_application,
+               members: [
+                 build(:household_member, requesting_food: "yes", requesting_healthcare: "no"),
+                 build(:household_member, requesting_food: "no", requesting_healthcare: "no"),
+               ])
+
+        create(:common_application,
+               members: [
+                 build(:household_member, requesting_food: "yes", requesting_healthcare: "no"),
+                 build(:household_member, requesting_food: "no", requesting_healthcare: "yes"),
+               ])
 
         food_apps = CommonApplication.applying_for_food_only
 
-        expect(food_apps).to match_array([applying])
+        expect(food_apps).to match_array([applying_one, applying_two])
       end
     end
 
     describe ".applying_for_food_and_healthcare" do
-      it "returns apps where at least one member is applying for both food and healthcare" do
-        applying = create(:common_application, :multi_member_food_and_healthcare)
+      it "returns apps where members are applying for both food and healthcare" do
+        applying_one = create(:common_application, members: [
+          build(:household_member, requesting_food: "yes", requesting_healthcare: "no"),
+          build(:household_member, requesting_food: "no", requesting_healthcare: "yes")
+        ])
+        applying_two = create(:common_application, :multi_member_food_and_healthcare)
+
         create(:common_application, :single_member_food)
         create(:common_application, :single_member_healthcare)
 
         food_and_healthcare_apps = CommonApplication.applying_for_food_and_healthcare
 
-        expect(food_and_healthcare_apps).to match_array([applying])
+        expect(food_and_healthcare_apps).to match_array([applying_one, applying_two])
       end
     end
   end

--- a/spec/models/household_member_spec.rb
+++ b/spec/models/household_member_spec.rb
@@ -58,6 +58,28 @@ RSpec.describe HouseholdMember do
         expect(HouseholdMember.with_additional_income.first).to eq(member)
       end
     end
+
+    describe ".requesting_food" do
+      it "returns members who are applying for food" do
+        food_members = [
+          create(:household_member, :requesting_food),
+        ]
+        create(:household_member)
+
+        expect(HouseholdMember.requesting_food).to match_array(food_members)
+      end
+    end
+
+    describe ".requesting_healthcare" do
+      it "returns members who are applying for healthcare" do
+        healthcare_members = [
+          create(:household_member, :requesting_healthcare),
+        ]
+        create(:household_member)
+
+        expect(HouseholdMember.requesting_healthcare).to match_array(healthcare_members)
+      end
+    end
   end
 
   describe "#display_name" do


### PR DESCRIPTION
Sets are fun! This updates the new integated flow scopes to what we intended:

* FAP-only returns applications that only have members applying for FAP
* Medicaid-only returns applications that only have members applying for Medicaid
* FAP and Medicaid returns applications that has memebers applying for either/both FAP and Medicaid

[Fixes #158617351]