### PR TITLE
Don't have screenreader read legend for each option

### DIFF
--- a/app/helpers/mb_form_builder.rb
+++ b/app/helpers/mb_form_builder.rb
@@ -18,13 +18,10 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
       autofocus: autofocus,
       type: type,
       class: classes.join(" "),
-    ).merge(options)
+    ).merge(options).merge(error_attributes(method: method))
 
     text_field_options[:id] ||= sanitized_id(method)
     options[:input_id] ||= sanitized_id(method)
-
-    text_field_options["aria-labelledby"] =
-      aria_labelledby(method: method, help_text: help_text)
 
     text_field_html = text_field(method, text_field_options)
 
@@ -64,7 +61,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
       type: "number",
       class: classes.join(" "),
       id: sanitized_id(slug),
-    ).merge(options)
+    ).merge(options).merge(error_attributes(method: method))
 
     if value_is_array
       text_field_options[:multiple] = "true"
@@ -160,8 +157,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
       autofocus: autofocus,
       class: classes.join(" "),
       placeholder: placeholder,
-      'aria-labelledby': aria_labelledby(method: method, help_text: help_text),
-    ).merge(options)
+    ).merge(options).merge(error_attributes(method: method))
 
     <<~HTML.html_safe
       <div class="form-group#{error_state(object, method)}">
@@ -196,10 +192,10 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
 
     <<~HTML.html_safe
       <fieldset class="form-group#{error_state(object, base_method)}">
-        #{fieldset_label_contents(method: base_method, label_text: label_text, help_text: help_text)}
+        #{fieldset_label_contents(label_text: label_text, help_text: help_text)}
         <div class="input-group--inline">
           <div class="form-group">
-            <label class="text--help form-subquestion" for="#{sanitized_id(month_method)}" id="#{sanitized_id(month_method)}__label">Month</label>
+            <label class="text--help form-subquestion" for="#{sanitized_id(month_method)}">Month</label>
             #{telephone_field(
               month_method,
               options.merge(
@@ -211,7 +207,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
             )}
           </div>
           <div class="form-group">
-            <label class="text--help form-subquestion" for="#{sanitized_id(day_method)}" id="#{sanitized_id(day_method)}__label">Day</label>
+            <label class="text--help form-subquestion" for="#{sanitized_id(day_method)}">Day</label>
             #{telephone_field(
               day_method,
               options.merge(
@@ -222,7 +218,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
             )}
           </div>
           <div class="form-group">
-            <label class="text--help form-subquestion" for="#{sanitized_id(year_method)}" id="#{sanitized_id(year_method)}__label">Year</label>
+            <label class="text--help form-subquestion" for="#{sanitized_id(year_method)}">Year</label>
             #{telephone_field(
               year_method,
               standard_options.merge(
@@ -249,18 +245,12 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     autofocus: nil
   )
 
-    aria_field = aria_labelledby(method: method, help_text: help_text)
-
-    aria_month = "#{aria_field} #{sanitized_id(method, '2i')}__label"
-    aria_day = "#{aria_field} #{sanitized_id(method, '3i')}__label"
-    aria_year = "#{aria_field} #{sanitized_id(method, '1i')}__label"
-
     <<~HTML.html_safe
       <fieldset class="form-group#{error_state(object, method)}">
-        #{fieldset_label_contents(method: method, label_text: label_text, help_text: help_text)}
+        #{fieldset_label_contents(label_text: label_text, help_text: help_text)}
         <div class="input-group--inline">
           <div class="select">
-            <label for="#{sanitized_id(method, '2i')}" class="sr-only" id="#{sanitized_id(method, '2i')}__label">Month</label>
+            <label for="#{sanitized_id(method, '2i')}" class="sr-only">Month</label>
             #{select_month(
               options[:default],
               { field_name: subfield_name(method, '2i'),
@@ -269,11 +259,10 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
                 prompt: 'Month' }.reverse_merge(options),
               class: 'select__element',
               autofocus: autofocus,
-              'aria-labelledby': aria_month,
             )}
           </div>
           <div class="select">
-            <label for="#{sanitized_id(method, '3i')}" class="sr-only" id="#{sanitized_id(method, '3i')}__label">Day</label>
+            <label for="#{sanitized_id(method, '3i')}" class="sr-only">Day</label>
             #{select_day(
               options[:default],
               { field_name: subfield_name(method, '3i'),
@@ -281,11 +270,10 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
                 prefix: object_name,
                 prompt: 'Day' }.merge(options),
               class: 'select__element',
-              'aria-labelledby': aria_day,
             )}
           </div>
           <div class="select">
-            <label for="#{sanitized_id(method, '1i')}" class="sr-only" id="#{sanitized_id(method, '1i')}__label">Year</label>
+            <label for="#{sanitized_id(method, '1i')}" class="sr-only">Year</label>
             #{select_year(
               options[:default],
               { field_name: subfield_name(method, '1i'),
@@ -293,7 +281,6 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
                 prefix: object_name,
                 prompt: 'Year' }.merge(options),
               class: 'select__element',
-              'aria-labelledby': aria_year,
             )}
           </div>
         </div>
@@ -304,7 +291,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
 
   def mb_radio_set(
     method,
-    label_text:,
+    label_text: "",
     collection:,
     help_text: nil,
     layout: "block",
@@ -313,12 +300,11 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     <<~HTML.html_safe
       <fieldset class="form-group#{error_state(object, method)}">
         #{fieldset_label_contents(
-          method: method,
           label_text: label_text,
           help_text: help_text,
           legend_class: legend_class,
         )}
-        #{mb_radio_button(method, collection, layout, help_text)}
+        #{mb_radio_button(method, collection, layout)}
         #{errors_for(object, method)}
       </fieldset>
     HTML
@@ -327,23 +313,15 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
   def mb_checkbox_set(
     method,
     collection,
-    label_text:,
+    label_text: "",
     help_text: nil,
     optional: false,
     legend_class: ""
   )
-    aria_labels = ["#{sanitized_id(method)}__label"]
-    aria_labels << "#{sanitized_id(method)}__help" if help_text
-
     checkbox_html = collection.map do |item|
-      checkbox_label_id = "#{sanitized_id(method)}_#{item[:method]}__label"
-      options = {
-        'aria-labelledby': (aria_labels + [checkbox_label_id]).join(" "),
-      }
-
       <<~HTML.html_safe
-        <label id="#{checkbox_label_id}" class="checkbox">
-          #{check_box(item[:method], options)} #{item[:label]}
+        <label class="checkbox">
+          #{check_box(item[:method])} #{item[:label]}
         </label>
       HTML
     end.join.html_safe
@@ -355,7 +333,6 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
           help_text: help_text,
           legend_class: legend_class,
           optional: optional,
-          method: method,
         )}
         #{checkbox_html}
         #{errors_for(object, method)}
@@ -366,7 +343,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
   def mb_checkbox_set_with_none(
     method,
     collection,
-    label_text:,
+    label_text: nil,
     value_is_array: false,
     options: {}
   )
@@ -374,39 +351,45 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     if value_is_array
       options[:multiple] = true
     end
-    legend_id = aria_label(method)
 
     checkbox_collection_html = collection.map do |item|
-      checkbox_label_id = aria_label(item[:method])
-
-      local_options = options.merge(
-        'aria-labelledby': [legend_id, checkbox_label_id].join(" "),
-      )
-
       checkbox_html = if value_is_array
-                        check_box(method, local_options, item[:method].to_s, "")
+                        check_box(method, options, item[:method].to_s, "")
                       else
