### PR TITLE
Feedback form accessible

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -35,8 +35,8 @@ var radioSelector = (function () {
         }
 
         $(this).find('input').click(function (e) {
-          $(this).parent().siblings().removeClass('is-selected')
-          $(this).parent().addClass('is-selected')
+          $(this).closest('.radio-button').siblings().removeClass('is-selected')
+          $(this).closest('.radio-button').addClass('is-selected')
         })
       })
     }

--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -237,21 +237,6 @@ var noneOfTheAbove = (function() {
   }
 })();
 
-var feedbackForm = (function() {
-  var feedback = {
-    init: function () {
-      $('body').on('ajax:success', function(event, xhr, status, error) {
-        var success = '<span class="radio-button__image emoji emoji--med emoji--blush">Thank you</span>' +
-          '<h3>Thanks for your feedback! It will help improve this application for people in the future.</h3>';
-        $('#feedback-form').html(success);
-      });
-    }
-  };
-  return {
-    init: feedback.init
-  }
-})();
-
 $(document).ready(function () {
   radioSelector.init();
   checkboxSelector.init();
@@ -262,5 +247,4 @@ $(document).ready(function () {
   followUpQuestion.init();
   incrementer.init();
   noneOfTheAbove.init();
-  feedbackForm.init();
 })

--- a/app/assets/stylesheets/molecules/_form-molecules.scss
+++ b/app/assets/stylesheets/molecules/_form-molecules.scss
@@ -43,7 +43,13 @@
   }
 
   input[type='radio'] {
-    display: none;
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px; margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
   }
 }
 

--- a/app/assets/stylesheets/molecules/_form-molecules.scss
+++ b/app/assets/stylesheets/molecules/_form-molecules.scss
@@ -219,6 +219,12 @@ fieldset.form-group {
   }
 
   .radio-button input {
-    display: none;
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px; margin: -1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
   }
 }

--- a/app/controllers/feedbacks_controller.rb
+++ b/app/controllers/feedbacks_controller.rb
@@ -2,12 +2,12 @@ class FeedbacksController < ApplicationController
   def create
     @form = FeedbackForm.new(form_params)
 
+    if @form.valid?
+      current_application&.update!(form_params)
+    end
+
     respond_to do |format|
-      if @form.valid? && current_application&.update(form_params)
-        format.json { render json: {}, status: :created }
-      else
-        format.json { render json: {}, status: :unprocessable_entity }
-      end
+      format.js { render layout: false, locals: { feedback_form: @form } }
     end
   end
 

--- a/app/forms/feedback_form.rb
+++ b/app/forms/feedback_form.rb
@@ -1,3 +1,5 @@
 class FeedbackForm < Form
   set_attributes_for :application, :feedback_rating, :feedback_comments
+
+  validates_presence_of :feedback_rating, message: "Please select a rating."
 end

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_for feedback_form, url: feedback_path, builder: MbFormBuilder, remote: true do |f| %>
+    <%= f.mb_radio_set :feedback_rating,
+      label_text: "<h3>How was your experience with this application?</h3>",
+      collection: [
+        { value: "negative", label: '<span class="radio-button__image emoji emoji--med emoji--frowning-face">Bad</span>' },
+        { value: "neutral", label: '<span class="radio-button__image emoji emoji--med emoji--neutral-face">Ok</span>' },
+        { value: "positive", label: '<span class="radio-button__image emoji emoji--med emoji--grinning-face">Good</span>' }
+      ],
+      layouts: ["inline", "image"] %>
+
+    <%= f.mb_textarea :feedback_comments, '<strong>Do you have any feedback for us?</strong>', options: {rows: '4'} %>
+    <button class="button button--full-mobile" type="submit">Submit</button>
+<% end %>

--- a/app/views/feedbacks/_success.html.erb
+++ b/app/views/feedbacks/_success.html.erb
@@ -1,0 +1,2 @@
+<span class="radio-button__image emoji emoji--med emoji--blush">Thank you</span>
+<h3>Thanks for your feedback! It will help improve this application for people in the future.</h3>

--- a/app/views/feedbacks/create.js.erb
+++ b/app/views/feedbacks/create.js.erb
@@ -1,0 +1,5 @@
+<% if @form.errors.any? %>
+  $('#feedback-form').html('<%= escape_javascript(render partial: "feedbacks/form", locals: { feedback_form: @form }) %>')
+<% else %>
+  $('#feedback-form').html('<%= escape_javascript(render partial: "feedbacks/success") %>');
+<% end %>

