### PR TITLE
Remove deploy config from Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,18 +81,6 @@ jobs:
           path: /tmp/test-results
           destination: test-results
 
-  deploy:
-    <<: *defaults
-    steps:
-      - checkout
-      - attach_workspace:
-          at: ~/repo
-      - run: bundle --path vendor/bundle
-      - run: "[[ ! -s \"$(git rev-parse --git-dir)/shallow\" ]] || git fetch --unshallow"
-      - run:
-          name: Deploy to Heroku
-          command: git push git@heroku.com:michigan-benefits-staging.git $CIRCLE_SHA1:refs/heads/master
-
 workflows:
   version: 2
   build-and-deploy:
@@ -108,9 +96,3 @@ workflows:
             branches:
               ignore:
                 - master
-      - deploy:
-          requires:
-            - rake_test
-          filters:
-            branches:
-              only: master


### PR DESCRIPTION
We use Heroku's Github hook to automatically deploy any push to master, so this piece of config is no longer needed.

[Finishes #158200178]