-                        check_box(item[:method], local_options)
+                        check_box(item[:method], options)
                       end
 
       <<~HTML.html_safe
-        <label id="#{checkbox_label_id}" class="checkbox">
+        <label class="checkbox">
           #{checkbox_html} #{item[:label]}
         </label>
       HTML
     end.join.html_safe
 
+    none_html = if value_is_array
+                  <<~HTML.html_safe
+                    <label class="checkbox">
+                      <input type="checkbox" name="#{@object_name}[#{method}][]" class="" id="none__checkbox">
+                      None of the above
+                    </label>
+                  HTML
+                else
+                  <<~HTML.html_safe
+                    <label class="checkbox">
+                      <input type="checkbox" name="" class="" id="none__checkbox">
+                      None of the above
+                    </label>
+                  HTML
+                end
+
     <<~HTML.html_safe
       <fieldset class="input-group">
-        <legend class="sr-only" id="#{legend_id}">
+        <legend class="sr-only">
           #{label_text}
         </legend>
         #{checkbox_collection_html}
         <hr>
-        <label class="checkbox" id="none__label">
-          <input aria-labelledby="#{legend_id} none__label" type="checkbox" name="" class="" id="none__checkbox">
-          None of the above
-        </label>
+        #{none_html}
       </fieldset>
     HTML
   end
@@ -441,8 +424,6 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
 
     html_options = {
       class: "select__element",
-      "aria-labelledby":
-        aria_labelledby(method: method, help_text: options[:help_text]),
     }
 
     formatted_label = label(
@@ -451,16 +432,16 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
         label_text,
         options[:help_text],
         options[:optional],
-        method,
       ),
       class: options[:hide_label] ? "sr-only" : "",
     )
+    html_options_with_errors = html_options.merge(error_attributes(method: method))
 
     html_output = <<~HTML
       <div class="form-group#{error_state(object, method)}">
         #{formatted_label}
         <div class="select">
-          #{select(method, collection, options, html_options, &block)}
+          #{select(method, collection, options, html_options_with_errors, &block)}
         </div>
         #{errors_for(object, method)}
       </div>
@@ -469,13 +450,9 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     html_output.html_safe
   end
 
-  def mb_checkbox(method, label_text, legend_id: nil, options: {})
+  def mb_checkbox(method, label_text, options: {})
     checked_value = options[:checked_value] || "1"
     unchecked_value = options[:unchecked_value] || "0"
-
-    options["aria-labelledby"] = aria_labelledby(method: method,
-                                                 help_text: nil,
-                                                 prefix: legend_id)
 
     classes = ["checkbox"]
     if options[:disabled] && object.public_send(method) == checked_value
@@ -485,9 +462,10 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
       classes.push("is-disabled")
     end
 
+    options_with_errors = options.merge(error_attributes(method: method))
     <<~HTML.html_safe
-      <label class="#{classes.join(' ')}" id="#{sanitized_id(method)}__label">
-        #{check_box(method, options, checked_value, unchecked_value)} #{label_text}
+      <label class="#{classes.join(' ')}">
+        #{check_box(method, options_with_errors, checked_value, unchecked_value)} #{label_text}
       </label>
       #{errors_for(object, method)}
     HTML
@@ -521,35 +499,31 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     }
   end
 
-  def mb_radio_button(method, collection, layout, help_text)
-    radio_html = <<~HTML
-      <radiogroup class="input-group--#{layout}">
-    HTML
-    collection.map do |item|
+  def mb_radio_button(method, collection, layout)
+    options = { class: "input-group--#{layout}" }.merge(error_attributes(method: method))
+
+    radiogroup_tag = @template.tag(:radiogroup, options, true)
+
+    radio_collection = collection.map do |item|
       item = { value: item, label: item } unless item.is_a?(Hash)
 
-      snake_case_value = sanitized_value(item[:value])
+      options = item[:options].to_h
 
-      aria_labels = aria_labelledby(method: method, help_text: help_text)
-      aria_labels += " #{sanitized_id(method)}_#{snake_case_value}__label"
-
-      options = { 'aria-labelledby': aria_labels }.merge(item[:options].to_h)
-
-      radio_html << <<~HTML.html_safe
-        <label class="radio-button" id="#{sanitized_id(method)}_#{snake_case_value}__label">
+      <<~HTML.html_safe
+        <label class="radio-button">
           #{radio_button(method, item[:value], options)}
           #{item[:label]}
         </label>
       HTML
     end
-    radio_html << <<~HTML
+    <<~HTML.html_safe
+      #{radiogroup_tag}
+        #{radio_collection.join}
       </radiogroup>
     HTML
-    radio_html.html_safe
   end
 
   def fieldset_label_contents(
-    method:,
     label_text:,
     help_text:,
     legend_class: "",
@@ -557,28 +531,28 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
   )
 
     label_html = <<~HTML
-      <legend class="form-question #{legend_class}" id="#{sanitized_id(method)}__label">
+      <legend class="form-question #{legend_class}">
         #{label_text + optional_text(optional)}
       </legend>
     HTML
 
     if help_text
       label_html += <<~HTML
-        <p class="text--help" id="#{sanitized_id(method)}__help">#{help_text}</p>
+        <p class="text--help">#{help_text}</p>
       HTML
     end
 
     label_html.html_safe
   end
 
-  def label_contents(label_text, help_text, optional, method)
+  def label_contents(label_text, help_text, optional)
     label_text = <<~HTML
-      <p class="form-question" id="#{sanitized_id(method)}__label">#{label_text + optional_text(optional)}</p>
+      <p class="form-question">#{label_text + optional_text(optional)}</p>
     HTML
 
     if help_text
       label_text << <<~HTML
-        <p class="text--help" id="#{sanitized_id(method)}__help">#{help_text}</p>
+        <p class="text--help">#{help_text}</p>
       HTML
     end
 
@@ -612,7 +586,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
 
     formatted_label = label(
       method,
-      label_contents(label_text, help_text, optional, method),
+      label_contents(label_text, help_text, optional),
       (for_options || options),
     )
     if prefix
@@ -632,7 +606,7 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     errors = object.errors[method]
     if errors.any?
       <<~HTML
-        <span class="text--error" id="#{sanitized_id(method)}__errors">
+        <span class="text--error" id="#{error_label(method)}">
           <i class="icon-warning"></i>
           #{errors.join(', ')}
         </span>
@@ -663,19 +637,12 @@ class MbFormBuilder < ActionView::Helpers::FormBuilder
     "#{sanitized_id(method)}__label"
   end
 
-  def aria_labelledby(method:, help_text: nil, prefix: "")
-    aria_labels = []
+  def error_label(method)
+    "#{sanitized_id(method)}__errors"
+  end
 
-    aria_labels << prefix if prefix.present?
-
-    if object.errors.present?
-      aria_labels << "#{sanitized_id(method)}__errors"
-    end
-
-    aria_labels << aria_label(method)
-    aria_labels << "#{sanitized_id(method)}__help" if help_text
-
-    aria_labels.join(" ")
+  def error_attributes(method:)
+    object.errors.present? ? { "aria-describedby": error_label(method) } : {}
   end
 
   # copied from ActionView::FormHelpers in order to coerce strings with spaces

--- a/app/views/household_more_info_per_member/_member_checkboxes.html.erb
+++ b/app/views/household_more_info_per_member/_member_checkboxes.html.erb
@@ -1,5 +1,5 @@
 <% step.members.each do |member| %>
   <%= f.fields_for('members[]', member) do |ff| %>
-    <%= ff.mb_checkbox(method, member.display_name, legend_id: legend_id) %>
+    <%= ff.mb_checkbox(method, member.display_name) %>
   <% end %>
 <% end %>