--- a/app/views/feedbacks/create.js.erb
+++ b/app/views/feedbacks/create.js.erb
@@ -1,5 +1,6 @@
 <% if @form.errors.any? %>
-  $('#feedback-form').html('<%= escape_javascript(render partial: "feedbacks/form", locals: { feedback_form: @form }) %>')
+  $('#feedback-form').html('<%= escape_javascript(render partial: "feedbacks/form", locals: { feedback_form: @form }) %>');
+  radioSelector.init();
 <% else %>
   $('#feedback-form').html('<%= escape_javascript(render partial: "feedbacks/success") %>');
 <% end %>

--- a/app/views/integrated/application_submitted/edit.html.erb
+++ b/app/views/integrated/application_submitted/edit.html.erb
@@ -75,21 +75,9 @@
       </div>
     </div>
     <div class="top-full-border"></div>
-    <%= form_for @feedback_form, url: feedback_path, builder: MbFormBuilder, remote: true do |f| %>
-      <div id="feedback-form" class="center">
-        <%= f.mb_radio_set :feedback_rating,
-                           label_text: "<h3>How was your experience with this application?</h3>",
-                           collection: [
-                               { value: "negative", label: '<span class="radio-button__image emoji emoji--med emoji--frowning-face">Bad</span>' },
-                               { value: "neutral", label: '<span class="radio-button__image emoji emoji--med emoji--neutral-face">Ok</span>' },
-                               { value: "positive", label: '<span class="radio-button__image emoji emoji--med emoji--grinning-face">Good</span>' }
-                           ],
-                           layouts: ["inline", "image"] %>
-
-        <%= f.mb_textarea :feedback_comments, '<strong>Do you have any feedback for us?</strong>', options: {rows: '4'} %>
-        <button class="button button--full-mobile" type="submit">Submit</button>
-      </div>
-    <% end %>
+    <div id="feedback-form" class="center">
+      <%= render partial: "feedbacks/form", locals: { feedback_form: @feedback_form } %>
+    </div>
   </main>
   <div class="form-card nudge--large">
     <div class="form-card__content">

--- a/spec/controllers/integrated/feedbacks_controller_spec.rb
+++ b/spec/controllers/integrated/feedbacks_controller_spec.rb
@@ -10,27 +10,34 @@ RSpec.describe FeedbacksController do
         }
       end
 
-      context "when there is no current application" do
-        it "does not process the request" do
-          post :create, xhr: true, params: { feedback_form: valid_params }
+      it "updates the application" do
+        current_app = create(:common_application, :with_navigator)
+        session[:current_application_id] = current_app.id
 
-          expect(response).to have_http_status(:unprocessable_entity)
-        end
+        post :create, xhr: true, params: { feedback_form: valid_params }
+
+        current_app.reload
+
+        expect(current_app.feedback_rating).to eq("neutral")
+        expect(current_app.feedback_comments).to eq("My comments")
+      end
+    end
+
+    context "with invalid params" do
+      let(:invalid_params) do
+        {
+          feedback_rating: "",
+        }
       end
 
-      context "when there is a current application" do
-        it "updates the application" do
-          current_app = create(:common_application, :with_navigator)
-          session[:current_application_id] = current_app.id
+      it "does not process the request" do
+        current_app = create(:common_application, :with_navigator)
+        session[:current_application_id] = current_app.id
 
-          post :create, xhr: true, params: { feedback_form: valid_params }
+        post :create, xhr: true, params: { feedback_form: invalid_params }
 
-          current_app.reload
-
-          expect(response).to have_http_status(:created)
-          expect(current_app.feedback_rating).to eq("neutral")
-          expect(current_app.feedback_comments).to eq("My comments")
-        end
+        current_app.reload
+        expect(current_app.feedback_rating).to eq("unfilled")
       end
     end
   end

--- a/spec/forms/feedback_form_spec.rb
+++ b/spec/forms/feedback_form_spec.rb
@@ -1,0 +1,12 @@
+require "rails_helper"
+
+RSpec.describe FeedbackForm do
+  describe "validations" do
+    it "requires feedback_rating" do
+      form = FeedbackForm.new
+
+      expect(form).not_to be_valid
+      expect(form.errors[:feedback_rating]).to be_present
+    end
+  end
+end


### PR DESCRIPTION
Renders an accessible radio button set and displays errors using our form builder.

I decided not to show a visible error if there's no application, since it seemed confusing to the user. Just fails silently.

Also fixes a related bug, where our radio button set didn't properly show when buttons are selected after an initial error submission (go to page, submit an invalid state, then try to select the button again to see this—the button won't be visibly selected, but it will submit the right value). 
