### PR TITLE
Require that any feedback be entered, not just rating

### DIFF
--- a/app/assets/stylesheets/michigan-benefits/molecules/_form-molecules.scss
+++ b/app/assets/stylesheets/michigan-benefits/molecules/_form-molecules.scss
@@ -35,3 +35,17 @@
     border-bottom: none;
   }
 }
+
+.feedback-survey__form {
+  .input-group--inline .radio-button {
+    margin-right: 0;
+
+    @include media($tablet-up) {
+      margin-right: 0.3em;
+    }
+  }
+
+  textarea {
+    max-width: 400px;
+  }
+}

--- a/app/forms/feedback_form.rb
+++ b/app/forms/feedback_form.rb
@@ -1,5 +1,10 @@
 class FeedbackForm < Form
   set_attributes_for :application, :feedback_rating, :feedback_comments
 
-  validates_presence_of :feedback_rating, message: "Please select a rating."
+  validate :feedback_entered
+
+  def feedback_entered
+    return true if feedback_rating.present? || feedback_comments.present?
+    errors.add(:feedback_rating, "Please select a rating or enter a comment.")
+  end
 end

--- a/app/views/feedbacks/_form.html.erb
+++ b/app/views/feedbacks/_form.html.erb
@@ -1,13 +1,15 @@
-<%= form_for feedback_form, url: feedback_path, builder: MbFormBuilder, remote: true do |f| %>
-    <%= f.mb_radio_set :feedback_rating,
-      label_text: "<h3>How was your experience with this application?</h3>",
-      collection: [
-        { value: "negative", label: '<span class="radio-button__image emoji emoji--med emoji--frowning-face">Bad</span>' },
-        { value: "neutral", label: '<span class="radio-button__image emoji emoji--med emoji--neutral-face">Ok</span>' },
-        { value: "positive", label: '<span class="radio-button__image emoji emoji--med emoji--grinning-face">Good</span>' }
-      ],
-      layouts: ["inline", "image"] %>
+<div class="feedback-survey__form">
+  <%= form_for feedback_form, url: feedback_path, builder: MbFormBuilder, remote: true do |f| %>
+      <%= f.mb_radio_set :feedback_rating,
+        label_text: "<h3>How was your experience with this application?</h3>",
+        collection: [
+          { value: "negative", label: '<span class="radio-button__image emoji emoji--med emoji--frowning-face">Bad</span>' },
+          { value: "neutral", label: '<span class="radio-button__image emoji emoji--med emoji--neutral-face">Ok</span>' },
+          { value: "positive", label: '<span class="radio-button__image emoji emoji--med emoji--grinning-face">Good</span>' }
+        ],
+        layouts: ["inline", "image"] %>
 
-    <%= f.mb_textarea :feedback_comments, '<strong>Do you have any feedback for us?</strong>', options: {rows: '4'} %>
-    <button class="button button--full-mobile" type="submit">Submit</button>
-<% end %>
+      <%= f.mb_textarea :feedback_comments, '<strong>Do you have any feedback for us?</strong>', options: {rows: '2'} %>
+      <button class="button button--full-mobile" type="submit">Submit</button>
+  <% end %>
+</div>

--- a/spec/forms/feedback_form_spec.rb
+++ b/spec/forms/feedback_form_spec.rb
@@ -2,11 +2,25 @@ require "rails_helper"
 
 RSpec.describe FeedbackForm do
   describe "validations" do
-    it "requires feedback_rating" do
+    it "is invalid without feedback rating or comments" do
       form = FeedbackForm.new
 
       expect(form).not_to be_valid
       expect(form.errors[:feedback_rating]).to be_present
+    end
+
+    it "is valid with feedback rating" do
+      form = FeedbackForm.new(feedback_rating: "positive")
+
+      expect(form).to be_valid
+      expect(form.errors[:feedback_rating]).to_not be_present
+    end
+
+    it "is valid with feedback comments" do
+      form = FeedbackForm.new(feedback_comments: "best application ever")
+
+      expect(form).to be_valid
+      expect(form.errors[:feedback_rating]).to_not be_present
     end
   end
 end


### PR DESCRIPTION
If user enters a comment or a rating, feedback submission is considered valid.

Also includes some minor styling changes.

[Fixes #159703918]

![screen shot 2018-08-29 at 2 46 29 pm](https://user-images.githubusercontent.com/3675092/44817471-6bff3200-ab9a-11e8-8275-a84d8357b183.png)