### PR TITLE
Add missing SMTP config for production env

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+require Rails.root.join("config/smtp")
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
   config.force_ssl = true


### PR DESCRIPTION
I missed requiring the SMTP config for production env when upgrading Rails to 5.2, which resulted in an error on Sentry in our staging env. This should fix that—we'll want to get in before we do the next production deploy.