### PR TITLE
Reduce default wait time for Capybara to 0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,6 +55,7 @@ gem "uglifier", ">= 1.3.0"
 
 group :test do
   gem "axe-matchers", "~> 1.3.4"
+  gem "capybara-webkit", git: "https://github.com/thoughtbot/capybara-webkit.git", ref: "8329b19" # Removes deprecation warnings, update to released Gem when >1.15 available
   gem "database_cleaner"
   gem "launchy"
   gem "pdf-reader"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,6 +8,15 @@ GIT
       rails (>= 3.2.6)
       rotp (>= 2.0.0)
 
+GIT
+  remote: https://github.com/thoughtbot/capybara-webkit.git
+  revision: 8329b19e94ff08eeb517cac49bfffd2f667ea90d
+  ref: 8329b19
+  specs:
+    capybara-webkit (1.15.0)
+      capybara (>= 2.3, < 4.0)
+      json
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -1035,6 +1044,7 @@ DEPENDENCIES
   browser
   bundler-audit
   capybara
+  capybara-webkit!
   climate_control
   codeclimate-test-reporter
   database_cleaner

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,9 @@ require "axe/rspec"
 require "devise"
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
-Capybara.javascript_driver = :selenium_chrome_headless # or `:selenium_chrome` for full browser
+Capybara.javascript_driver = :webkit
+Capybara.default_max_wait_time = 0 # No JS (only used for axe-matchers), so no waiting!
+Capybara::Webkit.configure(&:block_unknown_urls)
 
 ActiveRecord::Migration.maintain_test_schema!
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@ require File.expand_path("../config/environment", __dir__)
 require "rspec/rails"
 require "capybara/rails"
 require "capybara/rspec"
-require "selenium/webdriver"
 require "axe/rspec"
 require "devise"
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }


### PR DESCRIPTION
With the upgrade from Capybara 2 to 3, the behavior for `first` and `all` changed, causing our axe-matchers gem to cause tests with accesibility checks to run 7x slower or more. To fix this, we set the default wait for Capybara to 0, since we're not actually waiting on async responses.

This also begins using capybara-webkit as our driver for axe-matchers/js, since it's a bit faster.

[#158733145]