--- a/app/views/household_more_info_per_member/edit.html.erb
+++ b/app/views/household_more_info_per_member/edit.html.erb
@@ -11,7 +11,7 @@
 
       <% if !current_application.everyone_a_citizen? %>
         <fieldset class="form-group">
-          <legend class="form-question" id="citizen__legend">
+          <legend class="form-question">
             <%= t("snap.household_more_info_per_member.edit.prompt") %>
           </legend>
           <% @step.members.each do |member| %>
@@ -19,7 +19,6 @@
               <%= ff.mb_checkbox(
                 :citizen,
                 member.display_name,
-                legend_id: "citizen__legend",
               ) %>
             <% end %>
           <% end %>
@@ -29,28 +28,28 @@
       <% if current_application.anyone_disabled? %>
         <fieldset class="form-group">
           <legend class="form-question" id="disabled__legend">Who has a disability?</legend>
-          <%= render 'member_checkboxes', f: f, step: @step, method: :disabled, legend_id: "disabled__legend" %>
+          <%= render 'member_checkboxes', f: f, step: @step, method: :disabled %>
         </fieldset>
       <% end %>
 
       <% if current_application.anyone_new_mom? %>
         <fieldset class="form-group">
           <legend class="form-question" id="pregnant__legend">Who is pregnant or has been pregnant recently?</legend>
-          <%= render 'member_checkboxes', f: f, step: @step, method: :new_mom, legend_id: "pregnant__legend"  %>
+          <%= render 'member_checkboxes', f: f, step: @step, method: :new_mom  %>
         </fieldset>
       <% end %>
 
       <% if current_application.anyone_in_college? %>
         <fieldset class="form-group">
           <legend class="form-question" id="college__legend">Who is enrolled in college?</legend>
-          <%= render 'member_checkboxes', f: f, step: @step, method: :in_college, legend_id: "college__legend"  %>
+          <%= render 'member_checkboxes', f: f, step: @step, method: :in_college %>
         </fieldset>
       <% end %>
 
       <% if current_application.anyone_living_elsewhere? %>
         <fieldset class="form-group">
           <legend class="form-question" id="elsewhere__legend">Who is temporarily living outside the home?</legend>
-          <%= render 'member_checkboxes', f: f, step: @step, method: :living_elsewhere, legend_id: "elsewhere__legend"  %>
+          <%= render 'member_checkboxes', f: f, step: @step, method: :living_elsewhere %>
         </fieldset>
       <% end %>
 

--- a/app/views/integrated/buy_and_prepare_food_separately/edit.html.erb
+++ b/app/views/integrated/buy_and_prepare_food_separately/edit.html.erb
@@ -5,14 +5,13 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
     <fieldset class="input-group">
-      <legend class="sr-only" id="buy_and_prepare_food_together__legend">
+      <legend class="sr-only">
         Who buys and makes food separately?
       </legend>
       <% @form.members.each do |member| %>
         <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox :buy_and_prepare_food_together,
                              member.display_name,
-                             legend_id: "buy_and_prepare_food_together__legend",
                              options: { checked_value: "no", unchecked_value: "yes" } %>
         <% end %>
       <% end %>

--- a/app/views/integrated/food_assistance/edit.html.erb
+++ b/app/views/integrated/food_assistance/edit.html.erb
@@ -13,14 +13,13 @@
 <% content_for :form_card_body do %>
   <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
     <fieldset class="input-group">
-      <legend class="sr-only" id="requesting_food__legend">
+      <legend class="sr-only">
         Choose who needs Food Assistance.
       </legend>
       <% @form.members.each do |member| %>
         <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox :requesting_food,
                              member.display_name,
-                             legend_id: "requesting_food__legend",
                              options: { checked_value: "yes", unchecked_value: "no" } %>
         <% end %>
       <% end %>

--- a/app/views/integrated/healthcare/edit.html.erb
+++ b/app/views/integrated/healthcare/edit.html.erb
@@ -13,14 +13,13 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
         <fieldset class="input-group">
-          <legend class="sr-only" id="requesting_healthcare__legend">
+          <legend class="sr-only">
             Choose who needs Healthcare Coverage.
           </legend>
           <% @form.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
                   <%= ff.mb_checkbox :requesting_healthcare,
                     member.display_name,
-                    legend_id: "requesting_healthcare__legend",
                     options: { checked_value: "yes", unchecked_value: "no" } %>
               <% end %>
           <% end %>

--- a/app/views/integrated/ongoing_medical_expenses/edit.html.erb
+++ b/app/views/integrated/ongoing_medical_expenses/edit.html.erb
@@ -5,16 +5,16 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
         <fieldset class="input-group">
-          <legend class="sr-only" id="medical-expenses__legend">
+          <legend class="sr-only">
             <%= t(".title", count: current_application.members.count) %>
           </legend>
 
           <% Expense::MEDICAL_EXPENSES.each do |name, label| %>
-              <%= f.mb_checkbox(name, label, legend_id: "medical-expenses__legend") %>
+              <%= f.mb_checkbox(name, label) %>
           <% end %>
           <hr>
-          <label class="checkbox" id="none__label">
-            <input aria-labelledby="medical-expenses__legend none__label" type="checkbox" name="" class="" id="none__checkbox">
+          <label class="checkbox">
+            <input type="checkbox" name="" class="" id="none__checkbox">
             None of the above
           </label>
 

--- a/app/views/integrated/who_has_medical_bills/edit.html.erb
+++ b/app/views/integrated/who_has_medical_bills/edit.html.erb
@@ -4,14 +4,13 @@
 <% content_for :form_card_body do %>
   <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
     <fieldset class="input-group">
-      <legend class="sr-only" id="medical_bills__legend">
+      <legend class="sr-only">
         Choose who has medical bills from the past 3 months.
       </legend>
       <% @form.members.each do |member| %>
         <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox :medical_bills,
                              member.display_name,
