### PR TITLE
Reduce test time

### DIFF
--- a/app/controllers/integrated/introduce_yourself_controller.rb
+++ b/app/controllers/integrated/introduce_yourself_controller.rb
@@ -11,7 +11,7 @@ module Integrated
                            day: member_data.delete(:birthday_day),
                            month: member_data.delete(:birthday_month),
                            year: member_data.delete(:birthday_year),
-      ))
+                         ))
       if current_application.primary_member
         current_application.primary_member.update(member_data)
       else

--- a/spec/controllers/integrated/review_healthcare_household_controller_spec.rb
+++ b/spec/controllers/integrated/review_healthcare_household_controller_spec.rb
@@ -28,10 +28,10 @@ RSpec.describe Integrated::ReviewHealthcareHouseholdController do
       it "sets removable members and removed members" do
         application = create(:common_application,
           members: [
-           create(:household_member, requesting_healthcare: "no", filing_taxes_next_year: "yes"),
-           create(:household_member, requesting_healthcare: "no"),
-           create(:household_member, requesting_healthcare: "no", tax_relationship: "not_included"),
-         ])
+            create(:household_member, requesting_healthcare: "no", filing_taxes_next_year: "yes"),
+            create(:household_member, requesting_healthcare: "no"),
+            create(:household_member, requesting_healthcare: "no", tax_relationship: "not_included"),
+          ])
         session[:current_application_id] = application.id
 
         get :edit
@@ -48,9 +48,9 @@ RSpec.describe Integrated::ReviewHealthcareHouseholdController do
         application = create(:common_application,
           :with_navigator,
           members: [
-           create(:household_member, requesting_healthcare: "no", filing_taxes_next_year: "no"),
-           create(:household_member, requesting_healthcare: "no"),
-         ])
+            create(:household_member, requesting_healthcare: "no", filing_taxes_next_year: "no"),
+            create(:household_member, requesting_healthcare: "no"),
+          ])
         session[:current_application_id] = application.id
 
         get :edit

--- a/spec/controllers/integrated/share_food_costs_with_household_controller_spec.rb
+++ b/spec/controllers/integrated/share_food_costs_with_household_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Integrated::ShareFoodCostsWithHouseholdController do
         current_app = create(
           :common_application,
           :with_navigator,
-          members: build_list(:household_member, 3, requesting_food: "yes")
+          members: build_list(:household_member, 3, requesting_food: "yes"),
         )
         session[:current_application_id] = current_app.id
 

--- a/spec/controllers/medicaid/amounts_income_controller_spec.rb
+++ b/spec/controllers/medicaid/amounts_income_controller_spec.rb
@@ -88,8 +88,8 @@ RSpec.describe Medicaid::AmountsIncomeController do
                 :member,
                 employed: true,
                 employed_number_of_jobs: 2,
-              )
-            ]
+              ),
+            ],
           )
           existing_employments = build_list(:employment, 2)
           medicaid_application.members.first.update(employments: existing_employments)

--- a/spec/features/snap_application_with_maximum_info_spec.rb
+++ b/spec/features/snap_application_with_maximum_info_spec.rb
@@ -264,7 +264,7 @@ accounts?",
     end
 
     expect(page).to have_text(
-      "Your application has been sent to your email inbox",
+      "Your application has been sent to your email inbox", wait: 2
     )
 
     emails = ActionMailer::Base.deliveries

--- a/spec/models/dhs1426_pdf_spec.rb
+++ b/spec/models/dhs1426_pdf_spec.rb
@@ -98,19 +98,19 @@ RSpec.describe Dhs1426Pdf do
         filing_federal_taxes_next_year: true,
       )
       primary_member.update(employments: [
-        build(
-          :employment,
-          employer_name: "AA Accounting",
-          payment_frequency: "Hourly",
-          pay_quantity: "11",
-        ),
-        build(
-          :employment,
-          employer_name: "BB Burgers",
-          payment_frequency: "Weekly",
-          pay_quantity: "222",
-        ),
-      ])
+                              build(
+                                :employment,
+                                employer_name: "AA Accounting",
+                                payment_frequency: "Hourly",
+                                pay_quantity: "11",
+                              ),
+                              build(
+                                :employment,
+                                employer_name: "BB Burgers",
+                                payment_frequency: "Weekly",
+                                pay_quantity: "222",
+                              ),
+                            ])
 
       expected_client_data = {
         primary_member_full_name: "Christa Tester",

--- a/spec/models/medicaid_application_member_attributes_spec.rb
+++ b/spec/models/medicaid_application_member_attributes_spec.rb
@@ -54,7 +54,8 @@ RSpec.describe MedicaidApplicationMemberAttributes do
             payment_frequency: "Weekly",
             pay_quantity: "222",
           ),
-        ])
+        ],
+      )
 
       result = MedicaidApplicationMemberAttributes.new(
         member: member,

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,7 +9,8 @@ require "axe/rspec"
 require "devise"
 Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
-Capybara.javascript_driver = :selenium_chrome_headless # or `:selenium_chrome` for full browser
+Capybara.javascript_driver = :selenium_chrome_headless
+Capybara.default_max_wait_time = 0.2
 
 ActiveRecord::Migration.maintain_test_schema!
 


### PR DESCRIPTION
This contains Rubocop fixes (are my and @hartsick's Rubocop config different?) and sets `default_max_wait_time` to as low as it can be to pass the JS-dependent feature specs.