-                             legend_id: "medical_bills__legend",
                              options: {
                                checked_value: "yes",
                                unchecked_value: "no",

--- a/app/views/integrated/who_has_pregnancy_expenses/edit.html.erb
+++ b/app/views/integrated/who_has_pregnancy_expenses/edit.html.erb
@@ -5,14 +5,13 @@
 <% content_for :form_card_body do %>
   <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
     <fieldset class="input-group">
-      <legend class="sr-only" id="pregnancy_expenses__legend">
+      <legend class="sr-only">
         Choose who has pregnancy expenses from the last three months.
       </legend>
       <% @form.members.each do |member| %>
         <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox :pregnancy_expenses,
                              member.display_name,
-                             legend_id: "pregnancy_expenses__legend",
                              options: {
                                checked_value: "yes",
                                unchecked_value: "no",

--- a/app/views/integrated/who_is_caretaker/edit.html.erb
+++ b/app/views/integrated/who_is_caretaker/edit.html.erb
@@ -5,14 +5,13 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
         <fieldset class="input-group">
-          <legend class="sr-only" id="caretaker__legend">
+          <legend class="sr-only">
             Choose who is a caretaker.
           </legend>
           <% @form.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
                   <%= ff.mb_checkbox :caretaker,
                     member.display_name,
-                    legend_id: "caretaker__legend",
                     options: {
                       checked_value: "yes",
                       unchecked_value: "no",

--- a/app/views/integrated/who_is_disabled/edit.html.erb
+++ b/app/views/integrated/who_is_disabled/edit.html.erb
@@ -5,14 +5,13 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
         <fieldset class="input-group">
-          <legend class="sr-only" id="disabled__legend">
+          <legend class="sr-only">
             Choose who has a disability.
           </legend>
           <% @form.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
                   <%= ff.mb_checkbox :disabled,
                     member.display_name,
-                    legend_id: "disabled__legend",
                     options: {
                       checked_value: "yes",
                       unchecked_value: "no",

--- a/app/views/integrated/who_is_flint_water/edit.html.erb
+++ b/app/views/integrated/who_is_flint_water/edit.html.erb
@@ -4,14 +4,13 @@
 <% content_for :form_card_body do %>
   <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
     <fieldset class="input-group">
-      <legend class="sr-only" id="flint_water__legend">
-        Choose who is flint_water.
+      <legend class="sr-only">
+        Choose who has been affected by the Flint Water Crisis.
       </legend>
       <% @form.members.each do |member| %>
         <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox :flint_water,
                              member.display_name,
-                             legend_id: "flint_water__legend",
                              options: {
                                checked_value: "yes",
                                unchecked_value: "no",

--- a/app/views/integrated/who_is_healthcare_enrolled/edit.html.erb
+++ b/app/views/integrated/who_is_healthcare_enrolled/edit.html.erb
@@ -4,14 +4,13 @@
 <% content_for :form_card_body do %>
   <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
     <fieldset class="input-group">
-      <legend class="sr-only" id="healthcare_enrolled__legend">
+      <legend class="sr-only">
         Choose who is currently enrolled in a health insurance plan.
       </legend>
       <% @form.members.each do |member| %>
         <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox :healthcare_enrolled,
                              member.display_name,
-                             legend_id: "healthcare_enrolled__legend",
                              options: {
                                checked_value: "yes",
                                unchecked_value: "no",

--- a/app/views/integrated/who_is_married/edit.html.erb
+++ b/app/views/integrated/who_is_married/edit.html.erb
@@ -5,14 +5,13 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
       <fieldset class="input-group">
-        <legend class="sr-only" id="married__legend">
+        <legend class="sr-only">
           Choose who is married.
         </legend>
         <% @form.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
               <%= ff.mb_checkbox :married,
                 member.display_name,
-                legend_id: "married__legend",
                 options: {
                   checked_value: "yes",
                   unchecked_value: "no",

--- a/app/views/integrated/who_is_not_citizen/edit.html.erb
+++ b/app/views/integrated/who_is_not_citizen/edit.html.erb
@@ -5,14 +5,13 @@
 <% content_for :form_card_body do %>
   <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
     <fieldset class="input-group">
-      <legend class="sr-only" id="not_citizen__legend">
+      <legend class="sr-only">
         Choose who is not a citizen.
       </legend>
       <% @form.members.each do |member| %>
         <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox :citizen,
                              member.display_name,
-                             legend_id: "not_citizen__legend",
                              options: {
                                  checked_value: "no",
                                  unchecked_value: "yes",

--- a/app/views/integrated/who_is_pregnant/edit.html.erb
+++ b/app/views/integrated/who_is_pregnant/edit.html.erb
@@ -4,14 +4,13 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
       <fieldset class="input-group">
-        <legend class="sr-only" id="pregnant__legend">
+        <legend class="sr-only">
           Choose who is pregnant.
         </legend>
         <% @form.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
             <%= ff.mb_checkbox :pregnant,
                                member.display_name,
-                               legend_id: "pregnant__legend",
                                options: {
                                    checked_value: "yes",
                                    unchecked_value: "no",

--- a/app/views/integrated/who_is_self_employed/edit.html.erb
+++ b/app/views/integrated/who_is_self_employed/edit.html.erb
@@ -4,14 +4,13 @@
 <% content_for :form_card_body do %>
   <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
     <fieldset class="input-group">
-      <legend class="sr-only" id="self_employed__legend">
-        Choose who is self_employed.
+      <legend class="sr-only">
+        Choose who is self-employed.
       </legend>
       <% @form.members.each do |member| %>
         <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox :self_employed,
                              member.display_name,
-                             legend_id: "self_employed__legend",
                              options: {
                                checked_value: "yes",
                                unchecked_value: "no",

--- a/app/views/integrated/who_is_student/edit.html.erb
+++ b/app/views/integrated/who_is_student/edit.html.erb
@@ -5,14 +5,13 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
         <fieldset class="input-group">
-          <legend class="sr-only" id="student__legend">
+          <legend class="sr-only">
             Choose who is a student.
           </legend>
           <% @form.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
                   <%= ff.mb_checkbox :student,
                     member.display_name,
-                    legend_id: "student__legend",
                     options: {
                       checked_value: "yes",
                       unchecked_value: "no",

--- a/app/views/integrated/who_is_veteran/edit.html.erb
+++ b/app/views/integrated/who_is_veteran/edit.html.erb
@@ -5,14 +5,13 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
         <fieldset class="input-group">
-          <legend class="sr-only" id="veteran__legend">
+          <legend class="sr-only">
             Choose who is a veteran.
           </legend>
           <% @form.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
                   <%= ff.mb_checkbox :veteran,
                     member.display_name,
-                    legend_id: "veteran__legend",
                     options: {
                       checked_value: "yes",
                       unchecked_value: "no",

--- a/app/views/integrated/who_was_foster_care/edit.html.erb
+++ b/app/views/integrated/who_was_foster_care/edit.html.erb
@@ -4,14 +4,13 @@
 <% content_for :form_card_body do %>
     <%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
         <fieldset class="input-group">
-          <legend class="sr-only" id="foster_care_at_18__legend">
+          <legend class="sr-only">
             Choose who was in foster care when they turned 18.
           </legend>
           <% @form.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
                   <%= ff.mb_checkbox :foster_care_at_18,
                     member.display_name,
-                    legend_id: "foster_care_at_18__legend",
                     options: {
                       checked_value: "yes",
                       unchecked_value: "no",

--- a/app/views/medicaid/expenses_alimony_member/edit.html.erb
+++ b/app/views/medicaid/expenses_alimony_member/edit.html.erb
@@ -16,14 +16,13 @@
 
 
       <fieldset class="form-group">
-        <legend class="sr-only" id="support__legend">
+        <legend class="sr-only">
           <%= t('medicaid.expenses_alimony_member.edit.title') %>
         </legend>
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%= ff.mb_checkbox(:pay_child_support_alimony_arrears,
-                             member.display_name,
-                             legend_id: "support__legend") %>
+                             member.display_name) %>
           <% end %>
         <% end %>
         <%= f.mb_form_errors :child_support_alimony_arrears %>

--- a/app/views/medicaid/expenses_student_loan_member/edit.html.erb
+++ b/app/views/medicaid/expenses_student_loan_member/edit.html.erb
@@ -15,12 +15,12 @@
       method: :put do |f| %>
 
       <fieldset class="form-group">
-        <legend class="sr-only" id="loan__legend">
+        <legend class="sr-only">
           <%= t('medicaid.expenses_student_loan_member.edit.title') %>
         </legend>
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox(:pay_student_loan_interest, member.display_name, legend_id: "loan__legend") %>
+            <%= ff.mb_checkbox(:pay_student_loan_interest, member.display_name) %>
           <% end %>
         <% end %>
         <%= f.mb_form_errors :student_loan_interest %>

--- a/app/views/medicaid/health_disability_member/edit.html.erb
+++ b/app/views/medicaid/health_disability_member/edit.html.erb
@@ -16,12 +16,12 @@
 
 
       <fieldset class="form-group">
-        <legend class="sr-only" id="disability__legend">
+        <legend class="sr-only">
           <%= t('medicaid.health_disability_member.edit.title') %>
         </legend>
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox :disabled, member.display_name, legend_id: "disability__legend" %>
+            <%= ff.mb_checkbox :disabled, member.display_name %>
           <% end %>
         <% end %>
         <%= f.mb_form_errors :disabled %>

--- a/app/views/medicaid/health_pregnancy_member/edit.html.erb
+++ b/app/views/medicaid/health_pregnancy_member/edit.html.erb
@@ -18,7 +18,7 @@
       method: :put do |f| %>
 
       <fieldset class="form-group">
-        <legend class="sr-only" id="pregnant__legend">
+        <legend class="sr-only">
           <%= t("medicaid.health_pregnancy_member.edit.title") %>
         </legend>
         <% @step.members.each do |member| %>
@@ -26,7 +26,6 @@
             <%= ff.mb_checkbox(
               :new_mom,
               member.display_name,
-              legend_id: "pregnant__legend",
               options: { checked_value: "1", unchecked_value: "0" }
             ) %>
           <% end %>

--- a/app/views/medicaid/income_other_income_member/edit.html.erb
+++ b/app/views/medicaid/income_other_income_member/edit.html.erb
@@ -14,7 +14,7 @@
       url: current_path,
       method: :put do |f| %>
       <fieldset class="form-group">
-        <legend class="sr-only" id="income__legend">
+        <legend class="sr-only">
           <%= t("medicaid.income_other_income_member.edit.title") %>
         </legend>
         <% @step.members.each do |member| %>
@@ -22,7 +22,6 @@
             <%= ff.mb_checkbox(
               :other_income,
               member.display_name,
-              legend_id: "income__legend",
               options: { checked_value: "1", unchecked_value: "0" },
             ) %>
           <% end %>

--- a/app/views/medicaid/income_self_employment_member/edit.html.erb
+++ b/app/views/medicaid/income_self_employment_member/edit.html.erb
@@ -10,7 +10,7 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
         <fieldset class="form-group">
-          <legend class="sr-only" id="self_employed__legend">
+          <legend class="sr-only">
             <%= t("medicaid.income_self_employment_member.edit.title") %>
           </legend>
           <% @step.members.each do |member| %>
@@ -18,7 +18,6 @@
                   <%= ff.mb_checkbox(
                           :self_employed,
                           member.display_name,
-                          legend_id: "self_employed__legend",
                           options: { checked_value: "1", unchecked_value: "0" }
                       ) %>
               <% end %>

--- a/app/views/medicaid/insurance_current_member/edit.html.erb
+++ b/app/views/medicaid/insurance_current_member/edit.html.erb
@@ -17,7 +17,7 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
         <fieldset class="form-group">
-          <legend class="sr-only" id="enrolled__legend">
+          <legend class="sr-only">
             <%= t("medicaid.insurance_current_member.edit.title") %>
           </legend>
           <% @step.members.each do |member| %>
@@ -25,7 +25,6 @@
                 <%= ff.mb_checkbox(
                     :insured,
                     member.display_name,
-                    legend_id: "enrolled__legend",
                     options: { checked_value: "1", unchecked_value: "0" },
                 ) %>
               <% end %>

--- a/app/views/medicaid/insurance_needed/edit.html.erb
+++ b/app/views/medicaid/insurance_needed/edit.html.erb
@@ -14,7 +14,7 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
       <fieldset class="form-group">
-        <legend class="sr-only" id="household__legend">
+        <legend class="sr-only">
           <%= t("medicaid.insurance_needed.edit.title") %>
         </legend>
         <% @step.members.each do |member| %>
@@ -22,7 +22,6 @@
             <%= ff.mb_checkbox(
               :requesting_health_insurance,
               member.display_name,
-              legend_id: "household__legend",
               options: { checked_value: "1", unchecked_value: "0" },
             ) %>
           <% end %>

--- a/app/views/medicaid/intro_caretaker_member/edit.html.erb
+++ b/app/views/medicaid/intro_caretaker_member/edit.html.erb
@@ -15,15 +15,12 @@
                  method: :put do |f| %>
 
         <fieldset class="form-group">
-          <legend class="sr-only" id="caretaker__legend">
+          <legend class="sr-only">
             <%= t("medicaid.intro_caretaker_member.edit.title") %>
           </legend>
           <% @step.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-                  <%= ff.mb_checkbox :caretaker_or_parent,
-                                     member.display_name,
-                                     legend_id: "caretaker__legend"
-                  %>
+                  <%= ff.mb_checkbox(:caretaker_or_parent, member.display_name) %>
               <% end %>
           <% end %>
           <%= f.mb_form_errors :caretaker_or_parent %>

--- a/app/views/medicaid/intro_citizen_member/edit.html.erb
+++ b/app/views/medicaid/intro_citizen_member/edit.html.erb
@@ -15,12 +15,12 @@
       method: :put do |f| %>
 
       <fieldset class="form-group">
-        <legend class="sr-only" id="citizen__legend">
+        <legend class="sr-only">
           <%= t("medicaid.intro_citizen_member.edit.title") %>
         </legend>
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox :citizen, member.display_name, legend_id: "citizen__legend" %>
+            <%= ff.mb_checkbox :citizen, member.display_name %>
           <% end %>
         <% end %>
         <%= f.mb_form_errors :citizen %>

--- a/app/views/medicaid/intro_college_member/edit.html.erb
+++ b/app/views/medicaid/intro_college_member/edit.html.erb
@@ -10,7 +10,7 @@
   <div class="form-card__content">
     <%= form_for @step, as: :step, builder: MbFormBuilder, url: current_path, method: :put do |f| %>
         <fieldset class="form-group">
-          <legend class="sr-only" id="college__legend">
+          <legend class="sr-only">
             <%= t("medicaid.intro_college_member.edit.title") %>
           </legend>
           <% @step.members.each do |member| %>
@@ -18,7 +18,6 @@
                   <%= ff.mb_checkbox(
                     :in_college,
                     member.display_name,
-                    legend_id: "college__legend",
                     options: { checked_value: "1", unchecked_value: "0" },
                   ) %>
               <% end %>

--- a/app/views/medicaid/intro_marital_status_member/edit.html.erb
+++ b/app/views/medicaid/intro_marital_status_member/edit.html.erb
@@ -16,12 +16,12 @@
 
       <%= f.mb_form_errors :married %>
       <fieldset class="form-group">
-        <legend class="sr-only" id="household__legend">
+        <legend class="sr-only">
           <%= t("medicaid.intro_marital_status_member.edit.title") %>
         </legend>
         <% @step.members.each do |member| %>
           <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-            <%= ff.mb_checkbox :married, member.display_name, legend_id: "household__legend" %>
+            <%= ff.mb_checkbox :married, member.display_name %>
           <% end %>
         <% end %>
       </fieldset>

--- a/app/views/medicaid/tax_filing_with_household_members_member/edit.html.erb
+++ b/app/views/medicaid/tax_filing_with_household_members_member/edit.html.erb
@@ -15,15 +15,12 @@
                  method: :put do |f| %>
 
         <fieldset class="form-group">
-          <legend class="sr-only" id="taxes__legend">
+          <legend class="sr-only">
             <%= t("medicaid.tax_filing_with_household_members_member.edit.title") %>
           </legend>
           <% @step.members.each do |member| %>
               <%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
-                  <%= ff.mb_checkbox :filing_taxes_with_primary_member,
-                                     member.display_name,
-                                     legend_id: "taxes__legend"
-                  %>
+                <%= ff.mb_checkbox(:filing_taxes_with_primary_member, member.display_name) %>
               <% end %>
           <% end %>
           <%= f.mb_form_errors :filing_taxes_with_primary_member %>

--- a/lib/generators/section/who_is/templates/who_is/form_view.template
+++ b/lib/generators/section/who_is/templates/who_is/form_view.template
@@ -5,14 +5,13 @@
 <%% content_for :form_card_body do %>
   <%%= fields_for(:form, @form, builder: MbFormBuilder) do |f| %>
     <fieldset class="input-group">
-      <legend class="sr-only" id="<%= model_method %>__legend">
+      <legend class="sr-only">
         Choose who is <%= model_method %>.
       </legend>
       <%% @form.members.each do |member| %>
         <%%= f.fields_for('members[]', member, hidden_field_id: true) do |ff| %>
           <%%= ff.mb_checkbox :<%= model_method %>,
                              member.display_name,
-                             legend_id: "<%= model_method %>__legend",
                              options: {
                                checked_value: "yes",
                                unchecked_value: "no",

--- a/spec/helpers/mb_form_builder_spec.rb
+++ b/spec/helpers/mb_form_builder_spec.rb
@@ -21,9 +21,9 @@ RSpec.describe MbFormBuilder do
       expect(output).to match_html <<-HTML
         <div class="form-group">
           <label for="sample_name">
-            <p class="form-question" id="sample_name__label">How is name?</p>
+            <p class="form-question">How is name?</p>
           </label>
-          <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" class="text-input" id="sample_name" aria-labelledby="sample_name__label" name="sample[name]" />
+          <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" class="text-input" id="sample_name" name="sample[name]" />
         </div>
       HTML
     end
@@ -47,12 +47,12 @@ RSpec.describe MbFormBuilder do
         <div class="form-group form-group--error">
           <div class="field_with_errors">
             <label for="sample_name">
-              <p class="form-question" id="sample_name__label">How is name?</p>
-              <p class="text--help" id="sample_name__help">Name is name</p>
+              <p class="form-question">How is name?</p>
+              <p class="text--help"">Name is name</p>
             </label>
           </div>
           <div class="field_with_errors">
-            <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" class="text-input" id="sample_name" aria-labelledby="sample_name__errors sample_name__label sample_name__help" name="sample[name]" />
+            <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="text" class="text-input" aria-describedby="sample_name__errors" id="sample_name" name="sample[name]" />
           </div>
           <span class="text--error" id="sample_name__errors"><i class="icon-warning"></i> can't be blank </div>
         </div>
@@ -109,7 +109,7 @@ RSpec.describe MbFormBuilder do
           </div>
           <div class="incrementer">
             <div class="field_with_errors">
-              <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="number" class="dog-styles text-input form-width--short" id="sample_dog" name="sample[dog]" />
+              <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="number" class="dog-styles text-input form-width--short" id="sample_dog" aria-describedby="sample_dog__errors" name="sample[dog]" />
             </div>
             <span class="incrementer__subtract">-</span>
             <span class="incrementer__add">+</span>
@@ -170,12 +170,12 @@ RSpec.describe MbFormBuilder do
         <div class="form-group form-group--error">
          <div class="field_with_errors">
            <label class="sr-only" for="sample_description">
-             <p class="form-question" id="sample_description__label">Write a lot?</p>
-             <p class="text--help" id="sample_description__help">Name for texting</p>
+             <p class="form-question">Write a lot?</p>
+             <p class="text--help">Name for texting</p>
            </label>
          </div>
          <div class="field_with_errors">
-           <textarea autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" class="textarea" aria-labelledby="sample_description__errors sample_description__label sample_description__help" name="sample[description]" id="sample_description"></textarea>
+           <textarea autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" class="textarea" aria-describedby="sample_description__errors" name="sample[description]" id="sample_description"></textarea>
          </div>
          <span class="text--error" id="sample_description__errors"><i class="icon-warning"></i> can't be blank </span>
        </div>
@@ -196,11 +196,11 @@ RSpec.describe MbFormBuilder do
       expect(output).to match_html <<-HTML
         <div class="form-group">
           <label for="sample_phone_number">
-            <p class="form-question" id="sample_phone_number__label">What is phone?</p>
+            <p class="form-question">What is phone?</p>
           </label>
           <div class="text-input-group">
             <div class="text-input-group__prefix">+1</div>
-            <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="tel" class="text-input" maxlength="10" id="sample_phone_number" aria-labelledby="sample_phone_number__label" size="10" name="sample[phone_number]" />
+            <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" type="tel" class="text-input" maxlength="10" id="sample_phone_number" size="10" name="sample[phone_number]" />
           </div>
         </div>
       HTML
@@ -230,13 +230,13 @@ RSpec.describe MbFormBuilder do
         <div class="form-group form-group--error">
           <div class="field_with_errors">
             <label class="sr-only" for="sample_how_many">
-              <p class="form-question" id="sample_how_many__label">This is for screen readers!</p>
-              <p class="text--help" id="sample_how_many__help">Choose how many</p>
+              <p class="form-question">This is for screen readers!</p>
+              <p class="text--help">Choose how many</p>
             </label>
           </div>
           <div class="select">
             <div class="field_with_errors">
-              <select class="select__element" aria-labelledby="sample_how_many__errors sample_how_many__label sample_how_many__help" name="sample[how_many]" id="sample_how_many">
+              <select class="select__element" aria-describedby="sample_how_many__errors" name="sample[how_many]" id="sample_how_many">
                 <option value="0">0 things</option>
                 <option value="1">1 thing</option>
                 <option value="2">2 things</option>
@@ -280,12 +280,12 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
         <fieldset class="form-group">
-          <legend class="form-question " id="sample_birthday__label"> What is your birthday? </legend>
-          <p class="text--help" id="sample_birthday__help">(For surprises)</p>
+          <legend class="form-question "> What is your birthday? </legend>
+          <p class="text--help">(For surprises)</p>
           <div class="input-group--inline">
             <div class="select">
-              <label for="sample_birthday_2i" class="sr-only" id="sample_birthday_2i__label">Month</label>
-              <select id="sample_birthday_2i" name="sample[birthday(2i)]" class="select__element" aria-labelledby="sample_birthday__label sample_birthday__help sample_birthday_2i__label">
+              <label for="sample_birthday_2i" class="sr-only">Month</label>
+              <select id="sample_birthday_2i" name="sample[birthday(2i)]" class="select__element">
                 <option value="">Month</option>
                 <option value="1">January</option>
                 <option value="2">February</option>
@@ -302,8 +302,8 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
-              <label for="sample_birthday_3i" class="sr-only" id="sample_birthday_3i__label">Day</label>
-              <select id="sample_birthday_3i" name="sample[birthday(3i)]" class="select__element" aria-labelledby="sample_birthday__label sample_birthday__help sample_birthday_3i__label">
+              <label for="sample_birthday_3i" class="sr-only">Day</label>
+              <select id="sample_birthday_3i" name="sample[birthday(3i)]" class="select__element">
                 <option value="">Day</option>
                 <option value="1">1</option>
                 <option value="2">2</option>
@@ -339,8 +339,8 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
-              <label for="sample_birthday_1i" class="sr-only" id="sample_birthday_1i__label">Year</label>
-              <select id="sample_birthday_1i" name="sample[birthday(1i)]" class="select__element" aria-labelledby="sample_birthday__label sample_birthday__help sample_birthday_1i__label">
+              <label for="sample_birthday_1i" class="sr-only">Year</label>
+              <select id="sample_birthday_1i" name="sample[birthday(1i)]" class="select__element">
                 <option value="">Year</option>
                 <option value="1990" selected="selected">1990</option>
                 <option value="1991">1991</option>
@@ -388,12 +388,12 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
         <fieldset class="form-group">
-          <legend class="form-question " id="sample_members_72_birthday__label"> What is your birthday? </legend>
-          <p class="text--help" id="sample_members_72_birthday__help">(For surprises)</p>
+          <legend class="form-question "> What is your birthday? </legend>
+          <p class="text--help">(For surprises)</p>
           <div class="input-group--inline">
             <div class="select">
-              <label for="sample_members_72_birthday_2i" class="sr-only" id="sample_members_72_birthday_2i__label">Month</label>
-              <select id="sample_members_72_birthday_2i" name="sample[members][72][birthday(2i)]" class="select__element" aria-labelledby="sample_members_72_birthday__label sample_members_72_birthday__help sample_members_72_birthday_2i__label">
+              <label for="sample_members_72_birthday_2i" class="sr-only">Month</label>
+              <select id="sample_members_72_birthday_2i" name="sample[members][72][birthday(2i)]" class="select__element">
                 <option value="">Month</option>
                 <option value="1">January</option>
                 <option value="2">February</option>
@@ -410,8 +410,8 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
-              <label for="sample_members_72_birthday_3i" class="sr-only" id="sample_members_72_birthday_3i__label">Day</label>
-              <select id="sample_members_72_birthday_3i" name="sample[members][72][birthday(3i)]" class="select__element" aria-labelledby="sample_members_72_birthday__label sample_members_72_birthday__help sample_members_72_birthday_3i__label">
+              <label for="sample_members_72_birthday_3i" class="sr-only">Day</label>
+              <select id="sample_members_72_birthday_3i" name="sample[members][72][birthday(3i)]" class="select__element">
                 <option value="">Day</option>
                 <option value="1">1</option>
                 <option value="2">2</option>
@@ -447,8 +447,8 @@ RSpec.describe MbFormBuilder do
               </select>
             </div>
             <div class="select">
-              <label for="sample_members_72_birthday_1i" class="sr-only" id="sample_members_72_birthday_1i__label">Year</label>
-              <select id="sample_members_72_birthday_1i" name="sample[members][72][birthday(1i)]" class="select__element" aria-labelledby="sample_members_72_birthday__label sample_members_72_birthday__help sample_members_72_birthday_1i__label">
+              <label for="sample_members_72_birthday_1i" class="sr-only">Year</label>
+              <select id="sample_members_72_birthday_1i" name="sample[members][72][birthday(1i)]" class="select__element">
                 <option value="">Year</option>
                 <option value="1990" selected="selected">1990</option>
                 <option value="1991">1991</option>
@@ -480,19 +480,19 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
       <fieldset class="form-group">
-        <legend class="form-question " id="sample_birthday__label"> What is your birthday? </legend>
-        <p class="text--help" id="sample_birthday__help">(For surprises)</p>
+        <legend class="form-question "> What is your birthday? </legend>
+        <p class="text--help">(For surprises)</p>
         <div class="input-group--inline">
           <div class="form-group">
-            <label class="text--help form-subquestion" for="sample_birthday_month" id="sample_birthday_month__label">Month</label>
+            <label class="text--help form-subquestion" for="sample_birthday_month">Month</label>
             <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" size="2" minlength="1" maxlength="2" class="form-width--month text-input" id="sample_birthday_month" name="sample[birthday_month]" type="tel" />
           </div>
           <div class="form-group">
-            <label class="text--help form-subquestion" for="sample_birthday_day" id="sample_birthday_day__label">Day</label>
+            <label class="text--help form-subquestion" for="sample_birthday_day">Day</label>
             <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" size="2" minlength="1" maxlength="2" class="form-width--day text-input" id="sample_birthday_day" name="sample[birthday_day]" type="tel" />
           </div>
           <div class="form-group">
-            <label class="text--help form-subquestion" for="sample_birthday_year" id="sample_birthday_year__label">Year</label>
+            <label class="text--help form-subquestion" for="sample_birthday_year">Year</label>
             <input autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" class="form-width--year text-input" id="sample_birthday_year" name="sample[birthday_year]" size="4" minlength="4" maxlength="4" type="tel" />
           </div>
         </div>
@@ -556,13 +556,13 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
         <fieldset class="form-group form-group--error">
-          <legend class="form-question " id="sample_dependent_care__label">
+          <legend class="form-question ">
             Does your household have dependent care expenses?
           </legend>
-          <p class="text--help" id="sample_dependent_care__help">This includes child care.</p>
-          <radiogroup class="input-group--block">
-            <label class="radio-button" id="sample_dependent_care_true__label"><div class="field_with_errors"><input aria-labelledby="sample_dependent_care__errors sample_dependent_care__label sample_dependent_care__help sample_dependent_care_true__label" data-follow-up="#yep-follow-up" type="radio" value="true" name="sample[dependent_care]" id="sample_dependent_care_true"/></div> Yep </label>
-            <label class="radio-button" id="sample_dependent_care_false__label"><div class="field_with_errors"><input aria-labelledby="sample_dependent_care__errors sample_dependent_care__label sample_dependent_care__help sample_dependent_care_false__label" type="radio" value="false" name="sample[dependent_care]" id="sample_dependent_care_false"/></div> Nope </label>
+          <p class="text--help">This includes child care.</p>
+          <radiogroup class="input-group--block" aria-describedby="sample_dependent_care__errors">
+            <label class="radio-button"><div class="field_with_errors"><input data-follow-up="#yep-follow-up" type="radio" value="true" name="sample[dependent_care]" id="sample_dependent_care_true"/></div> Yep </label>
+            <label class="radio-button"><div class="field_with_errors"><input type="radio" value="false" name="sample[dependent_care]" id="sample_dependent_care_false"/></div> Nope </label>
           </radiogroup>
           <span class="text--error" id="sample_dependent_care__errors"><i class="icon-warning"></i> can't be blank </span>
         </fieldset>
@@ -599,12 +599,12 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
         <fieldset class="input-group form-group">
-          <legend class="form-question " id="sample_captains__label"> Which captains do you think are cool? </legend>
-          <p class="text--help" id="sample_captains__help">like, really cool</p>
-          <label id="sample_captains_tng__label" class="checkbox"><input name="sample[tng]" type="hidden" value="0" /><input aria-labelledby="sample_captains__label sample_captains__help sample_captains_tng__label" type="checkbox" value="1" name="sample[tng]" id="sample_tng"/> Picard </label>
-          <label id="sample_captains_ds9__label" class="checkbox"><input name="sample[ds9]" type="hidden" value="0" /><input aria-labelledby="sample_captains__label sample_captains__help sample_captains_ds9__label" type="checkbox" value="1" name="sample[ds9]" id="sample_ds9"/> Sisko </label>
-          <label id="sample_captains_voyager__label" class="checkbox"><input name="sample[voyager]" type="hidden" value="0" /><input aria-labelledby="sample_captains__label sample_captains__help sample_captains_voyager__label" type="checkbox" value="1" name="sample[voyager]" id="sample_voyager"/> Janeway </label>
-          <label id="sample_captains_tos__label" class="checkbox"><input name="sample[tos]" type="hidden" value="0" /><input aria-labelledby="sample_captains__label sample_captains__help sample_captains_tos__label" type="checkbox" value="1" name="sample[tos]" id="sample_tos"/> Kirk </label>
+          <legend class="form-question "> Which captains do you think are cool? </legend>
+          <p class="text--help">like, really cool</p>
+          <label class="checkbox"><input name="sample[tng]" type="hidden" value="0" /><input type="checkbox" value="1" name="sample[tng]" id="sample_tng"/> Picard </label>
+          <label class="checkbox"><input name="sample[ds9]" type="hidden" value="0" /><input type="checkbox" value="1" name="sample[ds9]" id="sample_ds9"/> Sisko </label>
+          <label class="checkbox"><input name="sample[voyager]" type="hidden" value="0" /><input type="checkbox" value="1" name="sample[voyager]" id="sample_voyager"/> Janeway </label>
+          <label class="checkbox"><input name="sample[tos]" type="hidden" value="0" /><input type="checkbox" value="1" name="sample[tos]" id="sample_tos"/> Kirk </label>
         </fieldset>
       HTML
     end
@@ -634,11 +634,11 @@ RSpec.describe MbFormBuilder do
 
       expect(output).to match_html <<-HTML
         <fieldset class="input-group">
-          <legend class="sr-only" id="sample_captains__label"> Which captains do you think are cool? </legend>
-          <label id="sample_tng__label" class="checkbox"><input name="sample[tng]" type="hidden" value="0" /><input aria-labelledby="sample_captains__label sample_tng__label" type="checkbox" value="1" checked="checked" name="sample[tng]" id="sample_tng" /> Picard </label>
-          <label id="sample_voyager__label" class="checkbox"><input name="sample[voyager]" type="hidden" value="0" /><input aria-labelledby="sample_captains__label sample_voyager__label" type="checkbox" value="1" name="sample[voyager]" id="sample_voyager" /> Janeway </label>
+          <legend class="sr-only"> Which captains do you think are cool? </legend>
+          <label class="checkbox"><input name="sample[tng]" type="hidden" value="0" /><input type="checkbox" value="1" checked="checked" name="sample[tng]" id="sample_tng" /> Picard </label>
+          <label class="checkbox"><input name="sample[voyager]" type="hidden" value="0" /><input type="checkbox" value="1" name="sample[voyager]" id="sample_voyager" /> Janeway </label>
           <hr />
-          <label class="checkbox" id="none__label"><input aria-labelledby="sample_captains__label none__label" type="checkbox" name="" class="" id="none__checkbox" /> None of the above </label>
+          <label class="checkbox"><input type="checkbox" name="" class="" id="none__checkbox" /> None of the above </label>
         </fieldset>
       HTML
     end
@@ -667,11 +667,11 @@ RSpec.describe MbFormBuilder do
 
         expect(output).to match_html <<-HTML
           <fieldset class="input-group">
-            <legend class="sr-only" id="sample_captains__label"> Which captains do you think are cool? </legend>
-            <label id="sample_tng__label" class="checkbox"><input name="sample[captains][]" type="hidden" value="" /><input aria-labelledby="sample_captains__label sample_tng__label" type="checkbox" value="tng" checked="checked" name="sample[captains][]" id="sample_captains_tng" /> Picard </label>
-            <label id="sample_ds9__label" class="checkbox"><input name="sample[captains][]" type="hidden" value="" /><input aria-labelledby="sample_captains__label sample_ds9__label" type="checkbox" value="ds9" name="sample[captains][]" id="sample_captains_ds9" /> Sisko </label>
+            <legend class="sr-only"> Which captains do you think are cool? </legend>
+            <label class="checkbox"><input name="sample[captains][]" type="hidden" value="" /><input type="checkbox" value="tng" checked="checked" name="sample[captains][]" id="sample_captains_tng" /> Picard </label>
+            <label class="checkbox"><input name="sample[captains][]" type="hidden" value="" /><input type="checkbox" value="ds9" name="sample[captains][]" id="sample_captains_ds9" /> Sisko </label>
             <hr />
-            <label class="checkbox" id="none__label"><input aria-labelledby="sample_captains__label none__label" type="checkbox" name="" class="" id="none__checkbox" /> None of the above </label>
+            <label class="checkbox"><input type="checkbox" name="sample[captains][]" class="" id="none__checkbox" /> None of the above </label>
           </fieldset>
         HTML
       end
@@ -730,40 +730,16 @@ RSpec.describe MbFormBuilder do
       expect(output).to be_html_safe
 
       expect(output).to match_html <<-HTML
-        <label class="checkbox" id="sample_read_tos__label">
+        <label class="checkbox">
           <input name="sample[read_tos]" type="hidden" value="0" />
           <div class="field_with_errors">
-            <input aria-labelledby="sample_read_tos__errors sample_read_tos__label" type="checkbox" value="1" name="sample[read_tos]" id="sample_read_tos" />
+            <input aria-describedby="sample_read_tos__errors" type="checkbox" value="1" name="sample[read_tos]" id="sample_read_tos"/>
           </div>
           Confirm that you agree to Terms of Service
         </label>
         <span class="text--error" id="sample_read_tos__errors">
           <i class="icon-warning"></i> can't be blank
         </span>
-      HTML
-    end
-
-    it "prefixes aria-labelledby with custom legend id" do
-      class SampleStep < Step
-        step_attributes(:read_tos)
-      end
-
-      sample = SampleStep.new
-      form = MbFormBuilder.new("sample", sample, template, {})
-      output = form.mb_checkbox(
-        :read_tos,
-        "Confirm that you agree to Terms of Service",
-        legend_id: "legend__label",
-      )
-
-      expect(output).to be_html_safe
-
-      expect(output).to match_html <<-HTML
-        <label class="checkbox" id="sample_read_tos__label">
-          <input name="sample[read_tos]" type="hidden" value="0" />
-          <input aria-labelledby="legend__label sample_read_tos__label" type="checkbox" value="1" name="sample[read_tos]" id="sample_read_tos" />
-          Confirm that you agree to Terms of Service
-        </label>
       HTML
     end
 
@@ -785,9 +761,9 @@ RSpec.describe MbFormBuilder do
         expect(output).to be_html_safe
 
         expect(output).to match_html <<-HTML
-        <label class="checkbox" id="sample_read_tos__label">
+        <label class="checkbox">
           <input name="sample[read_tos]" type="hidden" value="no" />
-          <input checked_value="yes" unchecked_value="no" aria-labelledby="sample_read_tos__label" type="checkbox" value="yes" checked="checked" name="sample[read_tos]" id="sample_read_tos" />
+          <input checked_value="yes" unchecked_value="no" type="checkbox" value="yes" checked="checked" name="sample[read_tos]" id="sample_read_tos" />
           Confirm that you agree to Terms of Service
         </label>
         HTML
@@ -813,9 +789,9 @@ RSpec.describe MbFormBuilder do
         expect(output).to be_html_safe
 
         expect(output).to match_html <<-HTML
-        <label class="checkbox is-selected is-disabled" id="sample_read_tos__label">
+        <label class="checkbox is-selected is-disabled">
           <input name="sample[read_tos]" disabled="disabled" type="hidden" value="no" />
-          <input checked_value="yes" unchecked_value="no" disabled="disabled" aria-labelledby="sample_read_tos__label" type="checkbox" value="yes" checked="checked" name="sample[read_tos]" id="sample_read_tos" />
+          <input checked_value="yes" unchecked_value="no" disabled="disabled" type="checkbox" value="yes" checked="checked" name="sample[read_tos]" id="sample_read_tos" />
           Confirm that you agree to Terms of Service
         </label>
         HTML


### PR DESCRIPTION
Also refactors form builder to use less custom setup for associating labels to inputs, and inputs to errors.

[Finishes #156832482]

Co-authored-by: Christa Hartsock <christa@codeforamerica.org>